### PR TITLE
Show a notification in the searchbar when a new version of Min is available

### DIFF
--- a/js/searchbar/searchbarPlugins.js
+++ b/js/searchbar/searchbarPlugins.js
@@ -58,17 +58,21 @@ function run (text, input, event) {
   resultCounts = {}
 
   for (var i = 0; i < searchbarPlugins.length; i++) {
-    if ( (!searchbarPlugins[i].trigger || searchbarPlugins[i].trigger(text))) {
-      searchbarPlugins[i].showResults(text, input, event, searchbarPlugins[i].container)
-    } else {
-      empty(searchbarPlugins[i].container)
+    try {
+      if ( (!searchbarPlugins[i].trigger || searchbarPlugins[i].trigger(text))) {
+        searchbarPlugins[i].showResults(text, input, event, searchbarPlugins[i].container)
+      } else {
+        empty(searchbarPlugins[i].container)
 
-      // if the plugin is not triggered, remove a previously created top answer
-      var associatedTopAnswer = getTopAnswer(searchbarPlugins[i].name)
+        // if the plugin is not triggered, remove a previously created top answer
+        var associatedTopAnswer = getTopAnswer(searchbarPlugins[i].name)
 
-      if (associatedTopAnswer) {
-        associatedTopAnswer.remove()
+        if (associatedTopAnswer) {
+          associatedTopAnswer.remove()
+        }
       }
+    } catch(e) {
+      console.error('error in searchbar plugin "' + searchbarPlugins[i].name + '":', e)
     }
   }
 }

--- a/js/searchbar/updateNotifications.js
+++ b/js/searchbar/updateNotifications.js
@@ -1,0 +1,115 @@
+const UPDATE_URL = 'https://minbrowser.github.io/min/updates/latestVersion.json'
+
+var settings = require('util/settings.js')
+var searchbarPlugins = require('searchbar/searchbarPlugins.js')
+var searchbarUtils = require('searchbar/searchbarUtils.js')
+
+function compareVersions (v1, v2) {
+  /*
+  1: v2 is newer than v1
+  -1: v1 is newer than v2
+  0: the two versions are equal
+  */
+  v1 = v1.split('.').map(i => parseInt(i))
+  v2 = v2.split('.').map(i => parseInt(i))
+
+  if (v1.length !== v2.length) {
+    throw new Error()
+  }
+
+  for (var i = 0; i < v1.length; i++) {
+    if (v2[i] > v1[i]) {
+      return 1
+    }
+    if (v1[i] > v2[i]) {
+      return -1
+    }
+  }
+
+  return 0
+}
+
+function getUpdateRandomNum () {
+  /* the update JSON might indicate that the update is only available to a % of clients, in order to avoid notifying everyone to update to a new version until there's time to report bugs.
+      Create a random number that is saved locally, and compare this to the indicated % to determine if the update notification should be shown. */
+
+  if (!localStorage.getItem('updateRandomNumber')) {
+    localStorage.setItem('updateRandomNumber', Math.random())
+  }
+  return parseFloat(localStorage.getItem('updateRandomNumber'))
+}
+
+function getAvailableUpdates () {
+  settings.get('updateNotificationsEnabled', function (value) {
+    if (value !== false) {
+      console.info('checking for updates')
+      fetch(UPDATE_URL, {
+        cache: 'no-cache'
+      })
+        .then(res => res.json())
+        .then(function (response) {
+          console.info('got response from update check', response)
+          if (response.version && 
+            compareVersions(remote.app.getVersion(), response.version) > 0 && 
+            (!response.availabilityPercent || getUpdateRandomNum() < response.availabilityPercent)) 
+            {
+            console.info('an update is available')
+            localStorage.setItem('availableUpdate', JSON.stringify(response))
+          } else {
+            console.info('update is not available')
+            /* this can happen if either the update is no longer being offered, or the update has already been installed */
+            localStorage.removeItem('availableUpdate')
+          }
+        })
+        .catch(function (e) {
+          console.info('failed to get update info', e)
+        })
+    } else {
+      console.info('update checking is disabled')
+    }
+  })
+}
+
+function showUpdateNotification (text, input, event, container) {
+  function displayUpdateNotification () {
+    empty(container)
+    container.appendChild(searchbarUtils.createItem({
+      title: l('updateNotificationTitle'),
+      descriptionBlock: update.releaseHeadline || 'View release notes',
+      url: update.releaseNotes,
+      icon: 'fa-bell'
+    }))
+  }
+  // is there an update?
+  var update = JSON.parse(localStorage.getItem('availableUpdate'))
+  if (update) {
+    // was the update already installed?
+    if (compareVersions(remote.app.getVersion(), update.version) <= 0) {
+      return
+    }
+    var updateAge = Date.now() - update.releaseTime
+
+    /* initially, only show an update notification when no tabs are open, in order to minimize disruption */
+    if (updateAge < (3 * 7 * 24 * 60 * 60 * 1000)) {
+      if (tabs.isEmpty()) {
+        displayUpdateNotification()
+      }
+    } else {
+      /* after 3 weeks, start showing a notification on all new tabs */
+      if (!tabs.get(tabs.getSelected()).url) {
+        displayUpdateNotification()
+      }
+    }
+  }
+}
+
+setTimeout(getAvailableUpdates, 30000)
+setInterval(getAvailableUpdates, 24 * 60 * 60 * 1000)
+
+searchbarPlugins.register('updateNotifications', {
+  index: 11,
+  trigger: function (text) {
+    return !text && performance.now() > 5000
+  },
+  showResults: showUpdateNotification
+})

--- a/localization/languages/ar.json
+++ b/localization/languages/ar.json
@@ -120,6 +120,7 @@
         "settingsSwipeNavigationToggle": "تمكين التمرير للتنقل ذهابًا وإيابًا بين الصفحات.",
         "settingsUserscriptsToggle": "تمكين سكريبت المستخدم",
         "settingsUserscriptsExplanation": {"unsafeHTML": "يمكن سكريبت المستخدم من  تغير سلوك المواقع - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">معرفة المزيد</a>."},
+        "settingsUpdateNotificationsToggle": null, //missing translation
         "settingsSearchEngineHeading": "محرك بحث",
         "settingsDefaultSearchEngine": "اختر محرك بحث اساسي",
         "settingsDDGExplanation": "كمحرك بحث اساسي لرؤية النتائج الآنية في مربع البحث DuckDuckGo ",
@@ -176,6 +177,8 @@
         /* Download manager */
         "downloadCancel": "الغاء",
         "downloadStateCompleted": "تم بنجاح",
-        "downloadStateFailed": "فشل"
+        "downloadStateFailed": "فشل",
+        /* Update Notifications */
+        "updateNotificationTitle": null //missing translation
     }
 }

--- a/localization/languages/bn.json
+++ b/localization/languages/bn.json
@@ -120,6 +120,7 @@
       "settingsSwipeNavigationToggle":"পৃষ্ঠার মধ্যে পিছনে এবং পিছনে নেভিগেট করার জন্য সোয়াইপ সক্ষম করুন",
       "settingsUserscriptsToggle":"ব্যবহারকারী স্ক্রিপ্ট সক্রিয় করুন",
       "settingsUserscriptsExplanation": {"unsafeHTML": "ব্যবহারকারীর স্ক্রিপ্ট আপনাকে ওয়েবসাইটের আচরণ পরিবর্তন করার অনুমতি দেয় - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\"> আরও শিখুন </a>"},
+      "settingsUpdateNotificationsToggle": null, //missing translation
       "settingsSearchEngineHeading":"খোঁজ যন্ত্র",
       "settingsDefaultSearchEngine":"একটি ডিফল্ট অনুসন্ধান ইঞ্জিন চয়ন করুন:",
       "settingsDDGExplanation":"Searchbar এ তাত্ক্ষণিক উত্তর দেখতে ডিফল্ট অনুসন্ধান ইঞ্জিন হিসাবে DuckDuckGo সেট করুন।",
@@ -176,6 +177,8 @@
       /* Download manager */
       "downloadCancel": null, //missing translation
       "downloadStateCompleted": null, //missing translation
-      "downloadStateFailed": null //missing translation
+      "downloadStateFailed": null, //missing translation
+      /* Update Notifications */
+      "updateNotificationTitle": null //missing translation
    }
 }

--- a/localization/languages/cs.json
+++ b/localization/languages/cs.json
@@ -117,6 +117,7 @@
         "settingsSwipeNavigationToggle": "Povolit touchpad swipe gesto pro navigaci zpět a vpřed mezi stránkami.",
         "settingsUserscriptsToggle": null, //missing translation
         "settingsUserscriptsExplanation": null, //missing translation
+        "settingsUpdateNotificationsToggle": null, //missing translation
         "settingsSearchEngineHeading": "Vyhledávač",
         "settingsDefaultSearchEngine": "Zvolte si výchozí vyhledávač:",
         "settingsDDGExplanation": "Nastavte DuckDuckGo jako výchozí vyhledávač pro zobrazování okamžitých odpovědí ve vyhledávacím panelu.",
@@ -173,6 +174,8 @@
         /* Download manager */
         "downloadCancel": null, //missing translation
         "downloadStateCompleted": null, //missing translation
-        "downloadStateFailed": null //missing translation
+        "downloadStateFailed": null, //missing translation
+        /* Update Notifications */
+        "updateNotificationTitle": null //missing translation
     }
 }

--- a/localization/languages/de.json
+++ b/localization/languages/de.json
@@ -120,6 +120,7 @@
         "settingsSwipeNavigationToggle": "Wischgesten zur Navigation zwischen Webseiten einschalten.",
         "settingsUserscriptsToggle": null, //missing translation
         "settingsUserscriptsExplanation": null, //missing translation
+        "settingsUpdateNotificationsToggle": null, //missing translation
         "settingsSearchEngineHeading": "Suchmaschine",
         "settingsDefaultSearchEngine": "Suchmaschine auswählen:",
         "settingsDDGExplanation": "DuckDuckGo als Standard-Suchmaschine einstellen, um sofort Vorschläge in der Suchleiste zu erhalten.",
@@ -176,6 +177,8 @@
         /* Download manager */
         "downloadCancel": null, //missing translation
         "downloadStateCompleted": null, //missing translation
-        "downloadStateFailed": null //missing translation
+        "downloadStateFailed": null, //missing translation
+        /* Update Notifications */
+        "updateNotificationTitle": null //missing translation
     }
 }

--- a/localization/languages/en-US.json
+++ b/localization/languages/en-US.json
@@ -120,6 +120,7 @@
         "settingsSwipeNavigationToggle": "Enable swipe for navigating back and forth between pages.",
         "settingsUserscriptsToggle": "Enable user scripts",
         "settingsUserscriptsExplanation": {"unsafeHTML": "User scripts allow you to modify the behavior of websites - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">learn more</a>."},
+        "settingsUpdateNotificationsToggle": "Automatically check for updates",
         "settingsSearchEngineHeading": "Search Engine",
         "settingsDefaultSearchEngine": "Choose a default search engine:",
         "settingsDDGExplanation": "Set DuckDuckGo as the default search engine to see instant answers in the searchbar.",
@@ -176,6 +177,8 @@
         /* Download manager */
         "downloadCancel": "Cancel",
         "downloadStateCompleted": "Completed",
-        "downloadStateFailed": "Failed"
+        "downloadStateFailed": "Failed",
+        /* Update Notifications */
+        "updateNotificationTitle": "A new version of Min is available"
     }
 }

--- a/localization/languages/es.json
+++ b/localization/languages/es.json
@@ -120,6 +120,7 @@
         "settingsSwipeNavigationToggle": "Habilitar gestos para navegar hacia atrás y adelante entre las páginas.",
         "settingsUserscriptsToggle": null, //missing translation
         "settingsUserscriptsExplanation": null, //missing translation
+        "settingsUpdateNotificationsToggle": null, //missing translation
         "settingsSearchEngineHeading": "Motor de búsqueda",
         "settingsDefaultSearchEngine": "Elija un motor de búsqueda predeterminado:",
         "settingsDDGExplanation": "Establezca DuckDuckGo como motor de búsqueda predeterminado para ver respuestas instantáneas en la barra de búsqueda.",
@@ -176,6 +177,8 @@
         /* Download manager */
         "downloadCancel": null, //missing translation
         "downloadStateCompleted": null, //missing translation
-        "downloadStateFailed": null //missing translation
+        "downloadStateFailed": null, //missing translation
+        /* Update Notifications */
+        "updateNotificationTitle": null //missing translation
         }
 }

--- a/localization/languages/fa.json
+++ b/localization/languages/fa.json
@@ -120,6 +120,7 @@
         "settingsSwipeNavigationToggle": "فعال سازی قابلیت کشیدن برای مرور به عقب و جلو بین صفحات.",
         "settingsUserscriptsToggle": "فعال کردن اسکریپت های کاربر",
         "settingsUserscriptsExplanation": {"unsafeHTML": "اسکریپت های کاربر این اجازه را به شما می دهند تا رفتار سایت ها را تغییر دهید - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">اطلاعات بیشتر</a>."},
+        "settingsUpdateNotificationsToggle": null, //missing translation
         "settingsSearchEngineHeading": "موتور جستجو",
         "settingsDefaultSearchEngine": "انتخاب موتور جستجوی پیش فرض:",
         "settingsDDGExplanation": "DuckDuckGo را به عنوان موتور جستجوی پیش فرض تنظیم کنید تا در نوار جستجو نتایج آنی ببینید.",
@@ -176,6 +177,8 @@
         /* Download manager */
         "downloadCancel": null, //missing translation
         "downloadStateCompleted": null, //missing translation
-        "downloadStateFailed": null //missing translation
+        "downloadStateFailed": null, //missing translation
+        /* Update Notifications */
+        "updateNotificationTitle": null //missing translation
     }
 }

--- a/localization/languages/fr-FR.json
+++ b/localization/languages/fr-FR.json
@@ -120,6 +120,7 @@
         "settingsSwipeNavigationToggle": "Activer le glissement pour changer de page.",
         "settingsUserscriptsToggle": "Activer les scripts personnalisés",
         "settingsUserscriptsExplanation": {"unsafeHTML": "Les scripts personnalisés vous permettent de modifier le comportement des pages web - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">en savoir plus (en anglais)</a>."},
+        "settingsUpdateNotificationsToggle": null, //missing translation
         "settingsSearchEngineHeading": "Moteur de recherche",
         "settingsDefaultSearchEngine": "Choisir un moteur de recherche par défaut :",
         "settingsDDGExplanation": "Définir DuckDuckGo comme moteur de recherche par défaut pour voir instantanément des résulats dans la barre de recherche.",
@@ -176,6 +177,8 @@
         /* Download manager */
         "downloadCancel": null, //missing translation
         "downloadStateCompleted": null, //missing translation
-        "downloadStateFailed": null //missing translation
+        "downloadStateFailed": null, //missing translation
+        /* Update Notifications */
+        "updateNotificationTitle": null //missing translation
     }
 }

--- a/localization/languages/hu.json
+++ b/localization/languages/hu.json
@@ -120,6 +120,7 @@
         "settingsSwipeNavigationToggle": "Kapcsolja be a swipe Navigációt előre és hátra az oldalakal.",
         "settingsUserscriptsToggle": "Felhasználói Szkriptek",
         "settingsUserscriptsExplanation": "Felhasználói Szkriptek magyarázat",
+        "settingsUpdateNotificationsToggle": null, //missing translation
         "settingsSearchEngineHeading": "Kereső Motor",
         "settingsDefaultSearchEngine": "Válasza ki az Alap kereső Motorját:",
         "settingsDDGExplanation": "Állitsa be a DuckDuckGo kereső motort hogy lássa a válaszokat a kereső sorba.",
@@ -176,6 +177,8 @@
         /* Download manager */
         "downloadCancel": null, //missing translation
         "downloadStateCompleted": null, //missing translation
-        "downloadStateFailed": null //missing translation
+        "downloadStateFailed": null, //missing translation
+        /* Update Notifications */
+        "updateNotificationTitle": null //missing translation
     }
 }

--- a/localization/languages/it.json
+++ b/localization/languages/it.json
@@ -120,6 +120,7 @@
         "settingsSwipeNavigationToggle": "Abilita swipe per andare avanti ed indietro tra le pagine.",
         "settingsUserscriptsToggle": "Abilita script definiti dall'utente",
         "settingsUserscriptsExplanation": {"unsafeHTML": "Gli script definiti dall'utente ti permettono di modificare il comportamento dei siti - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">scopri di più</a>."},
+        "settingsUpdateNotificationsToggle": null, //missing translation
         "settingsSearchEngineHeading": "Motore di ricerca",
         "settingsDefaultSearchEngine": "Scegli un motore di ricerac predefinito:",
         "settingsDDGExplanation": "Imposta DuckDuckGo come motore di ricerca predefinito per vedere risposte istantanee nella barra di ricerca.",
@@ -172,6 +173,12 @@
         "appMenuQuit": "Esci da %n",
         "appMenuBringToFront": "Porta avanti",
         /* PDF Viewer */
-        "PDFPageCounter": {"unsafeHTML": "pagina <input type='text'/> su <span id='total'></span>"}
+        "PDFPageCounter": {"unsafeHTML": "pagina <input type='text'/> su <span id='total'></span>"},
+        /* Download manager */
+        "downloadCancel": null, //missing translation
+        "downloadStateCompleted": null, //missing translation
+        "downloadStateFailed": null, //missing translation
+        /* Update Notifications */
+        "updateNotificationTitle": null //missing translation
     }
 }

--- a/localization/languages/ja.json
+++ b/localization/languages/ja.json
@@ -120,6 +120,7 @@
         "settingsSwipeNavigationToggle": "スワイプしてページを行き来できるようにする",
         "settingsUserscriptsToggle": null, //missing translation
         "settingsUserscriptsExplanation": null, //missing translation
+        "settingsUpdateNotificationsToggle": null, //missing translation
         "settingsSearchEngineHeading": "検索エンジン",
         "settingsDefaultSearchEngine": "デフォルトの検索エンジン:",
         "settingsDDGExplanation": "検索バーにインスタントアンサーを表示するには、DuckDuckGoをデフォルトの検索エンジンに設定してください。",
@@ -176,6 +177,8 @@
         /* Download manager */
         "downloadCancel": null, //missing translation
         "downloadStateCompleted": null, //missing translation
-        "downloadStateFailed": null //missing translation
+        "downloadStateFailed": null, //missing translation
+        /* Update Notifications */
+        "updateNotificationTitle": null //missing translation
     }
 }

--- a/localization/languages/ko.json
+++ b/localization/languages/ko.json
@@ -120,6 +120,7 @@
         "settingsSwipeNavigationToggle": "페이지간 이동을 위한 스와이프 모드 사용",
         "settingsUserscriptsToggle": "사용자 스크립트 사용",
         "settingsUserscriptsExplanation": {"unsafeHTML": "사용자 스크립트를 사용하면 웹 사이트의 행동을 수정할 수 있습니다. - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">더보기</a>."},
+        "settingsUpdateNotificationsToggle": null, //missing translation
         "settingsSearchEngineHeading": "검색 엔진",
         "settingsDefaultSearchEngine": "기본 검색 엔진:",
         "settingsDDGExplanation": "SDuckDuckGo를 기본 검색 엔진으로 설정하여 검색 창에서 바로 검색 해 보세요.",
@@ -176,6 +177,8 @@
         /* Download manager */
         "downloadCancel": null, //missing translation
         "downloadStateCompleted": null, //missing translation
-        "downloadStateFailed": null //missing translation
+        "downloadStateFailed": null, //missing translation
+        /* Update Notifications */
+        "updateNotificationTitle": null //missing translation
     }
 }

--- a/localization/languages/lt.json
+++ b/localization/languages/lt.json
@@ -120,6 +120,7 @@
         "settingsSwipeNavigationToggle": "Įjungti perbraukimus, skirtus naršyti tarp puslapių pirmyn ir atgal.",
         "settingsUserscriptsToggle": "Įjungti naudotojo scenarijus",
         "settingsUserscriptsExplanation": {"unsafeHTML": "Naudotojo scenarijai leidžia jums modifikuoti internetinių svetainių elgseną - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">sužinokite daugiau</a>."},
+        "settingsUpdateNotificationsToggle": null, //missing translation
         "settingsSearchEngineHeading": "Paieškos sistema",
         "settingsDefaultSearchEngine": "Pasirinkite numatytąją paieškos sistemą:",
         "settingsDDGExplanation": "Nustatykite DuckDuckGo kaip numatytąją paieškos sistemą, norėdami paieškos juostoje matyti greitus atsakymus.",
@@ -176,6 +177,8 @@
         /* Download manager */
         "downloadCancel": null, //missing translation
         "downloadStateCompleted": null, //missing translation
-        "downloadStateFailed": null //missing translation
+        "downloadStateFailed": null, //missing translation
+        /* Update Notifications */
+        "updateNotificationTitle": null //missing translation
     }
 }

--- a/localization/languages/pl.json
+++ b/localization/languages/pl.json
@@ -120,6 +120,7 @@
         "settingsAdditionalFeaturesHeading": "Dodatkowe funkcje",
         "settingsUserscriptsToggle": "Włącz skrypty użytkownika",
         "settingsUserscriptsExplanation": {"unsafeHTML": "Skrypty użytkownika pozwalają modyfikować zachowanie stron internetowych - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">learn more</a>."},
+        "settingsUpdateNotificationsToggle": null, //missing translation
         "settingsSearchEngineHeading": "Wyszukiwarka",
         "settingsDefaultSearchEngine": "Wybierz domyślną wyszukiwarkę:",
         "settingsDDGExplanation": "Ustaw DuckDuckGo jako domyślną wyszukiwarkę, aby zobaczyć błyskawiczne odpowiedzi na pasku wyszukiwania.",
@@ -176,6 +177,8 @@
         /* Download manager */
         "downloadCancel": null, //missing translation
         "downloadStateCompleted": null, //missing translation
-        "downloadStateFailed": null //missing translation
+        "downloadStateFailed": null, //missing translation
+        /* Update Notifications */
+        "updateNotificationTitle": null //missing translation
     }
 }

--- a/localization/languages/pt-BR.json
+++ b/localization/languages/pt-BR.json
@@ -120,6 +120,7 @@
         "settingsSwipeNavigationToggle": "Habilitar navegação por gestos para voltar e avançar entre páginas.",
         "settingsUserscriptsToggle": null, //missing translation
         "settingsUserscriptsExplanation": null, //missing translation
+        "settingsUpdateNotificationsToggle": null, //missing translation
         "settingsSearchEngineHeading": "Serviço de busca",
         "settingsDefaultSearchEngine": "Escolha o serviço de busca padrão:",
         "settingsDDGExplanation": "Defina DuckDuckGo como o serviço padrão de buscas para ver respostas instantâneas na barra de busca.",
@@ -176,6 +177,8 @@
         /* Download manager */
         "downloadCancel": null, //missing translation
         "downloadStateCompleted": null, //missing translation
-        "downloadStateFailed": null //missing translation
+        "downloadStateFailed": null, //missing translation
+        /* Update Notifications */
+        "updateNotificationTitle": null //missing translation
     }
 }

--- a/localization/languages/pt-PT.json
+++ b/localization/languages/pt-PT.json
@@ -120,6 +120,7 @@
         "settingsSwipeNavigationToggle": "Ativar gestos para navegar entre as páginas visitadas.",
         "settingsUserscriptsToggle": "Ativar scripts de utilizador",
         "settingsUserscriptsExplanation": {"unsafeHTML": "Os scripts permitem-lhe alterar o comportamento dos sites - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">Saber mais</a>."},
+        "settingsUpdateNotificationsToggle": null, //missing translation
         "settingsSearchEngineHeading": "Motor de pesquisa",
         "settingsDefaultSearchEngine": "Escolha o motor de pesquisa padrão:",
         "settingsDDGExplanation": "Defina DuckDuckGo como motor de pesquisa padrão para poder obter sugestões instantâneas na barra de pesquisa.",
@@ -176,6 +177,8 @@
         /* Download manager */
         "downloadCancel": "Cancelar",
         "downloadStateCompleted": "Terminada",
-        "downloadStateFailed": "Falhada"
+        "downloadStateFailed": "Falhada",
+        /* Update Notifications */
+        "updateNotificationTitle": null //missing translation
     }
 }

--- a/localization/languages/ru.json
+++ b/localization/languages/ru.json
@@ -120,6 +120,7 @@
         "settingsSwipeNavigationToggle": "Включить навигацию свайпом для перехода вперёд и назад по страницам.",
         "settingsUserscriptsToggle": null, //missing translation
         "settingsUserscriptsExplanation": null, //missing translation
+        "settingsUpdateNotificationsToggle": null, //missing translation
         "settingsSearchEngineHeading": "Поиск",
         "settingsDefaultSearchEngine": "Выберите поиск по умолчанию:",
         "settingsDDGExplanation": "Чтобы видеть мгновенные ответы в строке поиска, установите DuckDuckGo поисковиком по умолчанию.",
@@ -176,6 +177,8 @@
         /* Download manager */
         "downloadCancel": null, //missing translation
         "downloadStateCompleted": null, //missing translation
-        "downloadStateFailed": null //missing translation
+        "downloadStateFailed": null, //missing translation
+        /* Update Notifications */
+        "updateNotificationTitle": null //missing translation
     }
 }

--- a/localization/languages/tr_TR.json
+++ b/localization/languages/tr_TR.json
@@ -120,6 +120,7 @@
         "settingsSwipeNavigationToggle": "Sayfalar arasında ileri ve geri gitmek için kaydırmayı etkinleştirin.",
         "settingsUserscriptsToggle": null, //missing translation
         "settingsUserscriptsExplanation": null, //missing translation
+        "settingsUpdateNotificationsToggle": null, //missing translation
         "settingsSearchEngineHeading": "Arama Motoru",
         "settingsDefaultSearchEngine": "Bir varsayılan arama motoru seçi:",
         "settingsDDGExplanation": "Arama çubuğundaki anlık yanıtları görmek için DuckDuckGo’yu varsayılan arama motoru olarak ayarlayın.",
@@ -176,6 +177,8 @@
         /* Download manager */
         "downloadCancel": null, //missing translation
         "downloadStateCompleted": null, //missing translation
-        "downloadStateFailed": null //missing translation
+        "downloadStateFailed": null, //missing translation
+        /* Update Notifications */
+        "updateNotificationTitle": null //missing translation
     }
 }

--- a/localization/languages/zh-CN.json
+++ b/localization/languages/zh-CN.json
@@ -120,6 +120,7 @@
         "settingsSwipeNavigationToggle": "允许通过手势在页面上进行前进和后退操作。",
         "settingsUserscriptsToggle": "允许使用者指令",
         "settingsUserscriptsExplanation": {"unsafeHTML": "使用者指令允许您改变网站行为 - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">查看更多</a>."},
+        "settingsUpdateNotificationsToggle": null, //missing translation
         "settingsSearchEngineHeading": "搜索引擎",
         "settingsDefaultSearchEngine": "选择默认的搜索引擎:",
         "settingsDDGExplanation": "将 DuckDuckGo 设为默认的搜索引擎可以直接在搜索栏查看搜索结果。",
@@ -176,6 +177,8 @@
         /* Download manager */
         "downloadCancel": null, //missing translation
         "downloadStateCompleted": null, //missing translation
-        "downloadStateFailed": null //missing translation
+        "downloadStateFailed": null, //missing translation
+        /* Update Notifications */
+        "updateNotificationTitle": null //missing translation
     }
 }

--- a/localization/languages/zh-TW.json
+++ b/localization/languages/zh-TW.json
@@ -120,6 +120,7 @@
         "settingsSwipeNavigationToggle": "允許通過手勢在頁面上進行上一頁和下一頁的操作",
         "settingsUserscriptsToggle": "允許使用者指令",
         "settingsUserscriptsExplanation": {"unsafeHTML": "使用者指令允許您改變網站的行為 - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">查看更多</a>."},
+        "settingsUpdateNotificationsToggle": null, //missing translation
         "settingsSearchEngineHeading": "搜索引擎",
         "settingsDefaultSearchEngine": "選擇預設的搜索引擎：",
         "settingsDDGExplanation": "將 DuckDuckGo 設為預設的搜索引擎可以直接在網址欄查看搜尋結果",
@@ -176,6 +177,8 @@
         /* Download manager */
         "downloadCancel": "取消",
         "downloadStateCompleted": "已完成",
-        "downloadStateFailed": "失敗"
+        "downloadStateFailed": "失敗",
+        /* Update Notifications */
+        "updateNotificationTitle": null //missing translation
     }
 }

--- a/pages/settings/index.html
+++ b/pages/settings/index.html
@@ -74,6 +74,11 @@
 			<label for="checkbox-userscripts" data-string="settingsUserscriptsToggle"></label>
 			<div class="light-fade setting-secondary-label" data-string="settingsUserscriptsExplanation" data-allowHTML></div>
 		</div>
+
+		<div class="setting-section">
+			<input type="checkbox" id="checkbox-update-notifications">
+			<label for="checkbox-update-notifications" data-string="settingsUpdateNotificationsToggle"></label>
+		</div>
 	</div>
 
 	<div class="spacer">

--- a/pages/settings/settings.js
+++ b/pages/settings/settings.js
@@ -203,6 +203,23 @@ userscriptsCheckbox.addEventListener('change', function (e) {
   showRestartRequiredBanner()
 })
 
+/* update notifications setting */
+
+var updateNotificationsCheckbox = document.getElementById('checkbox-update-notifications')
+
+settings.get('updateNotificationsEnabled', function (value) {
+  if (value === false) {
+    updateNotificationsCheckbox.checked = false
+  } else {
+    updateNotificationsCheckbox.checked = true
+  }
+})
+
+updateNotificationsCheckbox.addEventListener('change', function (e) {
+  settings.set('updateNotificationsEnabled', this.checked)
+  showRestartRequiredBanner()
+})
+
 /* default search engine setting */
 
 var searchEngineDropdown = document.getElementById('default-search-engine')

--- a/scripts/buildBrowser.js
+++ b/scripts/buildBrowser.js
@@ -30,6 +30,7 @@ const legacyModules = [
   'js/searchbar/placeSuggestionsPlugin.js',
   'js/searchbar/hostsSuggestionsPlugin.js',
   'js/searchbar/keywordSuggestionsPlugin.js',
+  'js/searchbar/updateNotifications.js',
   'js/readerview.js',
   'js/navbar/tabBar.js',
   'js/taskOverlay/taskOverlay.js',


### PR DESCRIPTION
With this PR, Min will automatically check for new updates after startup, and once a day while the browser is open. If an update is found, it will display a notification in the searchbar that links to the release notes:

<img width="867" src="https://user-images.githubusercontent.com/10314059/52686556-dff88100-2f13-11e9-818e-6447f6794973.png">

The network requests to GitHub don't include any personally-identifying information (aside from an IP address), but in case of privacy concerns (or if you just don't want to be notified), I've also added an option to disable update checks to the settings page:

<img width="686" src="https://user-images.githubusercontent.com/10314059/52686638-42518180-2f14-11e9-92a0-3153d18753e0.png">
