### PR TITLE
Renamed page heading on settings Page

### DIFF
--- a/pages/settings/index.html
+++ b/pages/settings/index.html
@@ -16,7 +16,7 @@
 	</div>
 	<div class="hero short-hero blue-gradient-background">
 		<div class="container padding">
-			<h2>Privacy Settings</h2>
+			<h2>Settings</h2>
 		</div>
 	</div>
 	<div class="spacer"></div>


### PR DESCRIPTION
Renamed 'Privacy Settings' to 'Settings' since it's not just privacy settings anymore. 