### PR TITLE
Convert the taskPrototype to a TaskList class

### DIFF
--- a/js/api-wrapper.js
+++ b/js/api-wrapper.js
@@ -79,13 +79,13 @@ function closeTask (taskId) {
   if (taskId === currentTask.id) {
     // the current task was destroyed, find another task to switch to
 
-    if (tasks.get().length === 0) {
+    if (tasks.getLength() === 0) {
       // there are no tasks left, create a new one
       return addTask()
     } else {
       // switch to the most-recent task
 
-      var recentTaskList = tasks.get().map(function (task) {
+      var recentTaskList = tasks.map(function (task) {
         return { id: task.id, lastActivity: tasks.getLastActivity(task.id) }
       })
 

--- a/js/api-wrapper.js
+++ b/js/api-wrapper.js
@@ -38,7 +38,6 @@ options
   options.openInBackground - whether to open the tab without switching to it. Defaults to false.
 */
 function addTab (tabId = tabs.add(), options = {}) {
-
   tabBar.addTab(tabId)
   webviews.add(tabId)
 
@@ -89,12 +88,12 @@ function closeTask (taskId) {
         return { id: task.id, lastActivity: tasks.getLastActivity(task.id) }
       })
 
-      // sort the tasks based on how recent they are
-      recentTaskList.sort(function (a, b) {
-        return b.lastActivity - a.lastActivity
-      })
+      const mostRecent = recentTaskList.reduce(
+        (latest, current) =>
+          current.lastActivity > latest.lastActivity ? current : latest
+      )
 
-      return switchToTask(recentTaskList[0].id)
+      return switchToTask(mostRecent.id)
     }
   }
 }
@@ -109,7 +108,8 @@ function closeTab (tabId) {
 
   if (tabId === tabs.getSelected()) {
     var currentIndex = tabs.getIndex(tabs.getSelected())
-    var nextTab = tabs.getAtIndex(currentIndex - 1) || tabs.getAtIndex(currentIndex + 1)
+    var nextTab =
+      tabs.getAtIndex(currentIndex - 1) || tabs.getAtIndex(currentIndex + 1)
 
     destroyTab(tabId)
 
@@ -183,4 +183,14 @@ function switchToTab (id, options) {
   tabActivity.refresh()
 }
 
-module.exports = {navigate, addTask, addTab, destroyTask, destroyTab, closeTask, closeTab, switchToTask, switchToTab}
+module.exports = {
+  navigate,
+  addTask,
+  addTab,
+  destroyTask,
+  destroyTab,
+  closeTask,
+  closeTab,
+  switchToTask,
+  switchToTab
+}

--- a/js/keybindings.js
+++ b/js/keybindings.js
@@ -355,11 +355,8 @@ settings.get('keyMap', function (keyMapSettings) {
 
     const currentTaskIdx = tasks.indexOf(currentTask)
 
-    if (tasks.tasks[currentTaskIdx + 1]) {
-      browserUI.switchToTask(tasks.tasks[currentTaskIdx + 1].id)
-    } else {
-      browserUI.switchToTask(tasks.tasks[0].id)
-    }
+    const nextTaskIndex = (currentTaskIdx + 1) % tasks.getLength()
+    browserUI.switchToTask(tasks.tasks[nextTaskIndex].id)
 
     taskOverlay.show()
 
@@ -372,13 +369,13 @@ settings.get('keyMap', function (keyMapSettings) {
   defineShortcut('switchToPreviousTask', function (d) {
     taskOverlay.show()
 
-    var currentTaskIdx = tasks.indexOf(currentTask)
+    const currentTaskIdx = tasks.indexOf(currentTask),
+          taskCount = tasks.getLength()
 
-    if (tasks.tasks[currentTaskIdx - 1]) {
-      browserUI.switchToTask(tasks.tasks[currentTaskIdx - 1].id)
-    } else {
-      browserUI.switchToTask(tasks.tasks[tasks.getLength() - 1].id)
-    }
+    // The addition of taskCount fixes 0 --> -1
+    // E.g. with 5 elements: (0-1+5)%5 = 4, i.e. the last index
+    const previousTaskIndex = (currentTaskIdx - 1 + taskCount) % taskCount
+    browserUI.switchToTask(tasks.tasks[previousTaskIndex].id)
 
     taskOverlay.show()
 

--- a/js/keybindings.js
+++ b/js/keybindings.js
@@ -353,14 +353,14 @@ settings.get('keyMap', function (keyMapSettings) {
   defineShortcut('switchToNextTask', function (d) {
     taskOverlay.show()
 
-    var currentTaskIdx = tasks.get().map(function (task) {
+    var currentTaskIdx = tasks.map(function (task) {
       return task.id
     }).indexOf(currentTask.id)
 
-    if (tasks.get()[currentTaskIdx + 1]) {
-      browserUI.switchToTask(tasks.get()[currentTaskIdx + 1].id)
+    if (tasks.tasks[currentTaskIdx + 1]) {
+      browserUI.switchToTask(tasks.tasks[currentTaskIdx + 1].id)
     } else {
-      browserUI.switchToTask(tasks.get()[0].id)
+      browserUI.switchToTask(tasks.tasks[0].id)
     }
 
     taskOverlay.show()
@@ -374,14 +374,14 @@ settings.get('keyMap', function (keyMapSettings) {
   defineShortcut('switchToPreviousTask', function (d) {
     taskOverlay.show()
 
-    var currentTaskIdx = tasks.get().map(function (task) {
+    var currentTaskIdx = tasks.map(function (task) {
       return task.id
     }).indexOf(currentTask.id)
 
-    if (tasks.get()[currentTaskIdx - 1]) {
-      browserUI.switchToTask(tasks.get()[currentTaskIdx - 1].id)
+    if (tasks.tasks[currentTaskIdx - 1]) {
+      browserUI.switchToTask(tasks.tasks[currentTaskIdx - 1].id)
     } else {
-      browserUI.switchToTask(tasks.get()[tasks.get().length - 1].id)
+      browserUI.switchToTask(tasks.tasks[tasks.getLength() - 1].id)
     }
 
     taskOverlay.show()

--- a/js/keybindings.js
+++ b/js/keybindings.js
@@ -372,10 +372,8 @@ settings.get('keyMap', function (keyMapSettings) {
     const currentTaskIdx = tasks.indexOf(currentTask),
           taskCount = tasks.getLength()
 
-    // The addition of taskCount fixes 0 --> -1
-    // E.g. with 5 elements: (0-1+5)%5 = 4, i.e. the last index
-    const previousTaskIndex = (currentTaskIdx - 1 + taskCount) % taskCount
-    browserUI.switchToTask(tasks.byIndex(previousTaskIndex).id)
+    const previousTask = tasks.byIndex(currentTaskIdx - 1) || tasks.byIndex(tasks.getLength() - 1)
+    browserUI.switchToTask(previousTask.id)
 
     taskOverlay.show()
 

--- a/js/keybindings.js
+++ b/js/keybindings.js
@@ -355,8 +355,8 @@ settings.get('keyMap', function (keyMapSettings) {
 
     const currentTaskIdx = tasks.indexOf(currentTask)
 
-    const nextTaskIndex = (currentTaskIdx + 1) % tasks.getLength()
-    browserUI.switchToTask(tasks.byIndex(nextTaskIndex).id)
+    const nextTask = tasks.byIndex(currentTaskIdx + 1) || tasks.byIndex(0)
+    browserUI.switchToTask(nextTask.id)
 
     taskOverlay.show()
 

--- a/js/keybindings.js
+++ b/js/keybindings.js
@@ -356,7 +356,7 @@ settings.get('keyMap', function (keyMapSettings) {
     const currentTaskIdx = tasks.indexOf(currentTask)
 
     const nextTaskIndex = (currentTaskIdx + 1) % tasks.getLength()
-    browserUI.switchToTask(tasks.tasks[nextTaskIndex].id)
+    browserUI.switchToTask(tasks.byIndex(nextTaskIndex).id)
 
     taskOverlay.show()
 
@@ -375,7 +375,7 @@ settings.get('keyMap', function (keyMapSettings) {
     // The addition of taskCount fixes 0 --> -1
     // E.g. with 5 elements: (0-1+5)%5 = 4, i.e. the last index
     const previousTaskIndex = (currentTaskIdx - 1 + taskCount) % taskCount
-    browserUI.switchToTask(tasks.tasks[previousTaskIndex].id)
+    browserUI.switchToTask(tasks.byIndex(previousTaskIndex).id)
 
     taskOverlay.show()
 

--- a/js/keybindings.js
+++ b/js/keybindings.js
@@ -353,9 +353,7 @@ settings.get('keyMap', function (keyMapSettings) {
   defineShortcut('switchToNextTask', function (d) {
     taskOverlay.show()
 
-    var currentTaskIdx = tasks.map(function (task) {
-      return task.id
-    }).indexOf(currentTask.id)
+    const currentTaskIdx = tasks.indexOf(currentTask)
 
     if (tasks.tasks[currentTaskIdx + 1]) {
       browserUI.switchToTask(tasks.tasks[currentTaskIdx + 1].id)
@@ -374,9 +372,7 @@ settings.get('keyMap', function (keyMapSettings) {
   defineShortcut('switchToPreviousTask', function (d) {
     taskOverlay.show()
 
-    var currentTaskIdx = tasks.map(function (task) {
-      return task.id
-    }).indexOf(currentTask.id)
+    var currentTaskIdx = tasks.indexOf(currentTask)
 
     if (tasks.tasks[currentTaskIdx - 1]) {
       browserUI.switchToTask(tasks.tasks[currentTaskIdx - 1].id)

--- a/js/searchbar/customBangs.js
+++ b/js/searchbar/customBangs.js
@@ -74,17 +74,11 @@ registerCustomBang({
 
 // returns a task with the same name or index ("1" returns the first task, etc.)
 function getTaskByNameOrNumber (text) {
-  var taskSet = tasks.tasks // @TODO FIX ASAP. E.g. move this function to TaskList. Used here for simplicity
-  console.warn("tasks.tasks is a hack, should not be used.")
+  const textAsNumber = parseInt(text)
 
-  var textAsNumber = parseInt(text)
-
-  for (var i = 0; i < taskSet.length; i++) {
-    if ((taskSet[i].name && taskSet[i].name.toLowerCase() === text) || i + 1 === textAsNumber) {
-      return taskSet[i]
-    }
-  }
-  return null
+  return tasks.find((task, index) =>
+    (task.name && task.name.toLowerCase() === text) || index + 1 === textAsNumber
+  )
 }
 
 registerCustomBang({
@@ -92,7 +86,6 @@ registerCustomBang({
   snippet: l('switchToTask'),
   isAction: false,
   fn: function (text) {
-
     /* disabled in focus mode */
     if (focusMode.enabled()) {
       focusMode.warn()
@@ -120,7 +113,6 @@ registerCustomBang({
   snippet: l('createTask'),
   isAction: true,
   fn: function (text) {
-
     /* disabled in focus mode */
     if (focusMode.enabled()) {
       focusMode.warn()
@@ -143,7 +135,6 @@ registerCustomBang({
   snippet: l('moveToTask'),
   isAction: false,
   fn: function (text) {
-
     /* disabled in focus mode */
     if (focusMode.enabled()) {
       focusMode.warn()

--- a/js/searchbar/customBangs.js
+++ b/js/searchbar/customBangs.js
@@ -74,7 +74,8 @@ registerCustomBang({
 
 // returns a task with the same name or index ("1" returns the first task, etc.)
 function getTaskByNameOrNumber (text) {
-  var taskSet = tasks.get()
+  var taskSet = tasks.tasks // @TODO FIX ASAP. E.g. move this function to TaskList. Used here for simplicity
+  console.warn("tasks.tasks is a hack, should not be used.")
 
   var textAsNumber = parseInt(text)
 

--- a/js/searchbar/openTabsPlugin.js
+++ b/js/searchbar/openTabsPlugin.js
@@ -12,7 +12,7 @@ var searchOpenTabs = function (text, input, event, container) {
   var searchText = text.toLowerCase()
   var currentTab = currentTask.tabs.getSelected()
 
-  tasks.get().forEach(function (task) {
+  tasks.forEach(function (task) {
     task.tabs.get().forEach(function (tab) {
       if (tab.id === currentTab || !tab.title || tab.url === 'about:blank') {
         return

--- a/js/sessionRestore.js
+++ b/js/sessionRestore.js
@@ -4,7 +4,7 @@ window.sessionRestore = {
   save: function () {
     var data = {
       version: 2,
-      state: JSON.parse(JSON.stringify(tabState))
+      state: JSON.parse(JSON.stringify(tasks.getStringifyableState()))
     }
 
     // save all tabs that aren't private

--- a/js/tabState.js
+++ b/js/tabState.js
@@ -1,15 +1,7 @@
-var taskPrototype = require("tabState/task.js")
+const TaskList  = require("tabState/task.js")
 
 function initializeTabState () {
-  window.tabState = {
-    tasks: [], // each task is {id, name, tabs: [], tabHistory: TabStack}
-    selectedTask: null
-  }
-  for (var key in taskPrototype) {
-    tabState.tasks[key] = taskPrototype[key]
-  }
-
-  window.tasks = tabState.tasks
+  window.tasks = new TaskList()
   window.currentTask = undefined
   window.tabs = undefined
 }

--- a/js/tabState/task.js
+++ b/js/tabState/task.js
@@ -72,13 +72,8 @@ class TaskList {
     currentTask = null
   }
 
-  update (id, data) {
-    const task = this.get(id)
-    if (!task) {
-      throw new ReferenceError('Attempted to update a task that does not exist.')
-    }
-
-    for (var key in data) {
+  update (task, data) {
+    for (const key in data) {
       task[key] = data[key]
     }
   }

--- a/js/tabState/task.js
+++ b/js/tabState/task.js
@@ -1,17 +1,18 @@
-const tabPrototype = require("tabState/tab.js")
-const TabStack = require("tabRestore.js")
+const tabPrototype = require('tabState/tab.js')
+const TabStack = require('tabRestore.js')
 
-const taskPrototype = {
-  add: function (task, index) {
-    if (!task) {
-      task = {}
-    }
+class TaskList {
+  constructor () {
+    this.selected = null
+    this.tasks = [] // each task is {id, name, tabs: [], tabHistory: TabStack}
+  }
 
-    var newTask = {
+  add (task = {}, index) {
+    const newTask = {
       name: task.name || null,
       tabs: task.tabs || [],
       tabHistory: new TabStack(task.tabHistory),
-      id: task.id || String(getRandomId())
+      id: task.id || String(TaskList.getRandomId())
     }
 
     for (var key in tabPrototype) {
@@ -19,75 +20,91 @@ const taskPrototype = {
     }
 
     if (index) {
-      tabState.tasks.splice(index, 0, newTask)
+      this.tasks.splice(index, 0, newTask)
     } else {
-      tabState.tasks.push(newTask)
+      this.tasks.push(newTask)
     }
 
     return newTask.id
-  },
-  get: function (id) {
+  }
+
+  getStringifyableState () {
+    return {
+      tasks: this.tasks,
+      selectedTask: this.selected
+    }
+  }
+
+  get (id) {
     if (!id) {
-      return tabState.tasks
+      return this.tasks
     }
 
-    for (var i = 0; i < tabState.tasks.length; i++) {
-      if (tabState.tasks[i].id === id) {
-        return tabState.tasks[i]
+    for (var i = 0; i < this.tasks.length; i++) {
+      if (this.tasks[i].id === id) {
+        return this.tasks[i]
       }
     }
     return null
-  },
-  getTaskContainingTab: function (tabId) {
-    for (var i = 0; i < tabState.tasks.length; i++) {
-      if (tabState.tasks[i].tabs.has(tabId)) {
-        return tabState.tasks[i]
+  }
+
+  getTaskContainingTab (tabId) {
+    for (var i = 0; i < this.tasks.length; i++) {
+      if (this.tasks[i].tabs.has(tabId)) {
+        return this.tasks[i]
       }
     }
     return null
-  },
-  getIndex: function (id) {
-    for (var i = 0; i < tabState.tasks.length; i++) {
-      if (tabState.tasks[i].id === id) {
+  }
+
+  getIndex (id) {
+    for (var i = 0; i < this.tasks.length; i++) {
+      if (this.tasks[i].id === id) {
         return i
       }
     }
     return -1
-  },
-  setSelected: function (id) {
-    tabState.selectedTask = id
-    window.currentTask = tasks.get(id)
+  }
+
+  setSelected (id) {
+    this.selected = id
+    window.currentTask = this.get(id)
     window.tabs = currentTask.tabs
-  },
-  destroy: function (id) {
-    for (var i = 0; i < tabState.tasks.length; i++) {
-      if (tabState.tasks[i].id === id) {
-        tabState.tasks.splice(i, 1)
+  }
+
+  destroy (id) {
+    for (var i = 0; i < this.tasks.length; i++) {
+      if (this.tasks[i].id === id) {
+        this.tasks.splice(i, 1)
         return i
       }
     }
     return false
-  },
-  destroyAll: function () {
-    tabState.tasks = []
+  }
+
+  destroyAll () {
+    this.tasks = []
+    this.selected = null
     currentTask = null
-  },
-  update: function (id, data) {
-    if (!tasks.get(id)) {
+  }
+
+  update (id, data) {
+    if (!this.get(id)) {
       throw new ReferenceError('Attempted to update a task that does not exist.')
     }
 
-    for (var i = 0; i < tabState.tasks.length; i++) {
-      if (tabState.tasks[i].id === id) {
+    for (var i = 0; i < this.tasks.length; i++) {
+      if (this.tasks[i].id === id) {
         for (var key in data) {
-          tabState.tasks[i][key] = data[key]
+          this.tasks[i][key] = data[key]
         }
         break
       }
     }
-  },
-  getLastActivity: function (id) {
-    var tabs = tasks.get(id).tabs
+  }
+
+  getLastActivity (id) {
+    var tabs = this.get(id).tabs
     var lastActivity = 0
 
     for (var i = 0; i < tabs.length; i++) {
@@ -98,10 +115,10 @@ const taskPrototype = {
 
     return lastActivity
   }
+
+  static getRandomId () {
+    return Math.round(Math.random() * 100000000000000000)
+  }
 }
 
-function getRandomId () {
-  return Math.round(Math.random() * 100000000000000000)
-}
-
-module.exports = taskPrototype
+module.exports = TaskList

--- a/js/tabState/task.js
+++ b/js/tabState/task.js
@@ -73,17 +73,13 @@ class TaskList {
   }
 
   update (id, data) {
-    if (!this.get(id)) {
+    const task = this.get(id)
+    if (!task) {
       throw new ReferenceError('Attempted to update a task that does not exist.')
     }
 
-    for (var i = 0; i < this.tasks.length; i++) {
-      if (this.tasks[i].id === id) {
-        for (var key in data) {
-          this.tasks[i][key] = data[key]
-        }
-        break
-      }
+    for (var key in data) {
+      task[key] = data[key]
     }
   }
 

--- a/js/tabState/task.js
+++ b/js/tabState/task.js
@@ -120,6 +120,8 @@ class TaskList {
 
   forEach(fun) { return this.tasks.forEach(fun) }
 
+  indexOf(task) { return this.tasks.indexOf(task) }
+
   static getRandomId () {
     return Math.round(Math.random() * 100000000000000000)
   }

--- a/js/tabState/task.js
+++ b/js/tabState/task.js
@@ -72,12 +72,6 @@ class TaskList {
     currentTask = null
   }
 
-  update (task, data) {
-    for (const key in data) {
-      task[key] = data[key]
-    }
-  }
-
   getLastActivity (id) {
     var tabs = this.get(id).tabs
     var lastActivity = 0

--- a/js/tabState/task.js
+++ b/js/tabState/task.js
@@ -36,12 +36,7 @@ class TaskList {
   }
 
   get (id) {
-    for (var i = 0; i < this.tasks.length; i++) {
-      if (this.tasks[i].id === id) {
-        return this.tasks[i]
-      }
-    }
-    return null
+    return this.tasks.find(task => task.id == id) || null
   }
 
   byIndex (index) {
@@ -49,21 +44,11 @@ class TaskList {
   }
 
   getTaskContainingTab (tabId) {
-    for (var i = 0; i < this.tasks.length; i++) {
-      if (this.tasks[i].tabs.has(tabId)) {
-        return this.tasks[i]
-      }
-    }
-    return null
+    return this.find(task => task.tabs.has(tabId)) || null
   }
 
   getIndex (id) {
-    for (var i = 0; i < this.tasks.length; i++) {
-      if (this.tasks[i].id === id) {
-        return i
-      }
-    }
-    return -1
+    return this.tasks.findIndex(task => task.id == id)
   }
 
   setSelected (id) {
@@ -73,13 +58,12 @@ class TaskList {
   }
 
   destroy (id) {
-    for (var i = 0; i < this.tasks.length; i++) {
-      if (this.tasks[i].id === id) {
-        this.tasks.splice(i, 1)
-        return i
-      }
-    }
-    return false
+    const index = this.getIndex(id)
+
+    if(index < 0) return false
+
+    this.tasks.splice(index, 1)
+    return index
   }
 
   destroyAll () {

--- a/js/tabState/task.js
+++ b/js/tabState/task.js
@@ -36,7 +36,7 @@ class TaskList {
   }
 
   get (id) {
-    return this.tasks.find(task => task.id == id) || null
+    return this.find(task => task.id == id) || null
   }
 
   byIndex (index) {
@@ -95,7 +95,13 @@ class TaskList {
 
   indexOf(task) { return this.tasks.indexOf(task) }
 
-  find(task) { return this.tasks.find(task) }
+  find(filter) {
+    for (var i = 0, len = this.tasks.length; i < len; i++) {
+      if (filter(this.tasks[i])) {
+        return this.tasks[i]
+      }
+    } 
+  }
 
   static getRandomId () {
     return Math.round(Math.random() * 100000000000000000)

--- a/js/tabState/task.js
+++ b/js/tabState/task.js
@@ -36,10 +36,6 @@ class TaskList {
   }
 
   get (id) {
-    if (!id) {
-      return this.tasks
-    }
-
     for (var i = 0; i < this.tasks.length; i++) {
       if (this.tasks[i].id === id) {
         return this.tasks[i]
@@ -115,6 +111,14 @@ class TaskList {
 
     return lastActivity
   }
+
+  getLength() {
+    return this.tasks.length
+  }
+
+  map(fun) { return this.tasks.map(fun) }
+
+  forEach(fun) { return this.tasks.forEach(fun) }
 
   static getRandomId () {
     return Math.round(Math.random() * 100000000000000000)

--- a/js/tabState/task.js
+++ b/js/tabState/task.js
@@ -126,6 +126,8 @@ class TaskList {
 
   indexOf(task) { return this.tasks.indexOf(task) }
 
+  find(task) { return this.tasks.find(task) }
+
   static getRandomId () {
     return Math.round(Math.random() * 100000000000000000)
   }

--- a/js/tabState/task.js
+++ b/js/tabState/task.js
@@ -44,6 +44,10 @@ class TaskList {
     return null
   }
 
+  byIndex (index) {
+    return this.tasks[index]
+  }
+
   getTaskContainingTab (tabId) {
     for (var i = 0; i < this.tasks.length; i++) {
       if (this.tasks[i].tabs.has(tabId)) {

--- a/js/taskOverlay/taskOverlay.js
+++ b/js/taskOverlay/taskOverlay.js
@@ -69,7 +69,7 @@ window.taskOverlay = {
     empty(taskContainer)
 
     // show the task elements
-    tasks.get().forEach(function (task, index) {
+    tasks.forEach(function (task, index) {
       const el = createTaskContainer(task, index)
 
       taskContainer.appendChild(el)

--- a/js/taskOverlay/taskOverlayBuilder.js
+++ b/js/taskOverlay/taskOverlayBuilder.js
@@ -29,7 +29,7 @@ var TaskOverlayBuilder = {
         var input = document.createElement('input')
         input.classList.add('task-name')
 
-        var taskName = l('defaultTaskName').replace('%n', (taskIndex + 1))
+        var taskName = l('defaultTaskName').replace('%n', taskIndex + 1)
 
         input.placeholder = taskName
         input.value = task.name || taskName
@@ -38,7 +38,8 @@ var TaskOverlayBuilder = {
           if (e.keyCode === 13) {
             this.blur()
           }
-          tasks.update(task.id, { name: this.value })
+
+          tasks.update(task, { name: this.value })
         })
 
         input.addEventListener('focus', function () {
@@ -80,7 +81,11 @@ var TaskOverlayBuilder = {
         container.className = 'task-container'
         container.setAttribute('data-task', task.id)
 
-        var taskActionContainer = this.actionContainer(container, task, taskIndex)
+        var taskActionContainer = this.actionContainer(
+          container,
+          task,
+          taskIndex
+        )
         container.appendChild(taskActionContainer)
 
         var tabContainer = TaskOverlayBuilder.create.tab.container(task)
@@ -150,11 +155,10 @@ var TaskOverlayBuilder = {
         return closeTabButton
       }
     }
-
   }
-// extend with other helper functions?
+  // extend with other helper functions?
 }
 
-module.exports = function createTaskContainer(task, index) {
+module.exports = function createTaskContainer (task, index) {
   return TaskOverlayBuilder.create.task.container(task, index)
 }

--- a/js/taskOverlay/taskOverlayBuilder.js
+++ b/js/taskOverlay/taskOverlayBuilder.js
@@ -39,7 +39,7 @@ var TaskOverlayBuilder = {
             this.blur()
           }
 
-          tasks.update(task, { name: this.value })
+          task.name = this.value
         })
 
         input.addEventListener('focus', function () {


### PR DESCRIPTION
Rewrote it as a class. It has a mroe clear interface, with helpers for map/forEach/… on the inner `tasks[]` array (65ed6c4224fc742aaf0ef1ec5cb66b4bd06f5a7c), some optimizations (54ab215fbf9a53c3e56d3f8c83ad2edfa16330c8 - arr.map().indexOf() is inefficient, 013c01f9b2b5e2735cf42c8f9e16da2e272f0772 - no need to sort the whole array just to take the lowest value; here I've also ran `standard`, which made some extra styling changes), removed all direct references to the inner task array (helps us think about `tasks` as a *task list*, and not an *enhanced array of task objects* - 65ed6c4224fc742aaf0ef1ec5cb66b4bd06f5a7c), also rewrote some parts using the provided helpers to clean the code and avoid duplication (54ab215fbf9a53c3e56d3f8c83ad2edfa16330c8).

It got a bit longer than the previous PRs because there was more to clean, but if you look at it commit-by-commit, it should be clear. Let me know if you have any questions/critics.