### PR TITLE
Linux builds fails due to typo in application source directory

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -181,14 +181,14 @@ module.exports = function (grunt) {
 				options: {
 					arch: 'i386'
 				},
-				src: 'dist/app/Min-linux-ia32',
+				src: 'dist/app/min-linux-ia32',
 				dest: 'dist/app/linux'
 			},
 			linux64: {
 				options: {
 					arch: 'amd64'
 				},
-				src: 'dist/app/Min-linux-x64',
+				src: 'dist/app/min-linux-x64',
 				dest: 'dist/app/linux'
 			}
 		}


### PR DESCRIPTION
Linux builds fails due to a typographical error in the `electron-installer-debian` `grunt` task. The task looks for `Min-linux-*` whereas `electron:linuxBuild` writes `__dirname` as `min-linux-*`. This change-set fixes that issue.