### PR TITLE
Added macOS dock menu

### DIFF
--- a/main/main.js
+++ b/main/main.js
@@ -176,6 +176,7 @@ app.on('ready', function () {
   // mainWindow.openDevTools()
 
   createAppMenu()
+  createDockMenu()
 })
 
 app.on('open-url', function (e, url) {
@@ -538,4 +539,37 @@ function createAppMenu () {
 
   menu = Menu.buildFromTemplate(template)
   Menu.setApplicationMenu(menu)
+}
+
+function createDockMenu () {
+  // create the menu. based on example from https://github.com/electron/electron/blob/master/docs/tutorial/desktop-environment-integration.md#custom-dock-menu-macos
+  if (process.platform === 'darwin') {
+    var Menu = electron.Menu
+    var MenuItem = electron.MenuItem
+
+    var template = [
+      {
+        label: 'New Tab',
+        click: function (item, window) {
+          sendIPCToWindow(window, 'addTab')
+        }
+      },
+      {
+        label: 'New Private Tab',
+        click: function (item, window) {
+          sendIPCToWindow(window, 'addPrivateTab')
+        }
+      },
+      {
+        label: 'New Task',
+        click: function (item, window) {
+          sendIPCToWindow(window, 'addTask')
+        }
+      }
+    ];
+    
+    var dockMenu = new Menu()
+    dockMenu = Menu.buildFromTemplate(template)
+    app.dock.setMenu(dockMenu)
+  }
 }


### PR DESCRIPTION
I have added a dock menu for macOS. This should also be useful for whenever #169 is implemented as it is standard practice to open new windows from the dock menu.

Preview:
![screen shot 2017-04-10 at 12 17 11](https://cloud.githubusercontent.com/assets/159962/24857174/aae78f72-1de7-11e7-84dd-0616842165b2.png)
