### PR TITLE
Add options to block third-party ads and add site exceptions

### DIFF
--- a/ext/abp-filter-parser-modified/abp-filter-parser.js
+++ b/ext/abp-filter-parser-modified/abp-filter-parser.js
@@ -624,3 +624,4 @@ exports.parse = parse
 exports.matchesFilters = matchesFilters
 exports.matches = matches
 exports.getUrlHost = getUrlHost
+exports.isSameOriginHost = isSameOriginHost

--- a/js/filteringRenderer.js
+++ b/js/filteringRenderer.js
@@ -1,7 +1,17 @@
 // gets the tracking settings and sends them to the main process
 
-settings.get('filtering', function (settings) {
-  ipc.send('setFilteringSettings', settings)
+settings.get('filtering', function (value) {
+  // migrate from old settings (<v1.9.0)
+  if (value && typeof value.trackers === 'boolean') {
+    if (value.trackers === true) {
+      value.blockingLevel = 2
+    } else if (value.trackers === false) {
+      value.blockingLevel = 0
+    }
+    delete value.trackers
+    settings.set('filtering', value)
+  }
+  ipc.send('setFilteringSettings', value)
 })
 
 function registerFiltering (ses) {

--- a/localization/languages/bn.json
+++ b/localization/languages/bn.json
@@ -111,7 +111,7 @@
       "settingsBlockScriptsToggle":"স্ক্রিপ্ট ব্লক করুন",
       "settingsBlockImagesToggle":"ইমেজ ব্লক করুন",
       "settingsEasyListCredit": {
-        "unsafeHTML": "সহজলভ্য এবং সহজপ্রীতি উপর ভিত্তি করে, উপাদান গোপন নিয়ম ছাড়া। <a target=\"_blank\" href=\"https://easylist.to/\"> EasyList লেখকগণ দ্বারা তৈরি </a> - <a target=\"_blank\" href=\"https://easylist.to/\"> লাইসেন্স দেখুন </a>"
+        "unsafeHTML": null //missing translation
       },
       "settingsAppearanceHeading":"চেহারা",
       "settingsDarkModeToggle":"অন্ধকার মোড সক্রিয় করুন",

--- a/localization/languages/bn.json
+++ b/localization/languages/bn.json
@@ -104,7 +104,10 @@
       "settingsPreferencesHeading":"পছন্দসমূহ",
       "settingsRestartRequired":"আপনি এই পরিবর্তনগুলি প্রয়োগ করতে পুনরায় শুরু করতে হবে।",
       "settingsPrivacyHeading":"সামগ্রী ব্লকিং",
-      "settingsContentBlockingToggle":"ব্লক trackers এবং বিজ্ঞাপন ব্লক",
+      "settingsContentBlockingLevel0": null, //missing translation
+      "settingsContentBlockingLevel1": null, //missing translation
+      "settingsContentBlockingLevel2": null, //missing translation
+      "settingsContentBlockingExceptions": null, //missing translation
       "settingsBlockScriptsToggle":"স্ক্রিপ্ট ব্লক করুন",
       "settingsBlockImagesToggle":"ইমেজ ব্লক করুন",
       "settingsEasyListCredit": {

--- a/localization/languages/cs.json
+++ b/localization/languages/cs.json
@@ -108,7 +108,7 @@
         "settingsBlockScriptsToggle": "Blokovat skripty",
         "settingsBlockImagesToggle": "Blokovat obrázky",
         "settingsEasyListCredit": {
-            "unsafeHTML": "Na základě EasyList a EasyPrivacy bez pravidel skrývání prvků. Vytvořili <a target=\"_blank\" href=\"https://easylist.to/\">The EasyList authors</a> - <a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/3.0/legalcode\">s licencí</a>."
+            "unsafeHTML": null //missing translation
         },
         "settingsAppearanceHeading": "Vzhled",
         "settingsDarkModeToggle": "Použít tmavý režim",

--- a/localization/languages/de.json
+++ b/localization/languages/de.json
@@ -104,7 +104,10 @@
         "settingsPreferencesHeading": "Einstellungen",
         "settingsRestartRequired": "Ein Neustart ist erforderlich um die Änderungen zu übernehmen.",
         "settingsPrivacyHeading": "Inhalte blockieren",
-        "settingsContentBlockingToggle": "Tracker und Werbung blockieren",
+        "settingsContentBlockingLevel0": null, //missing translation
+        "settingsContentBlockingLevel1": null, //missing translation
+        "settingsContentBlockingLevel2": null, //missing translation
+        "settingsContentBlockingExceptions": null, //missing translation
         "settingsBlockScriptsToggle": "Scripte blockieren",
         "settingsBlockImagesToggle": "Bilder blockieren",
         "settingsEasyListCredit": {

--- a/localization/languages/de.json
+++ b/localization/languages/de.json
@@ -111,7 +111,7 @@
         "settingsBlockScriptsToggle": "Scripte blockieren",
         "settingsBlockImagesToggle": "Bilder blockieren",
         "settingsEasyListCredit": {
-            "unsafeHTML": "Basiert auf EasyList und EasyPrivacy, ohne Regeln zum Verstecken von Elementen. Erstellt von <a target=\"_blank\" href=\"https://easylist.to/\">den Easylist-Autoren</a> - <a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/3.0/legalcode\">Lizenz anzeigen</a>."
+            "unsafeHTML": null //missing translation
         },
         "settingsAppearanceHeading": "Aussehen",
         "settingsDarkModeToggle": "Dark-Mode einschalten",

--- a/localization/languages/en-US.json
+++ b/localization/languages/en-US.json
@@ -111,7 +111,7 @@
         "settingsBlockScriptsToggle": "Block scripts",
         "settingsBlockImagesToggle": "Block images",
         "settingsEasyListCredit": {
-            "unsafeHTML": "Based on EasyList and EasyPrivacy, without element hiding rules. Created by <a target=\"_blank\" href=\"https://easylist.to/\">The EasyList authors</a> - <a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/3.0/legalcode\">view license</a>."
+            "unsafeHTML": "Based on EasyList and EasyPrivacy, created by <a target=\"_blank\" href=\"https://easylist.to/\">The EasyList authors</a> (<a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/3.0/legalcode\">view license</a>)."
         },
         "settingsAppearanceHeading": "Appearance",
         "settingsDarkModeToggle": "Enable dark mode",

--- a/localization/languages/en-US.json
+++ b/localization/languages/en-US.json
@@ -104,7 +104,10 @@
         "settingsPreferencesHeading": "Preferences",
         "settingsRestartRequired": "You need to restart to apply these changes.",
         "settingsPrivacyHeading": "Content Blocking",
-        "settingsContentBlockingToggle": "Block trackers and ads",
+        "settingsContentBlockingLevel0": "Allow all ads and trackers",
+        "settingsContentBlockingLevel1": "Block third-party ads and trackers",
+        "settingsContentBlockingLevel2": "Block all ads and trackers",
+        "settingsContentBlockingExceptions": "Ads will still be allowed on these websites:",
         "settingsBlockScriptsToggle": "Block scripts",
         "settingsBlockImagesToggle": "Block images",
         "settingsEasyListCredit": {

--- a/localization/languages/es.json
+++ b/localization/languages/es.json
@@ -104,7 +104,10 @@
         "settingsPreferencesHeading": "Preferencias",
         "settingsRestartRequired": "Debe reiniciar para aplicar estos cambios.",
         "settingsPrivacyHeading": "Bloqueo de contenido",
-        "settingsContentBlockingToggle": "Bloquear rastreadores y anuncios",
+        "settingsContentBlockingLevel0": null, //missing translation
+        "settingsContentBlockingLevel1": null, //missing translation
+        "settingsContentBlockingLevel2": null, //missing translation
+        "settingsContentBlockingExceptions": null, //missing translation
         "settingsBlockScriptsToggle": "Bloquear scripts",
         "settingsBlockImagesToggle": "Bloquear imágenes",
         "settingsEasyListCredit": {

--- a/localization/languages/es.json
+++ b/localization/languages/es.json
@@ -111,7 +111,7 @@
         "settingsBlockScriptsToggle": "Bloquear scripts",
         "settingsBlockImagesToggle": "Bloquear imágenes",
         "settingsEasyListCredit": {
-            "unsafeHTML": "Basado en EasyList y EasyPrivacy, sin reglas de ocultación de elementos. Creado por <a target=\"_blank\" href=\"https://easylist.to/\">The EasyList authors</a> - <a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/3.0/legalcode\">ver licencia</a>."
+            "unsafeHTML": null //missing translation
         },
         "settingsAppearanceHeading": "Apariencia",
         "settingsDarkModeToggle": "Habilitar modo oscuro",

--- a/localization/languages/fa.json
+++ b/localization/languages/fa.json
@@ -104,7 +104,10 @@
         "settingsPreferencesHeading": "تنظیمات",
         "settingsRestartRequired": "جهت اعمال تغییرات شما می بایست مرورگر را دوباره باز کنید.",
         "settingsPrivacyHeading": "مسدود سازی",
-        "settingsContentBlockingToggle": "مسدود کردن تبلیغات و دنبال کنندگان",
+        "settingsContentBlockingLevel0": null, //missing translation
+        "settingsContentBlockingLevel1": null, //missing translation
+        "settingsContentBlockingLevel2": null, //missing translation
+        "settingsContentBlockingExceptions": null, //missing translation
         "settingsBlockScriptsToggle": "مسدود کردن اسکریپت ها",
         "settingsBlockImagesToggle": "مسدود کردن تصاویر",
         "settingsEasyListCredit": {

--- a/localization/languages/fa.json
+++ b/localization/languages/fa.json
@@ -111,7 +111,7 @@
         "settingsBlockScriptsToggle": "مسدود کردن اسکریپت ها",
         "settingsBlockImagesToggle": "مسدود کردن تصاویر",
         "settingsEasyListCredit": {
-            "unsafeHTML": "بر مبنای EasyList و EasyPrivacy بدون قوانین مخفی سازی. ساخته شده توسط <a target=\"_blank\" href=\"https://easylist.to/\">توسعه دهندگان EasyList</a> - <a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/3.0/legalcode\">نمایش گواهینامه</a>."
+            "unsafeHTML": null //missing translation
         },
         "settingsAppearanceHeading": "ظاهر",
         "settingsDarkModeToggle": "فعال کردن حالت تاریک",

--- a/localization/languages/fr-FR.json
+++ b/localization/languages/fr-FR.json
@@ -111,7 +111,7 @@
         "settingsBlockScriptsToggle": "Scripts bloqués",
         "settingsBlockImagesToggle": "Images bloquées",
         "settingsEasyListCredit": {
-            "unsafeHTML": "Basé sur EasyList et EasyPrivacy, sans élément caché. Créé par <a target=\"_blank\" href=\"https://easylist.to/\">Les auteurs de EasyList</a> - <a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/3.0/legalcode\">voir la licence</a>."
+            "unsafeHTML": null //missing translation
         },
         "settingsAppearanceHeading": "Apparence",
         "settingsDarkModeToggle": "Activer le mode nuit",

--- a/localization/languages/fr-FR.json
+++ b/localization/languages/fr-FR.json
@@ -104,7 +104,10 @@
         "settingsPreferencesHeading": "Préférences",
         "settingsRestartRequired": "Vous devez redémarrer pour appliquer les changements.",
         "settingsPrivacyHeading": "Contenu bloqué",
-        "settingsContentBlockingToggle": "Traceurs et publicités",
+        "settingsContentBlockingLevel0": null, //missing translation
+        "settingsContentBlockingLevel1": null, //missing translation
+        "settingsContentBlockingLevel2": null, //missing translation
+        "settingsContentBlockingExceptions": null, //missing translation
         "settingsBlockScriptsToggle": "Scripts bloqués",
         "settingsBlockImagesToggle": "Images bloquées",
         "settingsEasyListCredit": {

--- a/localization/languages/hu.json
+++ b/localization/languages/hu.json
@@ -111,7 +111,7 @@
         "settingsBlockScriptsToggle": "Szkriptek Tiltása",
         "settingsBlockImagesToggle": "Képek Tiltása",
         "settingsEasyListCredit": {
-            "unsafeHTML": "Az EasyList és EasyPrivacy, Elemek rejtése nélkul. Készitette <a target=\"_blank\" href=\"https://easylist.to/\">The EasyList authors</a> - <a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/3.0/legalcode\">view license</a>."
+            "unsafeHTML": null //missing translation
         },
         "settingsAppearanceHeading": "Megjelenés",
         "settingsDarkModeToggle": "Kapcsolja be a sotét nézetett",

--- a/localization/languages/hu.json
+++ b/localization/languages/hu.json
@@ -104,7 +104,10 @@
         "settingsPreferencesHeading": "Beálitások",
         "settingsRestartRequired": "Újra kell inditani hogy a változások életbe lépjenek.",
         "settingsPrivacyHeading": "Tartalom Tiltás",
-        "settingsContentBlockingToggle": "Tiltsa le a Reklámokat, és a követést",
+        "settingsContentBlockingLevel0": null, //missing translation
+        "settingsContentBlockingLevel1": null, //missing translation
+        "settingsContentBlockingLevel2": null, //missing translation
+        "settingsContentBlockingExceptions": null, //missing translation
         "settingsBlockScriptsToggle": "Szkriptek Tiltása",
         "settingsBlockImagesToggle": "Képek Tiltása",
         "settingsEasyListCredit": {

--- a/localization/languages/it.json
+++ b/localization/languages/it.json
@@ -104,7 +104,10 @@
         "settingsPreferencesHeading": "Impostazioni",
         "settingsRestartRequired": "Devi riavviare Min per applicare queste modifiche.",
         "settingsPrivacyHeading": "Blocco contenuti",
-        "settingsContentBlockingToggle": "Blocca tracker e pubblicità",
+        "settingsContentBlockingLevel0": null, //missing translation
+        "settingsContentBlockingLevel1": null, //missing translation
+        "settingsContentBlockingLevel2": null, //missing translation
+        "settingsContentBlockingExceptions": null, //missing translation
         "settingsBlockScriptsToggle": "Blocca script",
         "settingsBlockImagesToggle": "Blocca immagini",
         "settingsEasyListCredit": {

--- a/localization/languages/it.json
+++ b/localization/languages/it.json
@@ -111,7 +111,7 @@
         "settingsBlockScriptsToggle": "Blocca script",
         "settingsBlockImagesToggle": "Blocca immagini",
         "settingsEasyListCredit": {
-            "unsafeHTML": "Utilizza EasyList ed EasyPrivacy, senza regole che nascondono elementi. Creato da <a target=\"_blank\" href=\"https://easylist.to/\">gli autori di EasyList</a> - <a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/3.0/legalcode\">vedi licenza</a>."
+            "unsafeHTML": null //missing translation
         },
         "settingsAppearanceHeading": "Aspetto",
         "settingsDarkModeToggle": "Abilita dark mode",

--- a/localization/languages/ja.json
+++ b/localization/languages/ja.json
@@ -111,7 +111,7 @@
         "settingsBlockScriptsToggle": "スクリプトをブロック",
         "settingsBlockImagesToggle": "画像をブロック",
         "settingsEasyListCredit": {
-            "unsafeHTML": "フィルターはEasyListとEasyPrivacyから要素隠蔽ルールを省いたものに基づいています。<a target=\"_blank\" href=\"https://easylist.to/\">EasyListの作者</a> - <a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/3.0/legalcode\">ライセンスを表示</a>"
+            "unsafeHTML": null //missing translation
         },
         "settingsAppearanceHeading": "外観",
         "settingsDarkModeToggle": "ダークモードを使用",

--- a/localization/languages/ja.json
+++ b/localization/languages/ja.json
@@ -104,7 +104,10 @@
         "settingsPreferencesHeading": "環境設定",
         "settingsRestartRequired": "これらの変更を適用するには再起動が必要です。",
         "settingsPrivacyHeading": "コンテンツブロッカー",
-        "settingsContentBlockingToggle": "トラッカーと広告をブロックする",
+        "settingsContentBlockingLevel0": null, //missing translation
+        "settingsContentBlockingLevel1": null, //missing translation
+        "settingsContentBlockingLevel2": null, //missing translation
+        "settingsContentBlockingExceptions": null, //missing translation
         "settingsBlockScriptsToggle": "スクリプトをブロック",
         "settingsBlockImagesToggle": "画像をブロック",
         "settingsEasyListCredit": {

--- a/localization/languages/ko.json
+++ b/localization/languages/ko.json
@@ -111,7 +111,7 @@
         "settingsBlockScriptsToggle": "스크립트 차단",
         "settingsBlockImagesToggle": "이미지 차단",
         "settingsEasyListCredit": {
-            "unsafeHTML": "요소 숨기 규칙없이 EasyList 및 EasyPrivacy를 기반으로합니다. 작성자: <a target=\"_blank\" href=\"https://easylist.to/\">The EasyList authors</a> - <a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/3.0/legalcode\">라이선스</a>"
+            "unsafeHTML": null //missing translation
         },
         "settingsAppearanceHeading": "외모",
         "settingsDarkModeToggle": "어두운 모드 사용",

--- a/localization/languages/ko.json
+++ b/localization/languages/ko.json
@@ -104,7 +104,10 @@
         "settingsPreferencesHeading": "환경설정",
         "settingsRestartRequired": "변경 사항을 적용하려면 다시 시작해야합니다.",
         "settingsPrivacyHeading": "콘텐츠 차단",
-        "settingsContentBlockingToggle": "추적기 및 광고 차단",
+        "settingsContentBlockingLevel0": null, //missing translation
+        "settingsContentBlockingLevel1": null, //missing translation
+        "settingsContentBlockingLevel2": null, //missing translation
+        "settingsContentBlockingExceptions": null, //missing translation
         "settingsBlockScriptsToggle": "스크립트 차단",
         "settingsBlockImagesToggle": "이미지 차단",
         "settingsEasyListCredit": {

--- a/localization/languages/lt.json
+++ b/localization/languages/lt.json
@@ -111,7 +111,7 @@
         "settingsBlockScriptsToggle": "Blokuoti scenarijus",
         "settingsBlockImagesToggle": "Blokuoti paveikslus",
         "settingsEasyListCredit": {
-            "unsafeHTML": "Remiantis EasyList ir EasyPrivacy, be elementų slėpimo taisyklių. Sukurta <a target=\"_blank\" href=\"https://easylist.to/\">The EasyList autorių</a> - <a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/3.0/legalcode\">rodyti licenciją</a>."
+            "unsafeHTML": null //missing translation
         },
         "settingsAppearanceHeading": "Išvaizda",
         "settingsDarkModeToggle": "Įjungti tamsią veikseną",

--- a/localization/languages/lt.json
+++ b/localization/languages/lt.json
@@ -104,7 +104,10 @@
         "settingsPreferencesHeading": "Nuostatos",
         "settingsRestartRequired": "Norėdami taikyti šiuos pakeitimus, turite paleisti programą iš naujo.",
         "settingsPrivacyHeading": "Turinio blokavimas",
-        "settingsContentBlockingToggle": "Blokuoti seklius ir reklamas",
+        "settingsContentBlockingLevel0": null, //missing translation
+        "settingsContentBlockingLevel1": null, //missing translation
+        "settingsContentBlockingLevel2": null, //missing translation
+        "settingsContentBlockingExceptions": null, //missing translation
         "settingsBlockScriptsToggle": "Blokuoti scenarijus",
         "settingsBlockImagesToggle": "Blokuoti paveikslus",
         "settingsEasyListCredit": {

--- a/localization/languages/pl.json
+++ b/localization/languages/pl.json
@@ -104,7 +104,10 @@
         "settingsPreferencesHeading": "Preferencje",
         "settingsRestartRequired": "Musisz ponownie uruchomić, aby zastosować te zmiany.",
         "settingsPrivacyHeading": "Blokowanie treści",
-        "settingsContentBlockingToggle": "Zablokuj śledzenie i reklamy",
+        "settingsContentBlockingLevel0": null, //missing translation
+        "settingsContentBlockingLevel1": null, //missing translation
+        "settingsContentBlockingLevel2": null, //missing translation
+        "settingsContentBlockingExceptions": null, //missing translation
         "settingsBlockScriptsToggle": "Zablokuj skrypty",
         "settingsBlockImagesToggle": "Zablokuj obrazy",
         "settingsEasyListCredit": {

--- a/localization/languages/pl.json
+++ b/localization/languages/pl.json
@@ -111,7 +111,7 @@
         "settingsBlockScriptsToggle": "Zablokuj skrypty",
         "settingsBlockImagesToggle": "Zablokuj obrazy",
         "settingsEasyListCredit": {
-            "unsafeHTML": "Oparty na EasyList i EasyPrivacy, bez ukrywania elementów. Stworzone przez <a target=\"_blank\" href=\"https://easylist.to/\">Autorzy EasyList</a> - <a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/3.0/legalcode\">zobacz licencję</a>."
+            "unsafeHTML": null //missing translation
         },
         "settingsAppearanceHeading": "Wygląd",
         "settingsDarkModeToggle": "Włącz tryb ciemny",

--- a/localization/languages/pt-BR.json
+++ b/localization/languages/pt-BR.json
@@ -111,7 +111,7 @@
         "settingsBlockScriptsToggle": "Bloquear scripts",
         "settingsBlockImagesToggle": "Bloquear imagens",
         "settingsEasyListCredit": {
-            "unsafeHTML": "Baseado em EasyList e EasyPrivacy, sem regras para ocultar elementos. Criado pelos <a target=\"_blank\" href=\"https://easylist.to/\">autores EasyList</a> - <a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/3.0/legalcode\">ver licença</a>."
+            "unsafeHTML": null //missing translation
         },
         "settingsAppearanceHeading": "Aparência",
         "settingsDarkModeToggle": "Habilitar modo noturno",

--- a/localization/languages/pt-BR.json
+++ b/localization/languages/pt-BR.json
@@ -104,7 +104,10 @@
         "settingsPreferencesHeading": "Preferências",
         "settingsRestartRequired": "Você precisa reiniciar o navegador para aplicar estas mudanças.",
         "settingsPrivacyHeading": "Bloqueio de Conteúdo",
-        "settingsContentBlockingToggle": "Bloquear rastreadores e propagandas",
+        "settingsContentBlockingLevel0": null, //missing translation
+        "settingsContentBlockingLevel1": null, //missing translation
+        "settingsContentBlockingLevel2": null, //missing translation
+        "settingsContentBlockingExceptions": null, //missing translation
         "settingsBlockScriptsToggle": "Bloquear scripts",
         "settingsBlockImagesToggle": "Bloquear imagens",
         "settingsEasyListCredit": {

--- a/localization/languages/pt-PT.json
+++ b/localization/languages/pt-PT.json
@@ -111,7 +111,7 @@
         "settingsBlockScriptsToggle": "Bloquear scripts",
         "settingsBlockImagesToggle": "Bloquear imagens",
         "settingsEasyListCredit": {
-            "unsafeHTML": "Baseado em EasyList e EasyPrivacy, sem regras de ocultação de elementos. Criado por <a target=\"_blank\" href=\"https://easylist.to/\">The EasyList authors</a> - <a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/3.0/legalcode\">ver licença</a>."
+            "unsafeHTML": null //missing translation
         },
         "settingsAppearanceHeading": "Aparência",
         "settingsDarkModeToggle": "Ativar modo escuro",

--- a/localization/languages/pt-PT.json
+++ b/localization/languages/pt-PT.json
@@ -104,7 +104,10 @@
         "settingsPreferencesHeading": "Preferências",
         "settingsRestartRequired": "Tem que reiniciar o navegador para aplicar as alterações.",
         "settingsPrivacyHeading": "Bloqueio de conteúdo",
-        "settingsContentBlockingToggle": "Bloquear rastreadores e anúncios",
+        "settingsContentBlockingLevel0": null, //missing translation
+        "settingsContentBlockingLevel1": null, //missing translation
+        "settingsContentBlockingLevel2": null, //missing translation
+        "settingsContentBlockingExceptions": null, //missing translation
         "settingsBlockScriptsToggle": "Bloquear scripts",
         "settingsBlockImagesToggle": "Bloquear imagens",
         "settingsEasyListCredit": {

--- a/localization/languages/ru.json
+++ b/localization/languages/ru.json
@@ -104,7 +104,10 @@
         "settingsPreferencesHeading": "Настройки",
         "settingsRestartRequired": "Для применения этих изменений необходимо перезапустить браузер.",
         "settingsPrivacyHeading": "Блокирование содержимого",
-        "settingsContentBlockingToggle": "Блокировать программы слежения и рекламу",
+        "settingsContentBlockingLevel0": null, //missing translation
+        "settingsContentBlockingLevel1": null, //missing translation
+        "settingsContentBlockingLevel2": null, //missing translation
+        "settingsContentBlockingExceptions": null, //missing translation
         "settingsBlockScriptsToggle": "Блокировать скрипты",
         "settingsBlockImagesToggle": "Блокировать изображения",
         "settingsEasyListCredit": {

--- a/localization/languages/ru.json
+++ b/localization/languages/ru.json
@@ -111,7 +111,7 @@
         "settingsBlockScriptsToggle": "Блокировать скрипты",
         "settingsBlockImagesToggle": "Блокировать изображения",
         "settingsEasyListCredit": {
-            "unsafeHTML": "Основано на списках \"EasyList\" и \"EasyPrivacy\" (без правил для скрытия элементов). Создано <a target=\"_blank\" href=\"https://easylist.to/\">авторами \"EasyList\"</a> - <a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/3.0/legalcode\">посмотреть лицензионное соглашение</a>."
+            "unsafeHTML": null //missing translation
         },
         "settingsAppearanceHeading": "Внешний вид",
         "settingsDarkModeToggle": "Использовать тёмную тему",

--- a/localization/languages/tr_TR.json
+++ b/localization/languages/tr_TR.json
@@ -111,7 +111,7 @@
         "settingsBlockScriptsToggle": "Scriptleri engelle",
         "settingsBlockImagesToggle": "Resimleri engelle",
         "settingsEasyListCredit": {
-            "unsafeHTML": "Unsuru gizleme kuralları olmadan, EasyList ve EasyPrivacy'e dayanarak. Created by <a target=\"_blank\" href=\"https://easylist.to/\">The EasyList authors</a> - <a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/3.0/legalcode\">view license</a>."
+            "unsafeHTML": null //missing translation
         },
         "settingsAppearanceHeading": "Görünüm",
         "settingsDarkModeToggle": "Koyu modu etkinleştir",

--- a/localization/languages/tr_TR.json
+++ b/localization/languages/tr_TR.json
@@ -104,7 +104,10 @@
         "settingsPreferencesHeading": "Tercihler",
         "settingsRestartRequired": "Bu değişiklikleri uygulamak için yeniden başlatmanız gerekiyor.",
         "settingsPrivacyHeading": "İçerik Engelleme",
-        "settingsContentBlockingToggle": "İzleyicileri ve reklamları engelle",
+        "settingsContentBlockingLevel0": null, //missing translation
+        "settingsContentBlockingLevel1": null, //missing translation
+        "settingsContentBlockingLevel2": null, //missing translation
+        "settingsContentBlockingExceptions": null, //missing translation
         "settingsBlockScriptsToggle": "Scriptleri engelle",
         "settingsBlockImagesToggle": "Resimleri engelle",
         "settingsEasyListCredit": {

--- a/localization/languages/zh-CN.json
+++ b/localization/languages/zh-CN.json
@@ -111,7 +111,7 @@
         "settingsBlockScriptsToggle": "阻止脚本运行",
         "settingsBlockImagesToggle": "阻止加载图片",
         "settingsEasyListCredit": {
-            "unsafeHTML": "基于 EasyList 和 EasyPrivacy. <a target=\"_blank\" href=\"https://easylist.to/\">The EasyList authors</a> - <a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/3.0/legalcode\">view license</a>."
+            "unsafeHTML": null //missing translation
         },
         "settingsAppearanceHeading": "外观",
         "settingsDarkModeToggle": "启用夜间模式",

--- a/localization/languages/zh-CN.json
+++ b/localization/languages/zh-CN.json
@@ -104,7 +104,10 @@
         "settingsPreferencesHeading": "设置",
         "settingsRestartRequired": "您需要重启以应用这些修改",
         "settingsPrivacyHeading": "隐私设置",
-        "settingsContentBlockingToggle": "禁用跟踪和广告",
+        "settingsContentBlockingLevel0": null, //missing translation
+        "settingsContentBlockingLevel1": null, //missing translation
+        "settingsContentBlockingLevel2": null, //missing translation
+        "settingsContentBlockingExceptions": null, //missing translation
         "settingsBlockScriptsToggle": "阻止脚本运行",
         "settingsBlockImagesToggle": "阻止加载图片",
         "settingsEasyListCredit": {

--- a/localization/languages/zh-TW.json
+++ b/localization/languages/zh-TW.json
@@ -104,7 +104,10 @@
         "settingsPreferencesHeading": "設定",
         "settingsRestartRequired": "重新啟動以套用變更",
         "settingsPrivacyHeading": "隱私設定",
-        "settingsContentBlockingToggle": "封鎖跟蹤與廣告",
+        "settingsContentBlockingLevel0": null, //missing translation
+        "settingsContentBlockingLevel1": null, //missing translation
+        "settingsContentBlockingLevel2": null, //missing translation
+        "settingsContentBlockingExceptions": null, //missing translation
         "settingsBlockScriptsToggle": "封鎖 javascript 腳本運行",
         "settingsBlockImagesToggle": "封鎖圖片",
         "settingsEasyListCredit": {

--- a/localization/languages/zh-TW.json
+++ b/localization/languages/zh-TW.json
@@ -111,7 +111,7 @@
         "settingsBlockScriptsToggle": "封鎖 javascript 腳本運行",
         "settingsBlockImagesToggle": "封鎖圖片",
         "settingsEasyListCredit": {
-            "unsafeHTML": "基於 EasyList 和 EasyPrivacy. <a target=\"_blank\" href=\"https://easylist.to/\">The EasyList authors</a> - <a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/3.0/legalcode\">view license</a>."
+            "unsafeHTML": null //missing translation
         },
         "settingsAppearanceHeading": "外觀",
         "settingsDarkModeToggle": "啟用夜間模式",

--- a/localization/localizationHelpers.js
+++ b/localization/localizationHelpers.js
@@ -35,7 +35,7 @@ function l (stringId) {
   // get the translated string for the given ID
 
   // try to use the string for the user's language
-  if (languages[userLanguage] && languages[userLanguage].translations[stringId]) {
+  if (languages[userLanguage] && languages[userLanguage].translations[stringId] && languages[userLanguage].translations[stringId].unsafeHTML !== null) {
     return languages[userLanguage].translations[stringId]
   } else {
     // fallback to en-US

--- a/main/filtering.js
+++ b/main/filtering.js
@@ -21,6 +21,12 @@ function initFilterList () {
 
 function requestIsThirdParty (baseDomain, requestURL) {
   var requestDomain = parser.getUrlHost(requestURL)
+  if (baseDomain.startsWith('www.')) {
+    baseDomain = baseDomain.replace('www.', '')
+  }
+  if (requestDomain.startsWith('www.')) {
+    requestDomain = requestDomain.replace('www.', '')
+  }
   return !(parser.isSameOriginHost(baseDomain, requestDomain) || parser.isSameOriginHost(requestDomain, baseDomain))
 }
 

--- a/main/filtering.js
+++ b/main/filtering.js
@@ -1,9 +1,8 @@
 var thingsToFilter = {
-  trackers: false,
-  contentTypes: [] // script, image
+  blockingLevel: 0,
+  contentTypes: [], // script, image
+  exceptionDomains: []
 }
-
-var filterContentTypes = thingsToFilter.contentTypes.length !== 0
 
 var parser = require('./ext/abp-filter-parser-modified/abp-filter-parser.js')
 var parsedFilterData = {}
@@ -20,6 +19,18 @@ function initFilterList () {
   })
 }
 
+function requestIsThirdParty (baseDomain, requestURL) {
+  var requestDomain = parser.getUrlHost(requestURL)
+  return !(parser.isSameOriginHost(baseDomain, requestDomain) || parser.isSameOriginHost(requestDomain, baseDomain))
+}
+
+function requestDomainIsException (domain) {
+  if (domain.startsWith('www.')) {
+    domain = domain.replace('www.', '')
+  }
+  return thingsToFilter.exceptionDomains.includes(domain)
+}
+
 function handleRequest (details, callback) {
   if (!(details.url.startsWith('http://') || details.url.startsWith('https://')) || details.resourceType === 'mainFrame') {
     callback({
@@ -31,7 +42,7 @@ function handleRequest (details, callback) {
 
   // block javascript and images if needed
 
-  if (filterContentTypes) {
+  if (thingsToFilter.contentTypes.length > 0) {
     for (var i = 0; i < thingsToFilter.contentTypes.length; i++) {
       if (details.resourceType === thingsToFilter.contentTypes[i]) {
         callback({
@@ -46,19 +57,27 @@ function handleRequest (details, callback) {
   if (details.webContentsId) {
     var domain = parser.getUrlHost(webContents.fromId(details.webContentsId).getURL())
   } else {
+    // webContentsId may not exist if this request is for the main document of a subframe
     var domain = undefined
   }
 
-  if (thingsToFilter.trackers) {
-    if (parser.matches(parsedFilterData, details.url, {
+  if (thingsToFilter.blockingLevel > 0 && !(domain && requestDomainIsException(domain))) {
+    if (
+      (thingsToFilter.blockingLevel === 1 && (!domain || requestIsThirdParty(domain, details.url)))
+      || (thingsToFilter.blockingLevel === 2)
+    ) {
+      // by doing this check second, we can skip checking same-origin requests if only third-party blocking is enabled
+      var matchesFilters = parser.matches(parsedFilterData, details.url, {
         domain: domain,
         elementType: details.resourceType
-      })) {
-      callback({
-        cancel: true,
-        requestHeaders: details.requestHeaders
       })
-      return
+      if (matchesFilters) {
+        callback({
+          cancel: true,
+          requestHeaders: details.requestHeaders
+        })
+        return
+      }
     }
   }
 
@@ -73,14 +92,13 @@ function setFilteringSettings (settings) {
     settings = {}
   }
 
-  if (settings.trackers && !thingsToFilter.trackers) { // we're enabling tracker filtering
+  if (settings.blockingLevel > 0 && !(thingsToFilter.blockingLevel > 0)) { // we're enabling tracker filtering
     initFilterList()
   }
 
   thingsToFilter.contentTypes = settings.contentTypes || []
-  thingsToFilter.trackers = settings.trackers || false
-
-  filterContentTypes = thingsToFilter.contentTypes.length !== 0
+  thingsToFilter.blockingLevel = settings.blockingLevel || 0
+  thingsToFilter.exceptionDomains = settings.exceptions || []
 }
 
 function registerFiltering (ses) {

--- a/pages/settings/index.html
+++ b/pages/settings/index.html
@@ -21,11 +21,26 @@
 	<div class="spacer"></div>
 	<div class="container padding" id="privacy-settings-container">
 		<h3 data-string="settingsPrivacyHeading"></h3>
+		<div class="light-fade" data-string="settingsEasyListCredit" data-allowHTML></div>
 
-		<div class="setting-section">
-			<input type="checkbox" id="checkbox-block-trackers" />
-			<label for="checkbox-block-trackers" data-string="settingsContentBlockingToggle"></label>
-			<div class="light-fade setting-secondary-label" data-string="settingsEasyListCredit" data-allowHTML></div>
+		<div class="spacer"></div>
+
+		<div class="setting-section" id="tracking-level-container">
+			<input type="radio" name="blockingLevel" id="blocking-allow-all" />
+			<label for="blocking-allow-all" data-string="settingsContentBlockingLevel0"></label>
+			<div class="spacer-small"></div>
+			<input type="radio" name="blockingLevel" id="blocking-third-party" />
+			<label for="blocking-third-party" data-string="settingsContentBlockingLevel1"></label>
+			<div class="spacer-small"></div>
+			<input type="radio" name="blockingLevel" id="blocking-block-all" />
+			<label for="blocking-block-all" data-string="settingsContentBlockingLevel2"></label>
+			<div class="spacer-small"></div>
+
+			<div id="content-blocking-information" hidden>
+				<div><span data-string="settingsContentBlockingExceptions"></span> &nbsp;
+					<input type="text" id="content-blocking-exceptions" style="width: 100%; max-width: 500px">
+				</div>
+			</div>
 		</div>
 	</div>
 

--- a/pages/settings/settings.css
+++ b/pages/settings/settings.css
@@ -90,6 +90,9 @@ h1 + h2 {
 	left: 50%;
 	transform: translateX(-50%) translateY(-50%);
 }
+.spacer-small {
+	height: 0.5em;
+}
 .spacer {
 	height: 1em;
 }
@@ -150,10 +153,10 @@ button.disabled {
 	vertical-align: middle;
 }
 .setting-section input + label {
-	padding-left: 4px;
+	padding-left: 0.33em;
 }
 .setting-secondary-label {
-	padding-left: 1.1em;
+	padding-left: 1.18em;
 	padding-top: 0.2em;
 }
 .banner {
@@ -179,6 +182,15 @@ button.disabled {
 	padding: 0.2em;
 }
 
+#content-blocking-information {
+	padding: 0.5em;
+    margin: 0.75em 0.5em 0.25em 1.08em;
+    background-color: #f8f8f8;
+    border-radius: 3px;
+}
+.dark-mode #content-blocking-information {
+	background-color: #141414;
+}
 
 .dark-mode {
   background-color: rgb(33, 37, 43);

--- a/pages/settings/settings.js
+++ b/pages/settings/settings.js
@@ -56,7 +56,7 @@ settings.get('filtering', function (value) {
 
   updateBlockingLevelUI((value && value.blockingLevel) || 0)
 
-  if (value && value.exceptions) {
+  if (value && value.exceptions && value.exceptions.length > 0) {
     blockingExceptionsInput.value = value.exceptions.join(', ') + ', '
   }
 })

--- a/pages/settings/settings.js
+++ b/pages/settings/settings.js
@@ -1,7 +1,6 @@
 document.title = l('settingsPreferencesHeading') + ' | Min'
 
 var container = document.getElementById('privacy-settings-container')
-var trackerCheckbox = document.getElementById('checkbox-block-trackers')
 var banner = document.getElementById('restart-required-banner')
 var darkModeCheckbox = document.getElementById('checkbox-dark-mode')
 var historyButtonCheckbox = document.getElementById('checkbox-history-button')
@@ -12,22 +11,72 @@ function showRestartRequiredBanner () {
   banner.hidden = false
 }
 
-/* tracking checkbox */
+/* content blocking settings */
 
-settings.get('filtering', function (value) {
-  if (value) {
-    trackerCheckbox.checked = value.trackers
+var trackingLevelContainer = document.getElementById('tracking-level-container')
+var trackingLevelOptions = Array.from(document.querySelectorAll('input[name=blockingLevel]'))
+var blockingExceptionsContainer = document.getElementById('content-blocking-information')
+var blockingExceptionsInput = document.getElementById('content-blocking-exceptions')
+
+function updateBlockingLevelUI (level) {
+  trackingLevelOptions[level].checked = true
+
+  if (level === 0) {
+    blockingExceptionsContainer.hidden = true
+  } else {
+    blockingExceptionsContainer.hidden = false
+    var insertionPoint = Array.from(trackingLevelContainer.children).indexOf(trackingLevelOptions[level]) + 2
+    trackingLevelContainer.insertBefore(blockingExceptionsContainer, trackingLevelContainer.children[insertionPoint])
   }
-})
+}
 
-trackerCheckbox.addEventListener('change', function (e) {
+function changeBlockingLevelSetting (level) {
   settings.get('filtering', function (value) {
     if (!value) {
       value = {}
     }
-    value.trackers = e.target.checked
+    value.blockingLevel = level
     settings.set('filtering', value)
-    banner.hidden = false
+    updateBlockingLevelUI(level)
+    showRestartRequiredBanner()
+  })
+}
+
+settings.get('filtering', function (value) {
+  // migrate from old settings (<v1.9.0)
+  if (value && typeof value.trackers === 'boolean') {
+    if (value.trackers === true) {
+      value.blockingLevel = 2
+    } else if (value.trackers === false) {
+      value.blockingLevel = 0
+    }
+    delete value.trackers
+    settings.set('filtering', value)
+  }
+
+  updateBlockingLevelUI((value && value.blockingLevel) || 0)
+
+  if (value && value.exceptions) {
+    blockingExceptionsInput.value = value.exceptions.join(', ')
+  }
+})
+
+trackingLevelOptions.forEach(function (item, idx) {
+  item.addEventListener('change', function () {
+    changeBlockingLevelSetting(idx)
+  })
+})
+
+blockingExceptionsInput.addEventListener('change', function () {
+  var newValue = this.value.split(',').map(i => i.trim())
+
+  settings.get('filtering', function (value) {
+    if (!value) {
+      value = {}
+    }
+    value.exceptions = newValue
+    settings.set('filtering', value)
+    showRestartRequiredBanner()
   })
 })
 

--- a/pages/settings/settings.js
+++ b/pages/settings/settings.js
@@ -57,7 +57,7 @@ settings.get('filtering', function (value) {
   updateBlockingLevelUI((value && value.blockingLevel) || 0)
 
   if (value && value.exceptions) {
-    blockingExceptionsInput.value = value.exceptions.join(', ')
+    blockingExceptionsInput.value = value.exceptions.join(', ') + ', '
   }
 })
 
@@ -68,7 +68,7 @@ trackingLevelOptions.forEach(function (item, idx) {
 })
 
 blockingExceptionsInput.addEventListener('change', function () {
-  var newValue = this.value.split(',').map(i => i.trim())
+  var newValue = this.value.split(',').map(i => i.trim()).filter(i => !!i)
 
   settings.get('filtering', function (value) {
     if (!value) {


### PR DESCRIPTION
This addresses most of #639:

* It adds a third content-blocking level (block only third-party ad and tracking requests), which will become the default in 1.9.
* It adds an option to disable content-blocking for a specific site.

Screenshot:
<img width="1120" alt="contentblockingui" src="https://user-images.githubusercontent.com/10314059/50715895-caef1f00-1044-11e9-8d77-2f6f979ea9f5.png">

I think it looks a little cluttered - maybe separating the script and image options more clearly would help - but it should be OK for now.

Once this is merged, I'll change the default setting to third-party blocking in a separate PR.