### PR TITLE
Reduce storage space needed to store history

### DIFF
--- a/js/dbMigration.js
+++ b/js/dbMigration.js
@@ -45,6 +45,7 @@ fs.readFile(savePath, function (err, data) {
       places.initialize()
     // completed history migration, move on to reading list
       migrateReadingListItem()
+      return
     }
     var item = historyItems.shift()
     item.tags = []

--- a/js/dbMigration.js
+++ b/js/dbMigration.js
@@ -1,0 +1,85 @@
+const fs = require('fs')
+const {db, dbLegacy} = require('util/database.js')
+const places = require('js/places/places.js')
+
+var dbPath = userDataPath + (platformType === 'windows' ? '\\IndexedDB\\file__0.indexeddb.leveldb' : '/IndexedDB/file__0.indexeddb.leveldb')
+var savePath = userDataPath + (platformType === 'windows' ? '\\database-migration' : '/database-migration')
+
+dbLegacy.places.count().then(function (oldCount) {
+  if (oldCount > 0) {
+      // the legacy DB exists
+
+    var historyItems = []
+    var readingListItems = []
+
+    dbLegacy.places.each(function (item) {
+      historyItems.push(item)
+    }).then(function () {
+      dbLegacy.readingList.each(function (item) {
+        readingListItems.push(item)
+      }).then(function () {
+        fs.writeFileSync(savePath, JSON.stringify({history: historyItems, readingList: readingListItems}))
+        remote.app.relaunch({
+          args: remote.getGlobal('process').argv.slice(1).concat(['--rename-db-and-relaunch'])
+        })
+        remote.app.quit()
+      })
+    })
+  }
+})
+
+fs.readFile(savePath, function (err, data) {
+  if (err || !data) {
+    console.warn(err)
+    return
+  }
+
+  var items = JSON.parse(data)
+  var historyItems = items.history
+  var readingListItems = items.readingList
+  console.log(items)
+
+  function migrateHistoryItem () {
+    if (historyItems.length === 0) {
+    // restart the worker to fix autocomplete
+      places.initialize()
+    // completed history migration, move on to reading list
+      migrateReadingListItem()
+    }
+    var item = historyItems.shift()
+    item.tags = []
+    db.places.where('url').equals(item.url).count().then(function (count) {
+      if (count === 0) {
+        db.places.put(item).then(function () {
+          console.info('put item', item.url)
+          setTimeout(migrateHistoryItem, 100)
+        })
+      } else {
+        console.info('skipping item', item.url)
+        setTimeout(migrateHistoryItem, 100)
+      }
+    })
+  }
+  migrateHistoryItem()
+
+  function migrateReadingListItem () {
+    if (readingListItems.length === 0) {
+        // completed migration
+      fs.rename(savePath, savePath + '.recovery', function () {})
+      return
+    }
+
+    var item = readingListItems.shift()
+    db.readingList.where('url').equals(item.url).count().then(function (count) {
+      if (count === 0) {
+        db.readingList.put(item).then(function () {
+          console.info('put reading list item', item.url)
+          setTimeout(migrateReadingListItem, 100)
+        })
+      } else {
+        console.info('skipping item', item.url)
+        setTimeout(migrateReadingListItem, 100)
+      }
+    })
+  }
+})

--- a/js/dbMigration.js
+++ b/js/dbMigration.js
@@ -20,7 +20,7 @@ dbLegacy.places.count().then(function (oldCount) {
       }).then(function () {
         fs.writeFileSync(savePath, JSON.stringify({history: historyItems, readingList: readingListItems}))
         remote.app.relaunch({
-          args: remote.getGlobal('process').argv.slice(1).concat(['--rename-db-and-relaunch'])
+          args: remote.getGlobal('process').argv.slice(1).concat(['--rename-db'])
         })
         remote.app.quit()
       })

--- a/js/default.js
+++ b/js/default.js
@@ -119,6 +119,8 @@ window.addEventListener('load', function () {
   }, true)
 })
 
+require('dbMigration.js')
+
 require('util/settings/settings.js').initialize()
 require('menuBarVisibility.js').initialize()
 require('navbar/tabActivity.js').init()

--- a/js/navbar/bookmarkStar.js
+++ b/js/navbar/bookmarkStar.js
@@ -1,4 +1,4 @@
-const db = require('util/database.js')
+const db = require('util/database.js').db
 const places = require('places/places.js')
 
 const bookmarkStar = {

--- a/js/places/fullTextSearch.js
+++ b/js/places/fullTextSearch.js
@@ -153,7 +153,7 @@ function getMatchingDocs (prefixes) {
       })
 
     // Finally select entire documents from intersection
-    return yield db.places.where('url').anyOf(reduced).limit(100).toArray()
+    return yield db.places.where('id').anyOf(reduced).limit(100).toArray()
   })
 }
 

--- a/js/places/places.js
+++ b/js/places/places.js
@@ -1,7 +1,7 @@
 /* global Worker tabs */
 
 var webviews = require('webviews.js')
-const db = require('util/database.js')
+const db = require('util/database.js').db
 const searchEngine = require('util/searchEngine.js')
 const urlParser = require('util/urlParser.js')
 
@@ -137,6 +137,9 @@ const places = {
     })
   },
   initialize: function () {
+    if (places.worker) {
+      places.worker.terminate()
+    }
     places.worker = new Worker('js/places/placesWorker.js')
     places.worker.onmessage = places.onMessage
 

--- a/js/places/placesWorker.js
+++ b/js/places/placesWorker.js
@@ -143,13 +143,15 @@ onmessage = function (e) {
       pageHTML: '',
       extractedText: '',
       searchIndex: tokenize(pageData.extractedText || ''),
-      metadata: pageData.metadata
+      metadata: pageData.metadata,
+      tags: []
     }
 
     db.transaction('rw', db.places, function () {
       db.places.where('url').equals(pageData.url).first(function (oldItem) {
         // a previous item exists, update it
         if (oldItem) {
+          item.id = oldItem.id
           item.visitCount = oldItem.visitCount + 1
           item.isBookmarked = oldItem.isBookmarked
           db.places.put(item)
@@ -184,7 +186,8 @@ onmessage = function (e) {
             pageHTML: '',
             extractedText: '',
             searchIndex: [],
-            metadata: {}
+            metadata: {},
+            tags: []
           }
         }
         item.isBookmarked = pageData.shouldBeBookmarked

--- a/js/util/settings/settings.js
+++ b/js/util/settings/settings.js
@@ -1,5 +1,5 @@
 if (process.type === 'renderer') {
-  var db = require('util/database.js')
+  var db = require('util/database.js').db
 }
 
 var settings = {
@@ -18,7 +18,7 @@ var settings = {
       mainWindow.webContents.send('receiveSettingsData', settings.list)
     }
   },
-  runChangeCallacks() {
+  runChangeCallacks () {
     settings.onChangeCallbacks.forEach(function (listener) {
       if (listener.key) {
         listener.cb(settings.list[listener.key])
@@ -53,19 +53,6 @@ var settings = {
     }
     if (fileData) {
       settings.list = JSON.parse(fileData)
-    } else if (process.type === 'renderer') {
-      // import from indexeddb
-      var didMigrateSettings = false
-      db.settings.each(function (setting) {
-        didMigrateSettings = true
-        settings.set(setting.key, setting.value)
-      }).then(function () {
-        if (didMigrateSettings) {
-          // need to restart, since some setting changes won't apply otherwise
-          ipc.send('destroyAllViews')
-          remote.getCurrentWindow().webContents.reload()
-        }
-      })
     }
 
     ipc.on('receiveSettingsData', function (e, data) {

--- a/main/main.js
+++ b/main/main.js
@@ -19,16 +19,12 @@ var userDataPath = app.getPath('userData')
 
 var dbPath = userDataPath + (process.platform === 'win32' ? '\\IndexedDB\\file__0.indexeddb.leveldb' : '/IndexedDB/file__0.indexeddb.leveldb')
 
-if (process.argv.some(item => item.includes('rename-db-and-relaunch'))) {
-  fs.rename(dbPath, dbPath + '.recovery', function () {
-    setTimeout(function () {
-      app.relaunch({
-        args: process.argv.slice(1, -1)
-      })
-      app.quit()    
-    }, 500);
-  })
-  return
+if (process.argv.some(item => item.includes('rename-db'))) {
+  try {
+    fs.renameSync(dbPath, dbPath + '.recovery')
+  } catch (e) {
+    console.warn('renaming database failed', e)
+  }
 }
 
 const browserPage = 'file://' + __dirname + '/index.html'

--- a/main/main.js
+++ b/main/main.js
@@ -21,9 +21,10 @@ var dbPath = userDataPath + (process.platform === 'win32' ? '\\IndexedDB\\file__
 
 if (process.argv.some(item => item.includes('rename-db'))) {
   try {
-    fs.renameSync(dbPath, dbPath + '.recovery')
+    fs.renameSync(dbPath, dbPath + '-' + Date.now() + '.recovery')
   } catch (e) {
     console.warn('renaming database failed', e)
+    app.quit()
   }
 }
 

--- a/main/main.js
+++ b/main/main.js
@@ -17,6 +17,20 @@ app.commandLine.appendSwitch('disable-backgrounding-occluded-windows', 'true')
 
 var userDataPath = app.getPath('userData')
 
+var dbPath = userDataPath + (process.platform === 'win32' ? '\\IndexedDB\\file__0.indexeddb.leveldb' : '/IndexedDB/file__0.indexeddb.leveldb')
+
+if (process.argv.some(item => item.includes('rename-db-and-relaunch'))) {
+  fs.rename(dbPath, dbPath + '.recovery', function () {
+    setTimeout(function () {
+      app.relaunch({
+        args: process.argv.slice(1, -1)
+      })
+      app.quit()    
+    }, 500);
+  })
+  return
+}
+
 const browserPage = 'file://' + __dirname + '/index.html'
 
 var mainWindow = null
@@ -261,7 +275,7 @@ app.on('second-instance', function (e, argv, workingDir) {
  *
  * Opens a new tab when all tabs are closed, and min is still open by clicking on the application dock icon
  */
-app.on('activate', function ( /* e, hasVisibleWindows */) {
+app.on('activate', function (/* e, hasVisibleWindows */) {
   if (!mainWindow && appIsReady) { // sometimes, the event will be triggered before the app is ready, and creating new windows will fail
     createWindow()
   }


### PR DESCRIPTION
With the current database schema, the URL is the primary key of each page, and the search index is a multi-entry index, where each word in the page is an entry. As far as I can tell, this means that for each word added to the search index, Chrome stores a new entry of word -> URL, which means that at least ```(length of URL) * size of search index``` worth of storage space is wasted unnecessarily.

As a result, the database gets large fairly quickly. Also, something about the way it is stored seems to cause Chromium to not fully remove everything when old items are deleted, which causes the database to continually grow in size.

To fix this, I've updated the schema to use an auto-incrementing ID as the primary key, with the URL as a secondary index. I expect the ID's are still duplicated, but they take up so much less storage space than the URL that it's a pretty significant improvement. This also seems to fix the expanding-size issue; I've been using this for about a week now, and the database size seems stable.

Unfortunately, at least in my case, the database has grown so large that trying to use the built-in upgrade() function causes Chromium to run out of memory and crash, so we need to migrate the database manually. To do this:
* If there is an old database on startup, dbMigration.js will copy everything into a file, and store it in the user data directory.
* Min will then relaunch, and rename the old indexeddb folder (this has to be done at startup, since you can't rename files on Windows once they've been opened)
* Then the browserWindow will be created, and dbMigration.js will create a new database with all the contents of the migration file.

This upgrade process is fairly complicated, so I expect there is some potential for data loss; to account for this, the migration process will keep the old database as a backup rather than deleting it.

### Results

Using my existing history database:
* Current size: 2.38 gb
* After creating a new database in the same format: 179.6 mb (although that number goes back up once I start visiting more pages)
* With the new database format: 60.5 mb

This PR also adds a "tags" field as part of the migration to support #697.