### PR TITLE
Fixed Issue #414: Added mouse movement threshold for clicking on tabs

### DIFF
--- a/js/default.js
+++ b/js/default.js
@@ -81,13 +81,28 @@ function empty (node) {
 
 /* prevent a click event from firing after dragging the window */
 
+var mouseX = 0
+var mouseY = 0
+
+var mouseLocation = function(e) {
+  mouseX = e.screenX
+  mouseY = e.screenY
+  if (mouseX < 0){mouseX = 0}
+  if (mouseY < 0){mouseY = 0}
+  return true;
+}
+
 window.addEventListener('load', function () {
   var isMouseDown = false
   var isDragging = false
+  var recordX = 0
+  var recordY = 0
+  var pauseRecord = true
 
   document.body.addEventListener('mousedown', function () {
     isMouseDown = true
     isDragging = false
+    pauseRecord = false
   })
 
   document.body.addEventListener('mouseup', function () {
@@ -97,17 +112,27 @@ window.addEventListener('load', function () {
   var dragHandles = document.getElementsByClassName('windowDragHandle')
 
   for (var i = 0; i < dragHandles.length; i++) {
-    dragHandles[i].addEventListener('mousemove', function () {
+    dragHandles[i].addEventListener('mousemove', function (e) {
       if (isMouseDown) {
         isDragging = true
+        if (!pauseRecord){
+          mouseLocation(e)
+          recordX = mouseX
+          recordY = mouseY
+          pauseRecord = true
+        }
       }
     })
   }
 
-  document.body.addEventListener('click', function (e) {
-    if (isDragging) {
+  document.body.addEventListener('click', function (e) {    
+    mouseLocation(e)
+    distance = Math.sqrt(Math.pow(recordX-mouseX,2) + Math.pow(recordY-mouseY,2))
+
+    if (isDragging && distance >= 10.0) {
       e.stopImmediatePropagation()
       isDragging = false
+      pauseRecord = false
     }
   }, true)
 })

--- a/js/default.js
+++ b/js/default.js
@@ -81,28 +81,15 @@ function empty (node) {
 
 /* prevent a click event from firing after dragging the window */
 
-var mouseX = 0
-var mouseY = 0
-
-var mouseLocation = function(e) {
-  mouseX = e.screenX
-  mouseY = e.screenY
-  if (mouseX < 0){mouseX = 0}
-  if (mouseY < 0){mouseY = 0}
-  return true;
-}
-
 window.addEventListener('load', function () {
   var isMouseDown = false
   var isDragging = false
-  var recordX = 0
-  var recordY = 0
-  var pauseRecord = true
+  var distance = 0
 
   document.body.addEventListener('mousedown', function () {
     isMouseDown = true
     isDragging = false
-    pauseRecord = false
+    distance = 0
   })
 
   document.body.addEventListener('mouseup', function () {
@@ -115,24 +102,15 @@ window.addEventListener('load', function () {
     dragHandles[i].addEventListener('mousemove', function (e) {
       if (isMouseDown) {
         isDragging = true
-        if (!pauseRecord){
-          mouseLocation(e)
-          recordX = mouseX
-          recordY = mouseY
-          pauseRecord = true
-        }
+        distance += Math.abs(e.movementX) + Math.abs(e.movementY)
       }
     })
   }
 
   document.body.addEventListener('click', function (e) {    
-    mouseLocation(e)
-    distance = Math.sqrt(Math.pow(recordX-mouseX,2) + Math.pow(recordY-mouseY,2))
-
     if (isDragging && distance >= 10.0) {
       e.stopImmediatePropagation()
       isDragging = false
-      pauseRecord = false
     }
   }, true)
 })


### PR DESCRIPTION
Issue #414 was that if the mouse is moving at all, it is not possible to click on tabs. So sometimes when trying to click on a tab, if the mouse moves a few pixels between mouse press and release, the click is cancelled. I have added code that records the mouse position upon pressing the mouse on a tab, and again upon releasing it. The click is only cancelled if the distance between the location of the mouse press and the mouse release is above a small threshold. 

Hope this is to everyone's liking!