### PR TITLE
Add a Duplicate tab menu item. Fixes #400

### DIFF
--- a/js/keybindings.js
+++ b/js/keybindings.js
@@ -54,6 +54,27 @@ ipc.on('showHistory', function () {
   tabBar.enterEditMode(tabs.getSelected(), '!history ')
 })
 
+ipc.on('duplicateTab', function (e) {
+  /* new tabs can't be created in focus mode */
+  if (focusMode.enabled()) {
+    focusMode.warn()
+    return
+  }
+
+  // can't duplicate if tabs is empty 
+  if (tabs.isEmpty()) {
+    return
+  }
+
+  const newIndex = tabs.getIndex(tabs.getSelected()) + 1
+
+  const sourceTab = tabs.get(tabs.getSelected())
+  // strip tab id so that a new one is generated
+  const newTab = tabs.add({...sourceTab, id: undefined}, newIndex)
+
+  browserUI.addTab(newTab, { enterEditMode: false })
+})
+
 ipc.on('addTab', function (e, data) {
   /* new tabs can't be created in focus mode */
   if (focusMode.enabled()) {

--- a/localization/languages/en-US.json
+++ b/localization/languages/en-US.json
@@ -127,6 +127,7 @@
         /* app menu */
         "appMenuFile": "File",
         "appMenuNewTab": "New Tab",
+        "appMenuDuplicateTab": "Duplicate Tab",
         "appMenuNewPrivateTab": "New Private Tab",
         "appMenuNewTask": "New Task",
         "appMenuSavePageAs": "Save Page As",

--- a/main/main.js
+++ b/main/main.js
@@ -284,6 +284,13 @@ function createAppMenu () {
           }
         },
         {
+          label: l('appMenuDuplicateTab'),
+          accelerator: 'shift+CmdOrCtrl+d',
+          click: function (item, window) {
+            sendIPCToWindow(window, 'duplicateTab')
+          }
+        },
+        {
           label: l('appMenuNewPrivateTab'),
           accelerator: 'shift+CmdOrCtrl+p',
           click: function (item, window) {


### PR DESCRIPTION
Ctrl+Shift+D sounds a reasonable shortcut, D as for Duplicate

Cherry-picked from #615 