### PR TITLE
Add ability to restore closed tabs from the current session

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -48,6 +48,7 @@ module.exports = function (grunt) {
 						 "js/fileDownloadManager.js",
 						 "js/findinpage.js",
 							"js/sessionRestore.js",
+							"js/tabRestore.js",
 							"js/focusMode.js",
 							"js/util/theme.js",
 						 ],

--- a/js/api-wrapper.js
+++ b/js/api-wrapper.js
@@ -45,6 +45,8 @@ function closeTab (tabId) {
     return
   }
 
+  tabHistory.push(tabId)
+
   if (tabId === tabs.getSelected()) {
     var currentIndex = tabs.getIndex(tabs.getSelected())
     var nextTab = tabs.getAtIndex(currentIndex - 1) || tabs.getAtIndex(currentIndex + 1)

--- a/js/api-wrapper.js
+++ b/js/api-wrapper.js
@@ -45,8 +45,6 @@ function closeTab (tabId) {
     return
   }
 
-  tabHistory.push(tabId)
-
   if (tabId === tabs.getSelected()) {
     var currentIndex = tabs.getIndex(tabs.getSelected())
     var nextTab = tabs.getAtIndex(currentIndex - 1) || tabs.getAtIndex(currentIndex + 1)

--- a/js/keybindings.js
+++ b/js/keybindings.js
@@ -86,21 +86,6 @@ function addPrivateTab () {
 
 ipc.on('addPrivateTab', addPrivateTab)
 
-function restoreTab () {
-  if (isFocusMode) {
-    showFocusModeError()
-    return
-  }
-
-  if (isEmpty(tabs.get())) {
-    destroyTab(tabs.getAtIndex(0).id)
-  }
-
-  tabHistory.restore()
-}
-
-ipc.on('restoreTab', restoreTab)
-
 ipc.on('addTask', function () {
   /* new tasks can't be created in focus mode */
   if (isFocusMode) {
@@ -168,7 +153,16 @@ settings.get('keyMap', function (keyMapSettings) {
   })
 
   defineShortcut('restoreTab', function (e) {
-    restoreTab()
+    if (isFocusMode) {
+      showFocusModeError()
+      return
+    }
+
+    if (isEmpty(tabs.get())) {
+      destroyTab(tabs.getAtIndex(0).id)
+    }
+
+    tabHistory.restore()
   })
 
   defineShortcut('addToFavorites', function (e) {

--- a/js/keybindings.js
+++ b/js/keybindings.js
@@ -86,6 +86,21 @@ function addPrivateTab () {
 
 ipc.on('addPrivateTab', addPrivateTab)
 
+function restoreTab () {
+  if (isFocusMode) {
+    showFocusModeError()
+    return
+  }
+
+  if (isEmpty(tabs.get())) {
+    destroyTab(tabs.getAtIndex(0).id)
+  }
+
+  tabHistory.restore()
+}
+
+ipc.on('restoreTab', restoreTab)
+
 ipc.on('addTask', function () {
   /* new tasks can't be created in focus mode */
   if (isFocusMode) {
@@ -150,6 +165,10 @@ settings.get('keyMap', function (keyMapSettings) {
     closeTab(tabs.getSelected())
 
     return false
+  })
+
+  defineShortcut('restoreTab', function (e) {
+    restoreTab()
   })
 
   defineShortcut('addToFavorites', function (e) {

--- a/js/keybindings.js
+++ b/js/keybindings.js
@@ -158,11 +158,7 @@ settings.get('keyMap', function (keyMapSettings) {
       return
     }
 
-    if (isEmpty(tabs.get())) {
-      destroyTab(tabs.getAtIndex(0).id)
-    }
-
-    tabHistory.restore()
+    window.currentTask.history.restore()
   })
 
   defineShortcut('addToFavorites', function (e) {

--- a/js/keybindings.js
+++ b/js/keybindings.js
@@ -158,7 +158,22 @@ settings.get('keyMap', function (keyMapSettings) {
       return
     }
 
-    window.currentTask.history.restore()
+    var restoredTab = window.currentTask.tabHistory.pop()
+
+    // The tab history stack is empty
+    if (!restoredTab) {
+      return
+    }
+
+    if (isEmpty(tabs.get())) {
+      destroyTab(tabs.getAtIndex(0).id)
+    }
+
+    addTab(tabs.add(restoredTab, tabs.getIndex(tabs.getSelected()) + 1), {
+      focus: false,
+      leaveEditMode: true,
+      enterEditMode: false,
+    })
   })
 
   defineShortcut('addToFavorites', function (e) {

--- a/js/tabRestore.js
+++ b/js/tabRestore.js
@@ -1,0 +1,33 @@
+const MAX_TAB_HISTORY_DEPTH = 20
+var tabHistoryStack = Array()
+
+var tabHistory = {
+  push: function (tabId) {
+    var tab = tabs.get(tabId)
+    // Do not store private tabs or blank tabs
+    if (tab.private || tab.url === 'about:blank') {
+      return
+    }
+
+    if (tabHistoryStack.length < MAX_TAB_HISTORY_DEPTH) {
+      tabHistoryStack.push(tab)
+    } else {
+      tabHistoryStack.shift()
+      tabHistoryStack.push(tab)
+    }
+  },
+  restore: function () {
+    if (tabHistoryStack.length === 0) {
+      return
+    }
+
+    var newIndex = tabs.getIndex(tabs.getSelected()) + 1
+    var newTab = tabs.add(tabHistoryStack.pop(), newIndex)
+
+    addTab(newTab, {
+      focus: false,
+      leaveEditMode: true,
+      enterEditMode: false,
+    })
+  }
+}

--- a/js/tabRestore.js
+++ b/js/tabRestore.js
@@ -11,11 +11,10 @@ function TabStack(tabStack) {
 TabStack.prototype.push = function (tabId) {
   var closedTab = tabs.get(tabId)
 
-  // Do not store private tabs, blank tabs, or preferences
+  // Do not store private tabs or blank tabs
   if (closedTab.private
     || closedTab.url === 'about:blank'
-    || closedTab.url === ''
-    || closedTab.url.match(/^file:\/\/\/.*\/min\/pages\/settings\/index.html$/)) {
+    || closedTab.url === '') {
     return
   }
 

--- a/js/tabRestore.js
+++ b/js/tabRestore.js
@@ -1,15 +1,21 @@
-function TabStack() {
-  this.depth = 20
-  this.stack = []
+function TabStack(tabStack) {
+  if (tabStack) {
+    this.depth = tabStack.depth
+    this.stack = tabStack.stack
+  } else {
+    this.depth = 20
+    this.stack = []
+  }
 }
 
 TabStack.prototype.push = function (tabId) {
   var closedTab = tabs.get(tabId)
 
-  // Do not store private tabs or blank tabs
+  // Do not store private tabs, blank tabs, or preferences
   if (closedTab.private
     || closedTab.url === 'about:blank'
-    || closedTab.url === '') {
+    || closedTab.url === ''
+    || closedTab.url.match(/^file:\/\/\/.*\/min\/pages\/settings\/index.html$/)) {
     return
   }
 
@@ -20,29 +26,6 @@ TabStack.prototype.push = function (tabId) {
   this.stack.push(closedTab)
 }
 
-TabStack.prototype.restore = function () {
-  if (this.stack.length === 0) {
-    return
-  }
-
-  lastTab = window.currentTask.tabs[window.tabs.length - 1]
-
-  // Open the tab in the last slot
-  if (lastTab === undefined)  {
-    newIndex = 0
-  } else {
-    newIndex = tabs.getIndex(lastTab.id) + 1
-  }
-
-  if (isEmpty(tabs.get())) {
-    destroyTab(tabs.getAtIndex(0).id)
-  }
-
-  var newTab = tabs.add(this.stack.pop(), newIndex)
-
-  addTab(newTab, {
-    focus: false,
-    leaveEditMode: true,
-    enterEditMode: false,
-  })
+TabStack.prototype.pop = function () {
+  return this.stack.pop()
 }

--- a/js/tabRestore.js
+++ b/js/tabRestore.js
@@ -5,7 +5,7 @@ var tabHistory = {
   push: function (tabId) {
     var tab = tabs.get(tabId)
     // Do not store private tabs or blank tabs
-    if (tab.private || tab.url === 'about:blank') {
+    if (tab.private || tab.url === 'about:blank' || tab.url === '') {
       return
     }
 

--- a/js/tabRestore.js
+++ b/js/tabRestore.js
@@ -1,9 +1,9 @@
 function TabStack(tabStack) {
+  this.depth = 20
+
   if (tabStack) {
-    this.depth = tabStack.depth
     this.stack = tabStack.stack
   } else {
-    this.depth = 20
     this.stack = []
   }
 }

--- a/js/tabRestore.js
+++ b/js/tabRestore.js
@@ -1,33 +1,42 @@
-const MAX_TAB_HISTORY_DEPTH = 20
-var tabHistoryStack = Array()
+function TabHistory() {
+  this.depth = 20
+  this.stack = Array()
 
-var tabHistory = {
-  push: function (tabId) {
-    var tab = tabs.get(tabId)
-    // Do not store private tabs or blank tabs
-    if (tab.private || tab.url === 'about:blank' || tab.url === '') {
-      return
-    }
+  if (arguments.callee._singletonInstance) {
+    return arguments.callee._singletonInstance
+  }
 
-    if (tabHistoryStack.length < MAX_TAB_HISTORY_DEPTH) {
-      tabHistoryStack.push(tab)
-    } else {
-      tabHistoryStack.shift()
-      tabHistoryStack.push(tab)
-    }
-  },
-  restore: function () {
-    if (tabHistoryStack.length === 0) {
-      return
-    }
+  arguments.callee._singletonInstance = this;
+}
 
-    var newIndex = tabs.getIndex(tabs.getSelected()) + 1
-    var newTab = tabs.add(tabHistoryStack.pop(), newIndex)
+TabHistory.prototype.push = function (tabId) {
+  var tab = tabs.get(tabId)
+  // Do not store private tabs or blank tabs
+  if (tab.private || tab.url === 'about:blank' || tab.url === '') {
+    return
+  }
 
-    addTab(newTab, {
-      focus: false,
-      leaveEditMode: true,
-      enterEditMode: false,
-    })
+  if (this.stack.length < this.depth) {
+    this.stack.push(tab)
+  } else {
+    this.stack.shift()
+    this.stack.push(tab)
   }
 }
+
+TabHistory.prototype.restore = function () {
+  if (this.stack.length === 0) {
+    return
+  }
+
+  var newIndex = tabs.getIndex(tabs.getSelected()) + 1
+  var newTab = tabs.add(this.stack.pop(), newIndex)
+
+  addTab(newTab, {
+    focus: false,
+    leaveEditMode: true,
+    enterEditMode: false,
+  })
+}
+
+var tabHistory = new TabHistory()

--- a/js/tabState.js
+++ b/js/tabState.js
@@ -1,5 +1,5 @@
 var tabState = {
-  tasks: [], // each task is {id, name, tabs: [], history: TabStack}
+  tasks: [], // each task is {id, name, tabs: [], tabHistory: TabStack}
   selectedTask: null
 }
 
@@ -53,7 +53,7 @@ var tabPrototype = {
   destroy: function (id) {
     for (var i = 0; i < this.length; i++) {
       if (this[i].id === id) {
-        window.currentTask.history.push(id)
+        window.currentTask.tabHistory.push(id)
         this.splice(i, 1)
         return i
       }
@@ -131,17 +131,10 @@ var tasks = {
       task = {}
     }
 
-    var tabStack
-    if (task.history) {
-      tabStack = Object.setPrototypeOf(task.history, TabStack.prototype)
-    } else {
-      tabStack = new TabStack()
-    }
-
     var newTask = {
       name: task.name || null,
       tabs: task.tabs || [],
-      history: tabStack,
+      tabHistory: new TabStack(task.tabHistory),
       id: task.id || String(getRandomId())
     }
 

--- a/js/tabState.js
+++ b/js/tabState.js
@@ -1,5 +1,5 @@
 var tabState = {
-  tasks: [], // each task is {id, name, tabs: []}
+  tasks: [], // each task is {id, name, tabs: [], history: TabStack}
   selectedTask: null
 }
 
@@ -53,6 +53,7 @@ var tabPrototype = {
   destroy: function (id) {
     for (var i = 0; i < this.length; i++) {
       if (this[i].id === id) {
+        window.currentTask.history.push(id)
         this.splice(i, 1)
         return i
       }
@@ -133,6 +134,7 @@ var tasks = {
     var newTask = {
       name: task.name || null,
       tabs: task.tabs || [],
+      history: new TabStack(),
       id: task.id || String(getRandomId())
     }
 

--- a/js/tabState.js
+++ b/js/tabState.js
@@ -131,10 +131,17 @@ var tasks = {
       task = {}
     }
 
+    var tabStack
+    if (task.history) {
+      tabStack = Object.setPrototypeOf(task.history, TabStack.prototype)
+    } else {
+      tabStack = new TabStack()
+    }
+
     var newTask = {
       name: task.name || null,
       tabs: task.tabs || [],
-      history: new TabStack(),
+      history: tabStack,
       id: task.id || String(getRandomId())
     }
 

--- a/js/util/defaultKeyMap.js
+++ b/js/util/defaultKeyMap.js
@@ -6,6 +6,7 @@ var defaultKeyMap = {
   'enterEditMode': ['mod+l', 'mod+k'],
   'completeSearchbar': 'mod+enter',
   'closeTab': 'mod+w',
+  'restoreTab': 'shift+mod+t',
   'gotoFirstTab': 'shift+mod+9',
   'gotoLastTab': 'mod+9',
   'addToFavorites': 'mod+d',

--- a/main/main.js
+++ b/main/main.js
@@ -232,13 +232,6 @@ function createAppMenu () {
           }
         },
         {
-          label: 'Restore Last Closed Tab',
-          accelerator: 'shift+CmdOrCtrl+t',
-          click: function (item, window) {
-            sendIPCToWindow(window, 'restoreTab')
-          }
-        },
-        {
           label: 'New Task',
           accelerator: 'CmdOrCtrl+n',
           click: function (item, window) {

--- a/main/main.js
+++ b/main/main.js
@@ -226,9 +226,16 @@ function createAppMenu () {
         },
         {
           label: 'New Private Tab',
-          accelerator: 'shift+CmdOrCtrl+t',
+          accelerator: 'shift+CmdOrCtrl+p',
           click: function (item, window) {
             sendIPCToWindow(window, 'addPrivateTab')
+          }
+        },
+        {
+          label: 'Restore Last Closed Tab',
+          accelerator: 'shift+CmdOrCtrl+t',
+          click: function (item, window) {
+            sendIPCToWindow(window, 'restoreTab')
           }
         },
         {


### PR DESCRIPTION
Not sure how you would want this implemented, but here's a start at least.

The tab history is not persistent. Each session can store up to 20 closed tabs on a stack, older tabs are pushed out. No real reason for 20 other than it seemed reasonable. This replaces the shift+mod+t map for opening private tabs that was defined from the menu, now it's just on the custom keybinding. It's shift+mod+t because this is how most major browsers map it, afaik.

Fixes issue #290