### PR TITLE
TaskOverlayBuilder & UrlParser taken out of legacy modules

### DIFF
--- a/js/taskOverlay/taskOverlay.js
+++ b/js/taskOverlay/taskOverlay.js
@@ -1,6 +1,8 @@
 var browserUI = require('api-wrapper.js')
 var focusMode = require('focusMode.js')
 
+const createTaskContainer = require("taskOverlay/taskOverlayBuilder.js")
+
 var taskContainer = document.getElementById('task-area')
 var taskSwitcherButton = document.getElementById('switch-task-button')
 var addTaskButton = document.getElementById('add-task')
@@ -68,7 +70,7 @@ window.taskOverlay = {
 
     // show the task elements
     tasks.get().forEach(function (task, index) {
-      var el = window.task_container_build_func(task, index)
+      const el = createTaskContainer(task, index)
 
       taskContainer.appendChild(el)
       taskOverlay.tabDragula.containers.push(el.getElementsByClassName('task-tabs-container')[0])

--- a/js/taskOverlay/taskOverlayBuilder.js
+++ b/js/taskOverlay/taskOverlayBuilder.js
@@ -1,5 +1,6 @@
 var browserUI = require('api-wrapper.js')
 var searchbarUtils = require('searchbar/searchbarUtils.js')
+var urlParser = require('util/urlParser.js')
 
 function removeTabFromOverlay (tabId, task) {
   task.tabs.destroy(tabId)
@@ -154,4 +155,6 @@ var TaskOverlayBuilder = {
 // extend with other helper functions?
 }
 
-window.task_container_build_func = TaskOverlayBuilder.create.task.container.bind(TaskOverlayBuilder.create.task)
+module.exports = function createTaskContainer(task, index) {
+  return TaskOverlayBuilder.create.task.container(task, index)
+}

--- a/js/webviews.js
+++ b/js/webviews.js
@@ -1,6 +1,7 @@
 var browserUI = require('api-wrapper.js')
 const previewCache = require('previewCache.js')
 var getView = remote.getGlobal('getView')
+const urlParser = require('util/urlParser.js')
 
 /* implements selecting webviews, switching between them, and creating new ones. */
 

--- a/scripts/buildBrowser.js
+++ b/scripts/buildBrowser.js
@@ -36,7 +36,6 @@ const legacyModules = [
   'js/navbar/tabColor.js',
   'js/navbar/tabBar.js',
   'js/taskOverlay/taskOverlay.js',
-  'js/taskOverlay/taskOverlayBuilder.js',
   'js/navbar/addTabButton.js',
   'js/navbar/goBackButton.js',
   'js/navbar/menuButton.js',

--- a/scripts/buildBrowser.js
+++ b/scripts/buildBrowser.js
@@ -18,7 +18,6 @@ const legacyModules = [
   'js/util/settings.js',
   'js/util/searchEngine.js',
   'js/tabState.js',
-  'js/util/urlParser.js',
   'js/filteringRenderer.js',
   'js/webviews.js',
   'js/phishingWarning.js',


### PR DESCRIPTION
Removes the need to set a global function task_container_build_func, gave it a better name.

Also, I noticed you have turned the UrlParser to a module, but haven't removed it from the legacy modules list.

Btw, I understood why in previous PRs older commits appeared in the diff. It's because you squash the commits from my PR, and when I make new changes, my previous commits are still in my repo, but not on yours. When I started making this PR, github showed the changes from the entire previous PR. I had to rebase this branch onto your master to clean it. (And the effect is that they now appear to be made in the exact same second)