### PR TITLE
add setting to disable task overlay on task switch

### DIFF
--- a/localization/languages/en-US.json
+++ b/localization/languages/en-US.json
@@ -100,6 +100,7 @@
         "settingsAppearanceHeading": "Appearance",
         "settingsDarkModeToggle": "Enable dark mode",
         "settingsHistoryButtonToggle": "Enable back button",
+        "settingsTaskAnimationDisableToggle": "Disable task overlay animation",
         "settingsSwipeNavigationHeading": "Swipe navigation",
         "settingsSwipeNavigationToggle": "Enable swipe for navigating back and forth between pages.",
         "settingsSearchEngineHeading": "Search Engine",

--- a/pages/settings/index.html
+++ b/pages/settings/index.html
@@ -42,6 +42,9 @@
 			<div class="spacer"></div>
 			<input type="checkbox" id="checkbox-history-button" />
 			<label for="checkbox-history-button" data-string="settingsHistoryButtonToggle"></label>
+			<div class="spacer"></div>
+			<input type="checkbox" id="checkbox-task-animation-disable" />
+			<label for="checkbox-task-animation-disable" data-string="settingsTaskAnimationDisableToggle"></label>
 		</div>
 	</div>
 

--- a/pages/settings/settings.js
+++ b/pages/settings/settings.js
@@ -5,6 +5,7 @@ var trackerCheckbox = document.getElementById('checkbox-block-trackers')
 var banner = document.getElementById('restart-required-banner')
 var darkModeCheckbox = document.getElementById('checkbox-dark-mode')
 var historyButtonCheckbox = document.getElementById('checkbox-history-button')
+var taskAnimationDisabledCheckbox= document.getElementById('checkbox-task-animation-disable')
 var swipeNavigationCheckbox = document.getElementById('checkbox-swipe-navigation')
 
 function showRestartRequiredBanner () {
@@ -178,6 +179,21 @@ settings.get('historyButton', function (value) {
 
 historyButtonCheckbox.addEventListener('change', function (e) {
   settings.set('historyButton', this.checked)
+  showRestartRequiredBanner()
+})
+
+// Animation settings
+
+settings.get('taskAnimationDisabled', function (value) {
+  if (value === true || value === undefined) {
+    taskAnimationDisabledCheckbox.checked = true
+  } else {
+    taskAnimationDisabledCheckbox.checked = false
+  }
+})
+
+taskAnimationDisabledCheckbox.addEventListener('change', function (e) {
+  settings.set('taskAnimationDisabled', this.checked)
   showRestartRequiredBanner()
 })
 


### PR DESCRIPTION
This adds a setting to disable the task overlay popup on task switch (default mod+[ and mod+]). 

For me, it's visually jarring and doesn't provide much utility (especially in dark mode, the selected tab is barely visible). 