### PR TITLE
Convert tabColor to a module

### DIFF
--- a/ext/textColor/textColor.js
+++ b/ext/textColor/textColor.js
@@ -1,0 +1,65 @@
+// a neural network for determing which text color to use, generated using http://harthur.github.io/brain/
+var runNetwork = function anonymous (input) {
+  var net = {
+    'layers': [{
+      'r': {},
+      'g': {},
+      'b': {}
+    }, {
+      '0': {
+        'bias': 14.176907520571566,
+        'weights': {
+          'r': -3.2764240497480652,
+          'g': -16.90247884718719,
+          'b': -2.9976364179397814
+        }
+      },
+      '1': {
+        'bias': 9.086071102351246,
+        'weights': {
+          'r': -4.327474143397604,
+          'g': -15.780660155750773,
+          'b': 2.879230202567851
+        }
+      },
+      '2': {
+        'bias': 22.274487339773476,
+        'weights': {
+          'r': -3.5830205067960965,
+          'g': -25.498384261673618,
+          'b': -6.998329189107962
+        }
+      }
+    }, {
+      'black': {
+        'bias': 17.873962570788997,
+        'weights': {
+          '0': -15.542217788633987,
+          '1': -13.377152708685674,
+          '2': -24.52215186113144
+        }
+      }
+    }],
+    'outputLookup': true,
+    'inputLookup': true
+  }
+
+  for (var i = 1; i < net.layers.length; i++) {
+    var layer = net.layers[i]
+    var output = {}
+
+    for (var id in layer) {
+      var node = layer[id]
+      var sum = node.bias
+
+      for (var iid in node.weights) {
+        sum += node.weights[iid] * input[iid]
+      }
+      output[id] = (1 / (1 + Math.exp(-sum)))
+    }
+    input = output
+  }
+  return output
+}
+
+module.exports = runNetwork

--- a/js/api-wrapper.js
+++ b/js/api-wrapper.js
@@ -3,6 +3,7 @@
 var urlParser = require('util/urlParser.js')
 var focusMode = require('focusMode.js')
 var tabActivity = require('navbar/tabActivity.js')
+var tabColor = require('navbar/tabColor.js')
 
 /* loads a page in a webview */
 
@@ -37,8 +38,7 @@ options
   options.enterEditMode - whether to enter editing mode when the tab is created. Defaults to true.
   options.openInBackground - whether to open the tab without switching to it. Defaults to false.
 */
-function addTab (tabId = tabs.add(), options = {}) {
-
+function addTab (tabId = tabs.add() , options = {}) {
   tabBar.addTab(tabId)
   webviews.add(tabId)
 
@@ -176,7 +176,7 @@ function switchToTab (id, options) {
     focus: options.focusWebview !== false
   })
 
-  updateColorPalette()
+  tabColor.refresh()
 
   sessionRestore.save()
 

--- a/js/deferredLoad.js
+++ b/js/deferredLoad.js
@@ -1,0 +1,1 @@
+require('navbar/tabColor.js').initialize()

--- a/js/navbar/tabColor.js
+++ b/js/navbar/tabColor.js
@@ -1,6 +1,6 @@
-var colorExtractorImage = document.createElement('img')
-var colorExtractorCanvas = document.createElement('canvas')
-var colorExtractorContext = colorExtractorCanvas.getContext('2d')
+const colorExtractorImage = document.createElement('img')
+const colorExtractorCanvas = document.createElement('canvas')
+const colorExtractorContext = colorExtractorCanvas.getContext('2d')
 
 const textColorNN = require('ext/textColor/textColor.js')
 
@@ -11,22 +11,22 @@ const defaultColors = {
 }
 
 function getColorFromImage (image) {
-  var w = colorExtractorImage.width
-  var h = colorExtractorImage.height
+  const w = colorExtractorImage.width
+  const h = colorExtractorImage.height
   colorExtractorCanvas.width = w
   colorExtractorCanvas.height = h
 
-  var offset = Math.max(1, Math.round(0.00032 * w * h))
+  const offset = Math.max(1, Math.round(0.00032 * w * h))
 
   colorExtractorContext.drawImage(colorExtractorImage, 0, 0, w, h)
 
-  var data = colorExtractorContext.getImageData(0, 0, w, h).data
+  const data = colorExtractorContext.getImageData(0, 0, w, h).data
 
-  var pixels = {}
+  let pixels = {}
 
-  var d, add, sum
+  let d, add, sum
 
-  for (var i = 0; i < data.length; i += 4 * offset) {
+  for (let i = 0; i < data.length; i += 4 * offset) {
     d = Math.round(data[i] / 5) * 5 + ',' + Math.round(data[i + 1] / 5) * 5 + ',' + Math.round(data[i + 2] / 5) * 5
 
     add = 1
@@ -53,10 +53,10 @@ function getColorFromImage (image) {
   }
 
   // find the largest pixel set
-  var largestPixelSet = null
-  var ct = 0
+  let largestPixelSet = null
+  let ct = 0
 
-  for (var k in pixels) {
+  for (let k in pixels) {
     if (k === '255,255,255' || k === '0,0,0') {
       pixels[k] *= 0.05
     }
@@ -66,14 +66,14 @@ function getColorFromImage (image) {
     }
   }
 
-  var res = largestPixelSet.split(',')
+  let res = largestPixelSet.split(',')
 
-  for (var i = 0; i < res.length; i++) {
+  for (let i = 0; i < res.length; i++) {
     res[i] = parseInt(res[i])
   }
 
   // dim the colors late at night or early in the morning, or when dark mode is enabled
-  var colorChange = 1
+  let colorChange = 1
   if (hours > 20) {
     colorChange -= 0.015 * Math.pow(2.75, hours - 20)
   } else if (hours < 6.5) {
@@ -96,7 +96,7 @@ function getHours () {
   return date.getHours() + (date.getMinutes() / 60)
 }
 
-var hours = getHours()
+let hours = getHours()
 
 // we cache the hours so we don't have to query every time we change the color
 setInterval(function () {
@@ -107,13 +107,13 @@ function getRGBString (c) {
   return 'rgb(' + c[0] + ',' + c[1] + ',' + c[2] + ')'
 }
 
-var getTextColor = function (bgColor) {
-  var obj = {
+function getTextColor (bgColor) {
+  const obj = {
     r: bgColor[0] / 255,
     g: bgColor[1] / 255,
     b: bgColor[2] / 255
   }
-  var output = textColorNN(obj)
+  const output = textColorNN(obj)
   if (output.black > 0.5) {
     return 'black'
   }
@@ -121,14 +121,14 @@ var getTextColor = function (bgColor) {
 }
 
 function setColor (bg, fg) {
-  var backgroundElements = document.getElementsByClassName('theme-background-color')
-  var textElements = document.getElementsByClassName('theme-text-color')
+  const backgroundElements = document.getElementsByClassName('theme-background-color')
+  const textElements = document.getElementsByClassName('theme-text-color')
 
-  for (var i = 0; i < backgroundElements.length; i++) {
+  for (let i = 0; i < backgroundElements.length; i++) {
     backgroundElements[i].style.backgroundColor = bg
   }
 
-  for (var i = 0; i < textElements.length; i++) {
+  for (let i = 0; i < textElements.length; i++) {
     textElements[i].style.color = fg
   }
 
@@ -142,7 +142,7 @@ function setColor (bg, fg) {
 const tabColor = {
   initialize: function () {
     webviews.bindEvent('page-favicon-updated', function (e, favicons) {
-      var id = webviews.getTabFromContents(this)
+      const id = webviews.getTabFromContents(this)
       tabColor.updateFromImage(favicons, id)
     })
 
@@ -159,10 +159,10 @@ const tabColor = {
 
     requestIdleCallback(function () {
       colorExtractorImage.onload = function (e) {
-        let backgroundColor = getColorFromImage(colorExtractorImage)
-        let textColor = getTextColor(backgroundColor)
+        const backgroundColor = getColorFromImage(colorExtractorImage)
+        const textColor = getTextColor(backgroundColor)
 
-        let backgroundString = getRGBString(backgroundColor)
+        const backgroundString = getRGBString(backgroundColor)
 
         tabs.update(tabId, {
           backgroundColor: backgroundString,
@@ -179,7 +179,7 @@ const tabColor = {
     })
   },
   refresh: function () {
-    var tab = tabs.get(tabs.getSelected())
+    const tab = tabs.get(tabs.getSelected())
 
     // private tabs have their own color scheme
     if (tab.private) {

--- a/js/navbar/tabColor.js
+++ b/js/navbar/tabColor.js
@@ -2,6 +2,8 @@ var colorExtractorImage = document.createElement('img')
 var colorExtractorCanvas = document.createElement('canvas')
 var colorExtractorContext = colorExtractorCanvas.getContext('2d')
 
+const textColorNN = require('ext/textColor/textColor.js')
+
 const defaultColors = {
   private: ['rgb(58, 44, 99)', 'white'],
   lightMode: ['rgb(255, 255, 255)', 'black'],
@@ -111,75 +113,11 @@ var getTextColor = function (bgColor) {
     g: bgColor[1] / 255,
     b: bgColor[2] / 255
   }
-  var output = runNetwork(obj)
+  var output = textColorNN(obj)
   if (output.black > 0.5) {
     return 'black'
   }
   return 'white'
-}
-
-// generated using http://harthur.github.io/brain/
-var runNetwork = function anonymous (input) {
-  var net = {
-    'layers': [{
-      'r': {},
-      'g': {},
-      'b': {}
-    }, {
-      '0': {
-        'bias': 14.176907520571566,
-        'weights': {
-          'r': -3.2764240497480652,
-          'g': -16.90247884718719,
-          'b': -2.9976364179397814
-        }
-      },
-      '1': {
-        'bias': 9.086071102351246,
-        'weights': {
-          'r': -4.327474143397604,
-          'g': -15.780660155750773,
-          'b': 2.879230202567851
-        }
-      },
-      '2': {
-        'bias': 22.274487339773476,
-        'weights': {
-          'r': -3.5830205067960965,
-          'g': -25.498384261673618,
-          'b': -6.998329189107962
-        }
-      }
-    }, {
-      'black': {
-        'bias': 17.873962570788997,
-        'weights': {
-          '0': -15.542217788633987,
-          '1': -13.377152708685674,
-          '2': -24.52215186113144
-        }
-      }
-    }],
-    'outputLookup': true,
-    'inputLookup': true
-  }
-
-  for (var i = 1; i < net.layers.length; i++) {
-    var layer = net.layers[i]
-    var output = {}
-
-    for (var id in layer) {
-      var node = layer[id]
-      var sum = node.bias
-
-      for (var iid in node.weights) {
-        sum += node.weights[iid] * input[iid]
-      }
-      output[id] = (1 / (1 + Math.exp(-sum)))
-    }
-    input = output
-  }
-  return output
 }
 
 function setColor (bg, fg) {

--- a/js/navbar/tabColor.js
+++ b/js/navbar/tabColor.js
@@ -90,7 +90,8 @@ function getColorFromImage (image) {
 }
 
 function getHours () {
-  return new Date().getHours() + (new Date().getMinutes() / 60)
+  const date = new Date()
+  return date.getHours() + (date.getMinutes() / 60)
 }
 
 var hours = getHours()
@@ -242,18 +243,21 @@ const tabColor = {
   refresh: function () {
     var tab = tabs.get(tabs.getSelected())
 
+    // private tabs have their own color scheme
     if (tab.private) {
-      // private tabs have their own color scheme
       return setColor(defaultColors.private[0], defaultColors.private[1])
-    // use the colors extracted from the page icon
-    } else if (tab.backgroundColor || tab.foregroundColor) {
-      return setColor(tab.backgroundColor, tab.foregroundColor)
-    // otherwise use the default colors
-    } else if (window.isDarkMode) {
-      return setColor(defaultColors.darkMode[0], defaultColors.darkMode[1])
-    } else {
-      return setColor(defaultColors.lightMode[0], defaultColors.lightMode[1])
     }
+
+    // use the colors extracted from the page icon
+    if (tab.backgroundColor || tab.foregroundColor) {
+      return setColor(tab.backgroundColor, tab.foregroundColor)
+    }
+
+    // otherwise use the default colors
+    if (window.isDarkMode) {
+      return setColor(defaultColors.darkMode[0], defaultColors.darkMode[1])
+    }
+    return setColor(defaultColors.lightMode[0], defaultColors.lightMode[1])
   }
 }
 

--- a/js/webviews.js
+++ b/js/webviews.js
@@ -364,11 +364,6 @@ webviews.bindEvent('did-finish-load', onPageLoad)
 webviews.bindEvent('did-navigate-in-page', onPageLoad)
 webviews.bindEvent('did-navigate', onNavigate)
 
-webviews.bindEvent('page-favicon-updated', function (e, favicons) {
-  var id = webviews.getTabFromContents(this)
-  updateTabColor(favicons, id)
-})
-
 webviews.bindEvent('page-title-updated', function (e, title, explicitSet) {
   var tab = webviews.getTabFromContents(this)
   tabs.update(tab, {

--- a/scripts/buildBrowser.js
+++ b/scripts/buildBrowser.js
@@ -32,7 +32,6 @@ const legacyModules = [
   'js/searchbar/placeSuggestionsPlugin.js',
   'js/searchbar/hostsSuggestionsPlugin.js',
   'js/readerview.js',
-  'js/navbar/tabColor.js',
   'js/navbar/tabBar.js',
   'js/taskOverlay/taskOverlay.js',
   'js/navbar/addTabButton.js',
@@ -42,6 +41,7 @@ const legacyModules = [
   'js/pdfViewer.js',
   'js/findinpage.js',
   'js/userscripts.js',
+  'js/deferredLoad.js',
   'js/sessionRestore.js',
   'js/util/theme.js',
   'js/webviewGestures.js'

--- a/scripts/buildBrowser.js
+++ b/scripts/buildBrowser.js
@@ -3,7 +3,8 @@ const renderify = require('electron-renderify')
 const path = require('path')
 const fs = require('fs')
 
-const rootDir = path.resolve(__dirname, '../js')
+const rootDir = path.resolve(__dirname, '../')
+const jsDir = path.resolve(__dirname, '../js')
 
 const intermediateOutput = path.resolve(__dirname, '../dist/build.js')
 const outFile = path.resolve(__dirname, '../dist/bundle.js')
@@ -61,7 +62,7 @@ function buildBrowser () {
   fs.writeFileSync(intermediateOutput, output, 'utf-8')
 
   let instance = browserify(intermediateOutput, {
-    paths: [rootDir],
+    paths: [rootDir, jsDir],
     ignoreMissing: false,
     node: true,
     detectGlobals: false


### PR DESCRIPTION
@code-hunger Any suggestions?

I had to add an additional file, `deferredLoad.js`, that initializes the tabColor module. The reason for this is that in order to attach the events correctly, tabColor has to be initialized after the `webviews` object is created, but before the first view is created. I expect the solution to this is to convert webviews to a module and have tabColor depend on it, but that's going to require a bunch of other changes first.