### PR TITLE
custom bang for closing tasks

### DIFF
--- a/js/searchbar/customBangs.js
+++ b/js/searchbar/customBangs.js
@@ -160,6 +160,26 @@ registerCustomBang({
 })
 
 registerCustomBang({
+  phrase: '!closetask',
+  snippet: l('closeTask'),
+  isAction: false,
+  fn: function (text) {
+    if (text) {
+      taskToClose = getTaskByNameOrNumber(text)
+      if (taskToClose) {
+        browserUI.closeTask(taskToClose.id)
+      }
+    } else {
+      browserUI.closeTask(tasks.getSelected().id)
+    }
+    taskOverlay.show()
+    setTimeout(function () {
+      taskOverlay.hide()
+    }, 600)
+  }
+})
+
+registerCustomBang({
   phrase: '!bookmarks',
   snippet: l('searchBookmarks'),
   isAction: false,

--- a/js/searchbar/customBangs.js
+++ b/js/searchbar/customBangs.js
@@ -164,18 +164,24 @@ registerCustomBang({
   snippet: l('closeTask'),
   isAction: false,
   fn: function (text) {
+    var currentTask = tasks.getSelected()
+    var taskToClose
+
     if (text) {
       taskToClose = getTaskByNameOrNumber(text)
-      if (taskToClose) {
-        browserUI.closeTask(taskToClose.id)
-      }
     } else {
-      browserUI.closeTask(tasks.getSelected().id)
+      taskToClose = tasks.getSelected()
     }
-    taskOverlay.show()
-    setTimeout(function () {
-      taskOverlay.hide()
-    }, 600)
+
+    if (taskToClose) {
+      browserUI.closeTask(taskToClose.id)
+      if (currentTask.id === taskToClose.id) {
+        taskOverlay.show()
+        setTimeout(function () {
+          taskOverlay.hide()
+        }, 600)
+      }
+    }
   }
 })
 

--- a/localization/languages/ar.json
+++ b/localization/languages/ar.json
@@ -33,6 +33,7 @@
         "clearHistory": "مسح السجل",
         "switchToTask": "تحويل الى مهام",
         "createTask": "انشاء مهمة",
+        "closeTask": null, //missing translation
         "moveToTask": "نقل التبويب الى المهام",
         "searchBookmarks": "البحث عن الإشارات",
         "searchHistory": "البحث عن السجل",

--- a/localization/languages/bn.json
+++ b/localization/languages/bn.json
@@ -33,6 +33,7 @@
       "clearHistory":"সমস্ত ইতিহাস সাফ করুন",
       "switchToTask":"টাস্কে স্যুইচ করুন",
       "createTask":"একটি টাস্ক তৈরি করুন",
+      "closeTask": null, //missing translation
       "moveToTask":"একটি টাস্ক এই ট্যাব সরান",
       "searchBookmarks":"বুকমার্কগুলি অনুসন্ধান করুন",
       "searchHistory":"অনুসন্ধানের ইতিহাস",

--- a/localization/languages/cs.json
+++ b/localization/languages/cs.json
@@ -33,6 +33,7 @@
         "clearHistory": "Vymazat celou historii",
         "switchToTask": "Skočit do dimenze",
         "createTask": "Vytvořit dimenzi",
+        "closeTask": null, //missing translation
         "moveToTask": "Přesunout tuto kartu do dimenze",
         "searchBookmarks": "Vyhledávat záložky",
         "searchHistory": null, //missing translation

--- a/localization/languages/de.json
+++ b/localization/languages/de.json
@@ -33,6 +33,7 @@
         "clearHistory": "Verlauf komplett löschen",
         "switchToTask": "zu Aufgabe wechseln",
         "createTask": "Aufgabe erstellen",
+        "closeTask": null, //missing translation
         "moveToTask": "Verschiebe diesen Tab zu Aufgabe",
         "searchBookmarks": "Bookmarks durchsuchen",
         "searchHistory": null, //missing translation

--- a/localization/languages/en-US.json
+++ b/localization/languages/en-US.json
@@ -33,6 +33,7 @@
         "clearHistory": "Clear All History",
         "switchToTask": "Switch to Task",
         "createTask": "Create a Task",
+        "closeTask": "Close a Task",
         "moveToTask": "Move this tab to a task",
         "searchBookmarks": "Search bookmarks",
         "searchHistory": "Search history",

--- a/localization/languages/es.json
+++ b/localization/languages/es.json
@@ -33,6 +33,7 @@
         "clearHistory": "Limpiar todo el historial",
         "switchToTask": "Cambiar a la tarea",
         "createTask": "Crear una tarea",
+        "closeTask": null, //missing translation
         "moveToTask": "Mover esta pestaña a una tarea",
         "searchBookmarks": "Buscar marcadores",
         "searchHistory": null, //missing translation

--- a/localization/languages/fa.json
+++ b/localization/languages/fa.json
@@ -33,6 +33,7 @@
         "clearHistory": "حذف تاریخچه مرورگر",
         "switchToTask": "تغییر به وظیفه",
         "createTask": "ایجاد وظیفه جدید",
+        "closeTask": null, //missing translation
         "moveToTask": "انتقال این برگه به یک وظیفه",
         "searchBookmarks": "جستجوی نشانک ها",
         "searchHistory": "جستجوی تاریخچه",

--- a/localization/languages/fr-FR.json
+++ b/localization/languages/fr-FR.json
@@ -33,6 +33,7 @@
         "clearHistory": "Vider l'historique",
         "switchToTask": "Changer de tâche",
         "createTask": "Créer une tâche",
+        "closeTask": null, //missing translation
         "moveToTask": "Déplacer cette tâche à cet onglet",
         "searchBookmarks": "Rechercher des signets",
         "searchHistory": "Rechercher dans l'historique",

--- a/localization/languages/hu.json
+++ b/localization/languages/hu.json
@@ -33,6 +33,7 @@
         "clearHistory": "Összes történet törlés",
         "switchToTask": "Feladat váltása",
         "createTask": "Feladat létrehozás",
+        "closeTask": null, //missing translation
         "moveToTask": "Tedd a fület feladatba",
         "searchBookmarks": "Könyvjelző keresés",
         "searchHistory": "Keresési előzmények",

--- a/localization/languages/it.json
+++ b/localization/languages/it.json
@@ -33,6 +33,7 @@
         "clearHistory": "Svuota la cronologia",
         "switchToTask": "Passa a Task",
         "createTask": "Crea un Task",
+        "closeTask": null, //missing translation
         "moveToTask": "Sposta questa scheda in un task",
         "searchBookmarks": "Cerca nei preferiti",
         "searchHistory": "Cerca nella cronologia",

--- a/localization/languages/ja.json
+++ b/localization/languages/ja.json
@@ -33,6 +33,7 @@
         "clearHistory": "すべての履歴をクリア",
         "switchToTask": "タスクに切り替える",
         "createTask": "タスクを作成",
+        "closeTask": null, //missing translation
         "moveToTask": "このタブをタスクに移動",
         "searchBookmarks": "ブックマークを検索",
         "searchHistory": null, //missing translation

--- a/localization/languages/ko.json
+++ b/localization/languages/ko.json
@@ -33,6 +33,7 @@
         "clearHistory": "기록 삭제",
         "switchToTask": "태스크 변경",
         "createTask": "태스크 생성",
+        "closeTask": null, //missing translation
         "moveToTask": "태스트로 탭 이동",
         "searchBookmarks": "북마크 검색",
         "searchHistory": "기록 검색",

--- a/localization/languages/lt.json
+++ b/localization/languages/lt.json
@@ -33,6 +33,7 @@
         "clearHistory": "Išvalyti visą istoriją",
         "switchToTask": "Perjungti į užduotį",
         "createTask": "Sukurti užduotį",
+        "closeTask": null, //missing translation
         "moveToTask": "Perkelti šią kortelę į užduotį",
         "searchBookmarks": "Ieškoti adresyno įrašų",
         "searchHistory": "Ieškoti istorijos",

--- a/localization/languages/pl.json
+++ b/localization/languages/pl.json
@@ -33,6 +33,7 @@
         "clearHistory": "Wyczyść całą historię",
         "switchToTask": "Przełącz na zadanie",
         "createTask": "Utwórz zadanie",
+        "closeTask": null, //missing translation
         "moveToTask": "Przenieś tę kartę do zadania",
         "searchBookmarks": "Zakładki wyszukiwania",
         "searchHistory": "Historia wyszukiwania",

--- a/localization/languages/pt-BR.json
+++ b/localization/languages/pt-BR.json
@@ -33,6 +33,7 @@
         "clearHistory": "Limpar todo o histórico",
         "switchToTask": "Trocar para a tarefa",
         "createTask": "Criar uma tarefa",
+        "closeTask": null, //missing translation
         "moveToTask": "Mover esta aba para uma tarefa",
         "searchBookmarks": "Buscar nos favoritos",
         "searchHistory": null, //missing translation

--- a/localization/languages/pt-PT.json
+++ b/localization/languages/pt-PT.json
@@ -33,6 +33,7 @@
         "clearHistory": "Limpar todo o histórico",
         "switchToTask": "Trocar para a tarefa",
         "createTask": "Criar tarefa",
+        "closeTask": null, //missing translation
         "moveToTask": "Mover este separador para uma tarefa",
         "searchBookmarks": "Pesquisar nos marcadores",
         "searchHistory": "Pesquisar no histórico",

--- a/localization/languages/ru.json
+++ b/localization/languages/ru.json
@@ -33,6 +33,7 @@
         "clearHistory": "Очистить историю",
         "switchToTask": "Переключиться на задачу",
         "createTask": "Создать задачу",
+        "closeTask": null, //missing translation
         "moveToTask": "Переместить эту вкладку в задачу",
         "searchBookmarks": "Искать в закладках",
         "searchHistory": null, //missing translation

--- a/localization/languages/tr_TR.json
+++ b/localization/languages/tr_TR.json
@@ -33,6 +33,7 @@
         "clearHistory": "Tüm Geçmişi Temizle",
         "switchToTask": "Göreve geç",
         "createTask": "Görev oluştur",
+        "closeTask": null, //missing translation
         "moveToTask": "Bu sekmeyi bir göreve taşı",
         "searchBookmarks": "Yer işaretlerini ara",
         "searchHistory": null, //missing translation

--- a/localization/languages/uk.json
+++ b/localization/languages/uk.json
@@ -33,6 +33,7 @@
         "clearHistory": "Очистити історію",
         "switchToTask": "Перейти до завдання",
         "createTask": "Створити завдання",
+        "closeTask": null, //missing translation
         "moveToTask": "Перемістіть цю вкладку до завдання",
         "searchBookmarks": "Пошук закладок",
         "searchHistory": "Історія пошуку",

--- a/localization/languages/zh-CN.json
+++ b/localization/languages/zh-CN.json
@@ -32,6 +32,7 @@
         "takeScreenshot": "截图",
         "clearHistory": "清除所有历史记录",
         "switchToTask": "切换到标签组列表",
+        "closeTask": null, //missing translation
         "createTask": "新建标签组",
         "moveToTask": "以当前标签页创建一个新的标签组",
         "searchBookmarks": "搜索书签内容",

--- a/localization/languages/zh-TW.json
+++ b/localization/languages/zh-TW.json
@@ -33,6 +33,7 @@
         "clearHistory": "清除所有歷史",
         "switchToTask": "切換至工作",
         "createTask": "新增工作",
+        "closeTask": null, //missing translation
         "moveToTask": "移動至工作",
         "searchBookmarks": "搜尋書籤",
         "searchHistory": "搜尋歷史",


### PR DESCRIPTION
I was getting annoyed having to manually open the task overlay, and mouse over to the trash icon to remove tasks. This custom bang just gets rid of tasks by name/number or the current if nothing is specified.