### PR TITLE
#882 Hotfix

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "min",
   "productName": "Min",
   "author": "PalmerAL",
-  "version": "1.12.0",
+  "version": "1.12.01",
   "description": "A fast, minimal browser that protects your privacy",
   "electronVersion": "7.1.7",
   "main": "main.build.js",

--- a/resources/postinst_script
+++ b/resources/postinst_script
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ]; then
+if [ -z "$2" ]; then
     update-alternatives --install /usr/bin/x-www-browser \
         x-www-browser /usr/bin/min 80
     read -r -p "Would you like to set Min as your default web browser? [Y/n]" input


### PR DESCRIPTION
This will prevent postinst_script on **upgrade** but works on **install** step. I've tested it on Raspbian with dpkg and I think this may work on any Debian based **apt upgrade/full-upgrade**.

The version number is what I temporarily modified for testing purpose.