### PR TITLE
Fix accounts.google.com login ("This website is not secure")

### DIFF
--- a/main/UASwitcher.js
+++ b/main/UASwitcher.js
@@ -4,3 +4,20 @@ see https://github.com/minbrowser/min/issues/657 for more information */
 let defaultUserAgent = app.userAgentFallback
 let newUserAgent = defaultUserAgent.replace(/Min\/\S+\s/, '').replace(/Electron\/\S+\s/, '')
 app.userAgentFallback = newUserAgent
+
+
+/* Some websites use more than the User-Agent for fingerprinting, and so the above change is not enough. */
+
+app.once('ready', function () {
+  session.defaultSession.webRequest.onBeforeSendHeaders((details, callback) => {
+    const url = new URL(details.url);
+    // Google login : Will throw a "Your browser is unsecured" and will not permit authentification,
+    // even using a valid Chrome User-Agent
+    // See https://github.com/timche/gmail-desktop/issues/174
+    // Using a Firefox User-Agent works
+    if(url.hostname == 'accounts.google.com') {
+      details.requestHeaders['User-Agent'] = 'Mozilla/5.0 (X11; Linux x86_64; rv:72.0) Gecko/20100101 Firefox/72.0';
+    }
+    callback({ cancel: false, requestHeaders: details.requestHeaders });
+  })
+})

--- a/main/main.js
+++ b/main/main.js
@@ -1,6 +1,7 @@
 const electron = require('electron')
 const fs = require('fs')
 const path = require('path')
+const url = require('url');
 const app = electron.app // Module to control application life.
 const protocol = electron.protocol // Module to control protocol handling
 const BrowserWindow = electron.BrowserWindow // Module to create native browser window.


### PR DESCRIPTION
Accounts.google.com seems to use more than the User-Agent for fingerprinting Chrome (other headers, javascript objects, ...), so use a Firefox UA instead.

This is not the perfect solution (the Firefox UA will need manual updating every X years; the website may do bad things thinking it is an actual Firefox), but this is the best I can think of, since using a valid Chrome UserAgent is not enough.

Another approach would require us to find out how accounts.google.com is fingerprinting chrome, with which other header or javascript check... but this would be hard, and it could change any day.

Let me know if you think of another better approach.