### PR TITLE
Fixes issue #411 - Adds mailto protocol handling

### DIFF
--- a/main/main.js
+++ b/main/main.js
@@ -2,6 +2,8 @@ const electron = require('electron')
 const fs = require('fs')
 const path = require('path')
 const app = electron.app // Module to control application life.
+const protocol = electron.protocol // Module to control protocol handling
+const shell = electron.shell // Module to call system functionality
 const BrowserWindow = electron.BrowserWindow // Module to create native browser window.
 
 var userDataPath = app.getPath('userData')
@@ -160,6 +162,8 @@ app.on('window-all-closed', function () {
 app.on('ready', function () {
   appIsReady = true
 
+  registerProtocols()
+
   createWindow(function () {
     mainWindow.webContents.on('did-finish-load', function () {
       // if a URL was passed as a command line argument (probably because Min is set as the default browser on Linux), open it.
@@ -205,6 +209,17 @@ app.on('activate', function (/* e, hasVisibleWindows */) {
     createWindow()
   }
 })
+
+function registerProtocols() {
+  protocol.registerStringProtocol('mailto', function(req, cb) {
+    shell.openExternal(req.url)
+    return null
+  }, function (error) {
+    if (error) {
+      console.log('Could not register mailto protocol.')
+    }
+  })
+}
 
 function createAppMenu () {
   // create the menu. based on example from http://electron.atom.io/docs/v0.34.0/api/menu/


### PR DESCRIPTION
Fixing #411 

This commit adds a protocol handler for "mailto" links. It only delegates the url to the default system mail application.

As a disclaimer, I'm quite new to electron projects (and open source in general), so any input is appreciated.

I thought of creating a separate protocol handling file (so we could handle not only mailto, but magnet links, stream, etc), but wasn't too sure about changing a lot of things, so I just changed enought to fix the issue.