### PR TITLE
Fixes #311

### DIFF
--- a/js/navbar/navbarTabs.js
+++ b/js/navbar/navbarTabs.js
@@ -238,13 +238,22 @@ function createTabElement (data) {
   })
 
   // click to enter edit mode or switch to a tab
-  tabEl.addEventListener('click', function (e) {
-    if (e.which === 2) { // if mouse middle click -> close tab
-      closeTab(data.id)
-    } else if (tabs.getSelected() !== data.id) { // else switch to tab if it isn't focused
-      switchToTab(data.id)
-    } else { // the tab is focused, edit tab instead
-      enterEditMode(data.id)
+  var dragged = false
+  tabEl.addEventListener('mousedown', function (e) {
+    dragged = false
+  })
+  tabEl.addEventListener('mousemove', function (e) {
+    dragged = true
+  })
+  tabEl.addEventListener('mouseup', function (e) {
+    if (!dragged) {
+      if (e.which === 2) { // if mouse middle click -> close tab
+        closeTab(data.id)
+      } else if (tabs.getSelected() !== data.id) { // else switch to tab if it isn't focused
+        switchToTab(data.id)
+      } else { // the tab is focused, edit tab instead
+        enterEditMode(data.id)
+      }
     }
   })
 


### PR DESCRIPTION
Replaces each tab element's `click` event listener with separate `mousedown`, `mousemove` and `mouseup` event listeners which determine whether or not the user dragged the mouse during the click.

If a drag was detected on the tab element, a flag is toggled and the action for the click won't happen.

This is the same solution mentioned in [this](http://stackoverflow.com/questions/6042202/how-to-distinguish-mouse-click-and-drag) StackOverflow post.