### PR TITLE
Translate settingsKeyboardShortcutsHelp (fr-FR)

### DIFF
--- a/localization/languages/fr-FR.json
+++ b/localization/languages/fr-FR.json
@@ -100,13 +100,13 @@
         "settingsAppearanceHeading": "Apparence",
         "settingsDarkModeToggle": "Activer le mode nuit",
         "settingsHistoryButtonToggle": "Activer le boutton navigation",
-        "settingsSwipeNavigationHeading": "Swipe navigation", //same on french
-        "settingsSwipeNavigationToggle": "Activer swipe pour changer de page.",
+        "settingsSwipeNavigationHeading": "Navigation par glissement",
+        "settingsSwipeNavigationToggle": "Activer le glissement pour changer de page.",
         "settingsSearchEngineHeading": "Moteur de recherche",
         "settingsDefaultSearchEngine": "Choisir un moteur de recherche par défaut :",
         "settingsDDGExplanation": "Définir DuckDuckGo comme moteur de recherche par défaut pour voir instantanément des résulats dans la barre de recherche.",
         "settingsKeyboardShortcutsHeading": "Raccourcis clavier",
-        "settingsKeyboardShortcutsHelp": "Séparer les raccourcis clavier par une virgule.",
+        "settingsKeyboardShortcutsHelp": "Séparer les raccourcis clavier multiples par une virgule.",
         /* app menu */
         "appMenuFile": "Fichier",
         "appMenuNewTab": "Nouvel onglet",

--- a/localization/languages/fr-FR.json
+++ b/localization/languages/fr-FR.json
@@ -106,7 +106,7 @@
         "settingsDefaultSearchEngine": "Choisir un moteur de recherche par défaut :",
         "settingsDDGExplanation": "Définir DuckDuckGo comme moteur de recherche par défaut pour voir instantanément des résulats dans la barre de recherche.",
         "settingsKeyboardShortcutsHeading": "Raccourcis clavier",
-        "settingsKeyboardShortcutsHelp": null, //missing translation
+        "settingsKeyboardShortcutsHelp": "Séparer les raccourcis clavier par une virgule.",
         /* app menu */
         "appMenuFile": "Fichier",
         "appMenuNewTab": "Nouvel onglet",


### PR DESCRIPTION
Hello,

I have a little doubt about this one. 
The user should write something like my example?
```
^n: open, ^q: close
```

Also, I saw that it's written `"Swipe navigation" // same in french`, however I would (rather) say `Navigation par swipe`. We don't really have word/verb for swipe, I think that the cause of the issue.