### PR TITLE
Added Site Themes toggle for #619

### DIFF
--- a/js/navbar/tabColor.js
+++ b/js/navbar/tabColor.js
@@ -214,7 +214,7 @@ window.updateColorPalette = function () {
     // private tabs have their own color scheme
     return setColor(defaultColors.private[0], defaultColors.private[1])
   // use the colors extracted from the page icon
-  } else if (tab.backgroundColor || tab.foregroundColor) {
+  } else if (window.allowSiteThemes && (tab.backgroundColor || tab.foregroundColor)) {
     return setColor(tab.backgroundColor, tab.foregroundColor)
   // otherwise use the default colors
   } else if (window.isDarkMode) {

--- a/js/util/theme.js
+++ b/js/util/theme.js
@@ -4,14 +4,9 @@ function shouldEnableDarkMode () {
 }
 
 settings.get('siteThemes', function(value) {
-  if (value === true) {
-    window.allowSiteThemes = true
-    window.dispatchEvent(new CustomEvent('themechange'))
-  } else {
-    window.allowSiteThemes = false
-    window.dispatchEvent(new CustomEvent('themechange'))
-  }
-});
+  window.allowSiteThemes = value
+  window.dispatchEvent(new CustomEvent('themechange'))
+})
 
 settings.get('darkMode', function (value) {
   if (value === true || shouldEnableDarkMode()) {

--- a/js/util/theme.js
+++ b/js/util/theme.js
@@ -3,6 +3,16 @@ function shouldEnableDarkMode () {
   return hours > 21 || hours < 6
 }
 
+settings.get('siteThemes', function(value) {
+  if (value === true) {
+    window.allowSiteThemes = true
+    window.dispatchEvent(new CustomEvent('themechange'))
+  } else {
+    window.allowSiteThemes = false
+    window.dispatchEvent(new CustomEvent('themechange'))
+  }
+});
+
 settings.get('darkMode', function (value) {
   if (value === true || shouldEnableDarkMode()) {
     document.body.classList.add('dark-mode')

--- a/localization/languages/en-US.json
+++ b/localization/languages/en-US.json
@@ -112,6 +112,7 @@
             "unsafeHTML": "Based on EasyList and EasyPrivacy, without element hiding rules. Created by <a target=\"_blank\" href=\"https://easylist.to/\">The EasyList authors</a> - <a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/3.0/legalcode\">view license</a>."
         },
         "settingsAppearanceHeading": "Appearance",
+        "settingsSiteThemesToggle": "Enable site themes",
         "settingsDarkModeToggle": "Enable dark mode",
         "settingsHistoryButtonToggle": "Enable back button",
         "settingsAdditionalFeaturesHeading": "Additional Features",

--- a/pages/settings/index.html
+++ b/pages/settings/index.html
@@ -37,6 +37,9 @@
 		<h3 data-string="settingsAppearanceHeading"></h3>
 
 		<div class="setting-section">
+			<input type="checkbox" id="checkbox-site-themes" />
+			<label for="checkbox-site-themes" data-string="settingsSiteThemesToggle"></label>
+			<div class="spacer"></div>
 			<input type="checkbox" id="checkbox-dark-mode" />
 			<label for="checkbox-dark-mode" data-string="settingsDarkModeToggle"></label>
 			<div class="spacer"></div>
@@ -91,7 +94,7 @@
 			<span data-string="settingsRestartRequired"></span>
 		</div>
 	</div>
-
+	
 	<script src="../../ext/Dexie.min.js"></script>
 	<script src="../../js/util/database.js"></script>
 	<script src="../../js/util/defaultKeyMap.js"></script>

--- a/pages/settings/settings.js
+++ b/pages/settings/settings.js
@@ -3,6 +3,7 @@ document.title = l('settingsPreferencesHeading') + ' | Min'
 var container = document.getElementById('privacy-settings-container')
 var trackerCheckbox = document.getElementById('checkbox-block-trackers')
 var banner = document.getElementById('restart-required-banner')
+var siteThemesCheckbox = document.getElementById('checkbox-site-themes')
 var darkModeCheckbox = document.getElementById('checkbox-dark-mode')
 var historyButtonCheckbox = document.getElementById('checkbox-history-button')
 var swipeNavigationCheckbox = document.getElementById('checkbox-swipe-navigation')
@@ -95,6 +96,17 @@ for (var contentType in contentTypes) {
     })
   })(contentType)
 }
+
+/* site themes setting */
+
+settings.get('siteThemes', function (value) {
+  siteThemesCheckbox.checked = value
+})
+
+siteThemesCheckbox.addEventListener('change', function (e) {
+  settings.set('siteThemes', this.checked)
+  showRestartRequiredBanner()
+})
 
 /* dark mode setting */
 


### PR DESCRIPTION
So #619 asked for a simple toggle in the preferences to disable site colors (like when you go on Google and it changes tabs to blue or something). 

This will require adding new translations for every language, I have only added for en_us for now. 
Also it might conflict with other current PRs that are refactoring the tabColor module though it shouldn't be too hard to fix. 

Another idea to make this better would be to allow for custom theming (where users can select from a variety of colors instead of a simple toggle), but this would be outside of the scope of the original issue.
