### PR TITLE
Added simple tab dividers to make tabs more defined.

### DIFF
--- a/css/navbarTabs.css
+++ b/css/navbarTabs.css
@@ -242,4 +242,5 @@ body.is-focus-mode .navbar-action-button {
 
 body.is-focus-mode .tab-item {
 	background: none !important;
+	border-right-style: none;
 }

--- a/css/navbarTabs.css
+++ b/css/navbarTabs.css
@@ -50,6 +50,13 @@ body.notMac #navbar {
 	/* https://github.com/w3c/csswg-drafts/issues/92 - don't make the scrollbar height affect the layout */
 	overflow: overlay;
 }
+
+/* for borders */
+.tab-item + .tab-item {
+	border-left-style: solid;
+	border-width: 1px;
+}
+
 .tab-item {
 	flex: 1;
 	min-width: 125px;
@@ -58,8 +65,6 @@ body.notMac #navbar {
 	font-size: 0.8em;
 	line-height: 36px;
 	height: 36px;
-	border-right-style: solid;
-	border-width: 1px;
 	overflow: hidden;
 	word-break: break-all;
 }

--- a/css/navbarTabs.css
+++ b/css/navbarTabs.css
@@ -58,6 +58,8 @@ body.notMac #navbar {
 	font-size: 0.8em;
 	line-height: 36px;
 	height: 36px;
+	border-right-style: solid;
+	border-width: 1px;
 	overflow: hidden;
 	word-break: break-all;
 }
@@ -119,6 +121,7 @@ body.notMac #navbar {
 	width: 0;
 	height: 0;
 	padding: 0;
+	border-style: none;
 	overflow: hidden;
 }
 

--- a/js/navbar/tabColor.js
+++ b/js/navbar/tabColor.js
@@ -286,12 +286,12 @@ function setColor (bg, fg) {
   if (fg === 'white') {
     document.body.classList.add('dark-theme')
     for (var i = 0; i < tabs.length; i++) {
-		tabs[i].style.borderRightColor = lightenDarkenHexColor(rgb2hex(bg), 20)
+		tabs[i].style.borderLeftColor = lightenDarkenHexColor(rgb2hex(bg), 20)
 	}
   } else {
     document.body.classList.remove('dark-theme')
     for (var i = 0; i < tabs.length; i++) {
-		tabs[i].style.borderRightColor = lightenDarkenHexColor(rgb2hex(bg), -20)
+		tabs[i].style.borderLeftColor = lightenDarkenHexColor(rgb2hex(bg), -20)
 	}
   }
 }

--- a/js/navbar/tabColor.js
+++ b/js/navbar/tabColor.js
@@ -224,9 +224,56 @@ function updateColorPalette () {
   }
 }
 
+// Below function from http://jsfiddle.net/Mottie/xcqpF/1/light/
+
+function rgb2hex(rgb){
+	
+ rgb = rgb.match(/^rgba?[\s+]?\([\s+]?(\d+)[\s+]?,[\s+]?(\d+)[\s+]?,[\s+]?(\d+)[\s+]?/i);
+ 
+ return (rgb && rgb.length === 4) ? "#" +
+  ("0" + parseInt(rgb[1],10).toString(16)).slice(-2) +
+  ("0" + parseInt(rgb[2],10).toString(16)).slice(-2) +
+  ("0" + parseInt(rgb[3],10).toString(16)).slice(-2) : '';
+}
+
+// Below function from https://css-tricks.com/snippets/javascript/lighten-darken-color/
+
+function lightenDarkenHexColor(col, amt) {
+  
+    var usePound = false;
+  
+    if (col[0] == "#") {
+        col = col.slice(1);
+        usePound = true;
+    }
+ 
+    var num = parseInt(col,16);
+ 
+    var r = (num >> 16) + amt;
+ 
+    if (r > 255) r = 255;
+    else if  (r < 0) r = 0;
+ 
+    var b = ((num >> 8) & 0x00FF) + amt;
+ 
+    if (b > 255) b = 255;
+    else if  (b < 0) b = 0;
+ 
+    var g = (num & 0x0000FF) + amt;
+ 
+    if (g > 255) g = 255;
+    else if (g < 0) g = 0;
+ 
+    return (usePound?"#":"") + String("000000" + (g | (b << 8) | (r << 16)).toString(16)).slice(-6);
+  
+}
+
 function setColor (bg, fg) {
   var background = document.getElementsByClassName('theme-background-color')
   var textcolor = document.getElementsByClassName('theme-text-color')
+  var tabs = document.getElementsByClassName('tab-item')
+  
+  console.log(bg)
 
   for (var i = 0; i < background.length; i++) {
     background[i].style.backgroundColor = bg
@@ -238,8 +285,14 @@ function setColor (bg, fg) {
 
   if (fg === 'white') {
     document.body.classList.add('dark-theme')
+    for (var i = 0; i < tabs.length; i++) {
+		tabs[i].style.borderRightColor = lightenDarkenHexColor(rgb2hex(bg), 20)
+	}
   } else {
     document.body.classList.remove('dark-theme')
+    for (var i = 0; i < tabs.length; i++) {
+		tabs[i].style.borderRightColor = lightenDarkenHexColor(rgb2hex(bg), -20)
+	}
   }
 }
 


### PR DESCRIPTION
I thought min was very confusing because it was hard to see where a tab started and began. Using CSS, I added a simple border to the right of tab items. It works pretty well, and does not seem to get in the way of much. Thankfully, the color of the border matches the tab font color, making it contrast correctly.

Before:
![tabdividers_before](https://user-images.githubusercontent.com/20055246/30785587-dc97e1a2-a136-11e7-8082-15a45cd760a8.png)

After:
![tabdividers](https://user-images.githubusercontent.com/20055246/30785564-906f16a6-a136-11e7-876d-b53ef3b9a43a.png)

Hope ya like it.