### PR TITLE
Make sure the files build on watch start too

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -100,6 +100,7 @@ module.exports = function (grunt) {
         files: ['js/**/*.js', 'main/*.js'],
         tasks: ['default'],
         options: {
+          atBegin: true,
           spawn: false
         }
       }


### PR DESCRIPTION
This removes the need for running "grunt" before "grunt watch:scripts"
the first time.