### PR TITLE
Remove settings.js from the legacy modules list and fix imports

### DIFF
--- a/js/keybindings.js
+++ b/js/keybindings.js
@@ -54,6 +54,27 @@ ipc.on('showHistory', function () {
   tabBar.enterEditMode(tabs.getSelected(), '!history ')
 })
 
+ipc.on('duplicateTab', function (e) {
+  /* new tabs can't be created in focus mode */
+  if (focusMode.enabled()) {
+    focusMode.warn()
+    return
+  }
+
+  // can't duplicate if tabs is empty 
+  if (tabs.isEmpty()) {
+    return
+  }
+
+  const newIndex = tabs.getIndex(tabs.getSelected()) + 1
+
+  const sourceTab = tabs.get(tabs.getSelected())
+  // strip tab id so that a new one is generated
+  const newTab = tabs.add({...sourceTab, id: undefined}, newIndex)
+
+  browserUI.addTab(newTab, { enterEditMode: false })
+})
+
 ipc.on('addTab', function (e, data) {
   /* new tabs can't be created in focus mode */
   if (focusMode.enabled()) {

--- a/js/util/searchEngine.js
+++ b/js/util/searchEngine.js
@@ -1,3 +1,7 @@
+if (typeof settings === 'undefined' && typeof require !== 'undefined') {
+  var settings = require('util/settings.js')
+}
+
 window.currentSearchEngine = {
   name: '',
   searchURL: '%s'

--- a/localization/languages/en-US.json
+++ b/localization/languages/en-US.json
@@ -127,6 +127,7 @@
         /* app menu */
         "appMenuFile": "File",
         "appMenuNewTab": "New Tab",
+        "appMenuDuplicateTab": "Duplicate Tab",
         "appMenuNewPrivateTab": "New Private Tab",
         "appMenuNewTask": "New Task",
         "appMenuSavePageAs": "Save Page As",

--- a/main/main.js
+++ b/main/main.js
@@ -284,6 +284,13 @@ function createAppMenu () {
           }
         },
         {
+          label: l('appMenuDuplicateTab'),
+          accelerator: 'shift+CmdOrCtrl+d',
+          click: function (item, window) {
+            sendIPCToWindow(window, 'duplicateTab')
+          }
+        },
+        {
           label: l('appMenuNewPrivateTab'),
           accelerator: 'shift+CmdOrCtrl+p',
           click: function (item, window) {

--- a/scripts/buildBrowser.js
+++ b/scripts/buildBrowser.js
@@ -15,7 +15,6 @@ const legacyModules = [
   'js/windowsCaptionButtons.js',
   'js/util/database.js',
   'js/util/defaultKeyMap.js',
-  'js/util/settings.js',
   'js/util/searchEngine.js',
   'js/tabState.js',
   'js/util/urlParser.js',


### PR DESCRIPTION
`settings.js` no more needs to be concatenated with the others. I used the same technique from settings.js to check if the page is loaded in the browser from an html file or not, in order to decide whether to import settings.js or not. Otherwise one part of the browser was giving an error about `settings` being undefined.