### PR TITLE
Modularize hosts list generation

### DIFF
--- a/js/searchbar/hostsSuggestionsPlugin.js
+++ b/js/searchbar/hostsSuggestionsPlugin.js
@@ -1,8 +1,7 @@
 var searchbarPlugins = require('searchbar/searchbarPlugins.js')
 var searchbarUtils = require('searchbar/searchbarUtils.js')
 var urlParser = require('util/urlParser.js')
-
-// hosts are parsed in util/urlParser
+const hosts = require('util/hosts.js')
 
 function showHostsSuggestions (text, input, event, container) {
   empty(container)

--- a/js/util/hosts.js
+++ b/js/util/hosts.js
@@ -4,6 +4,12 @@ var HOSTS_FILE = process.platform === 'win32'
   ? 'C:/Windows/System32/drivers/etc/hosts'
   : '/etc/hosts'
 
+function truncatedHostsFileLines(data, limit) {
+  if (data.length <= limit) return data.split('\n')
+
+  return data.substring(0, limit).split('\n').slice(0, -1)
+}
+
 fs.readFile(HOSTS_FILE, 'utf8', function (err, data) {
   if (err) {
     console.warn('error retrieving hosts file', err)
@@ -12,22 +18,9 @@ fs.readFile(HOSTS_FILE, 'utf8', function (err, data) {
 
   var hostsMap = {} // this is used to deduplicate the list
 
-  // truncate data to 1MB
-  var truncationLimit = Math.pow(1024, 2)
-  var isTruncated = false
+  const lines = truncatedHostsFileLines(data, Math.pow(1024, 2))
 
-  if (data.length > truncationLimit) {
-    data = data.substring(0, truncationLimit)
-    isTruncated = true
-  }
-
-  data = data.split('\n')
-
-  if (isTruncated) { // if the data is truncated the last line won't be complete
-    data = data.slice(0, -1)
-  }
-
-  data.forEach(function (line) {
+  lines.forEach(function (line) {
     if (line.startsWith('#')) {
       return
     }

--- a/js/util/hosts.js
+++ b/js/util/hosts.js
@@ -4,10 +4,10 @@ var HOSTS_FILE = process.platform === 'win32'
   ? 'C:/Windows/System32/drivers/etc/hosts'
   : '/etc/hosts'
 
-function truncatedHostsFileLines(data, limit) {
-  if (data.length <= limit) return data.split('\n')
-
-  return data.substring(0, limit).split('\n').slice(0, -1)
+function truncatedHostsFileLines (data, limit) {
+  return data.length > limit
+    ? data.substring(0, limit).split('\n').slice(0, -1)
+    : data.split('\n')
 }
 
 fs.readFile(HOSTS_FILE, 'utf8', function (err, data) {

--- a/js/util/hosts.js
+++ b/js/util/hosts.js
@@ -1,0 +1,43 @@
+var hosts = []
+
+var HOSTS_FILE = process.platform === 'win32'
+  ? 'C:/Windows/System32/drivers/etc/hosts'
+  : '/etc/hosts'
+
+fs.readFile(HOSTS_FILE, 'utf8', function (err, data) {
+  if (err) {
+    console.warn('error retrieving hosts file', err)
+    return
+  }
+
+  var hostsMap = {} // this is used to deduplicate the list
+
+  // truncate data to 1MB
+  var truncationLimit = Math.pow(1024, 2)
+  var isTruncated = false
+
+  if (data.length > truncationLimit) {
+    data = data.substring(0, truncationLimit)
+    isTruncated = true
+  }
+
+  data = data.split('\n')
+
+  if (isTruncated) { // if the data is truncated the last line won't be complete
+    data = data.slice(0, -1)
+  }
+
+  data.forEach(function (line) {
+    if (line.startsWith('#')) {
+      return
+    }
+    line.split(/\s/g).forEach(function (host) {
+      if (host.length > 0 && host !== '255.255.255.255' && host !== 'broadcasthost' && !hostsMap[host]) {
+        hosts.push(host)
+        hostsMap[host] = true
+      }
+    })
+  })
+})
+
+module.exports = hosts

--- a/js/util/urlParser.js
+++ b/js/util/urlParser.js
@@ -1,45 +1,4 @@
-// cache host file entries for host matching
-if(typeof window.hosts !== 'object') window.hosts = []
-
-var HOSTS_FILE = process.platform === 'win32'
-  ? 'C:/Windows/System32/drivers/etc/hosts'
-  : '/etc/hosts'
-
-fs.readFile(HOSTS_FILE, 'utf8', function (err, data) {
-  if (err) {
-    console.warn('error retrieving hosts file', err)
-    return
-  }
-
-  var hostsMap = {} // this is used to deduplicate the list
-
-  // truncate data to 1MB
-  var truncationLimit = Math.pow(1024, 2)
-  var isTruncated = false
-
-  if (data.length > truncationLimit) {
-    data = data.substring(0, truncationLimit)
-    isTruncated = true
-  }
-
-  data = data.split('\n')
-
-  if (isTruncated) { // if the data is truncated the last line won't be complete
-    data = data.slice(0, -1)
-  }
-
-  data.forEach(function (line) {
-    if (line.startsWith('#')) {
-      return
-    }
-    line.split(/\s/g).forEach(function (host) {
-      if (host.length > 0 && host !== '255.255.255.255' && host !== 'broadcasthost' && !hostsMap[host]) {
-        hosts.push(host)
-        hostsMap[host] = true
-      }
-    })
-  })
-})
+const hosts = require('./hosts.js')
 
 var urlParser = {
   startingWWWRegex: /www\.(.+\..+\/)/g,


### PR DESCRIPTION
The hosts list are not exclusively bound to the urlParser. This way is more testable and reusable.