### PR TITLE
Added pinch-zoom support for Mac

### DIFF
--- a/js/webview/swipeEvents.js
+++ b/js/webview/swipeEvents.js
@@ -9,10 +9,10 @@ window.addEventListener("mousewheel", function (e) {
 
 	verticalMouseMove += e.deltaY;
 	eventsCaptured++;
-	platformZoomKey = e.ctrlKey;
+	var platformZoomKey = e.ctrlKey;
 
 	if (navigator.platform == "MacIntel") {
-		if(e.ctrlKey) {
+		if(e.ctrlKey && !e.defaultPrevented) {
 			if( verticalMouseMove > 10 ) {
 				return zoomOut();
 			}

--- a/js/webview/swipeEvents.js
+++ b/js/webview/swipeEvents.js
@@ -9,8 +9,13 @@ window.addEventListener("mousewheel", function (e) {
 
 	verticalMouseMove += e.deltaY;
 	eventsCaptured++;
+	/* default zoom modifier is ctrl. Mac uses cmd/meta/super so an exeption will be made below */
 	var platformZoomKey = e.ctrlKey;
 
+	/* if platform is Mac Enable pinch zoom
+		the browser engine detects piches as ctrl+mousewheel on mac,
+		therefore it should not affect other platforms that user ctrl+mousewheel to zoom.
+	*/
 	if (navigator.platform == "MacIntel") {
 		if(e.ctrlKey && !e.defaultPrevented) {
 			if( verticalMouseMove > 10 ) {

--- a/js/webview/swipeEvents.js
+++ b/js/webview/swipeEvents.js
@@ -9,15 +9,27 @@ window.addEventListener("mousewheel", function (e) {
 
 	verticalMouseMove += e.deltaY;
 	eventsCaptured++;
+	platformZoomKey = e.ctrlKey;
 
+	if (navigator.platform == "MacIntel") {
+		if(e.ctrlKey) {
+			if( verticalMouseMove > 10 ) {
+				return zoomOut();
+			}
+			if( verticalMouseMove < -10 ) {
+				return zoomIn();
+			}
+		}
+		platformZoomKey = e.metaKey;
+	}
 	/* cmd-key while scrolling should zoom in and out */
 
-	if (verticalMouseMove > 55 && (e.metaKey || e.ctrlKey) && eventsCaptured > 1) {
+	if (verticalMouseMove > 55 && platformZoomKey && eventsCaptured > 1) {
 		verticalMouseMove = -10;
 		return zoomOut();
 	}
 
-	if (verticalMouseMove < -55 && (e.metaKey || e.ctrlKey) && eventsCaptured > 1) {
+	if (verticalMouseMove < -55 && platformZoomKey && eventsCaptured > 1) {
 		verticalMouseMove = -10;
 		return zoomIn();
 	}


### PR DESCRIPTION
#### Added pinch-zoom support for Mac
On pinch, the browser-engine sends a ctrl keypress & a mousewheel event. However, platforms other than Mac use ctrl+mouswheel to zoom. Pinch-zooming should be smoother than normal zooming, so the threshold is lowered to 10. Non-mac devices are not affected and cmd+mousewheel is still working.