### PR TITLE
Rewrite the tab open/close animation

### DIFF
--- a/css/tabBar.css
+++ b/css/tabBar.css
@@ -117,6 +117,7 @@ body.linux.menu-bar-hidden #menu-button {
 .tab-item {
 	flex: 1;
 	min-width: 125px;
+	transition: 0.2s transform;
 	line-height: 36px;
 	height: 36px;
 	overflow: hidden;

--- a/css/tabBar.css
+++ b/css/tabBar.css
@@ -123,6 +123,7 @@ body.linux.menu-bar-hidden #menu-button {
 	overflow: hidden;
 	word-break: break-all;
 	position: relative;
+	padding: 0 0.8em;
 }
 .tab-item:not(.active):hover {
 	background-color: rgba(0, 0, 0, 0.03);
@@ -132,10 +133,6 @@ body.linux.menu-bar-hidden #menu-button {
 }
 .dark-theme.theme-background-low-contrast .tab-item:not(.active):hover {
 	background-color: rgba(255, 255, 255, 0.15);
-}
-
-.tab-view-contents {
-	padding: 0 0.8em;
 }
 
 /* icons */
@@ -225,7 +222,7 @@ body.dark-mode #overlay {
 .tab-item:not(.active) .icon-tab-not-secure {
 	display: none;
 }
-.tab-item .tab-view-contents .title {
+.tab-item .title {
 	font-size: 15px;
 }
 

--- a/css/tabBar.css
+++ b/css/tabBar.css
@@ -117,7 +117,6 @@ body.linux.menu-bar-hidden #menu-button {
 .tab-item {
 	flex: 1;
 	min-width: 125px;
-	transition: .15s min-width, 0.2s transform;
 	line-height: 36px;
 	height: 36px;
 	overflow: hidden;
@@ -159,12 +158,6 @@ body.linux.menu-bar-hidden #menu-button {
 .dark-theme.theme-background-low-contrast .tab-item.active:not(:only-child) {
 	background: rgba(255, 255, 255, 0.25);
 }
-.tab-item.selected {
-	min-width: 100%;
-	/* remove the white transparent-ness */
-	background: none;
-	padding-left: 9px;
-}
 .tab-item.fade {
 	opacity: 0.55;
 }
@@ -194,45 +187,10 @@ body.linux.menu-bar-hidden #menu-button {
 	background-color: rgba(255, 255, 255, 0.6);
 }
 
-/* when an input is selected, hide other tabs */
+/* hide tabs when tab editor is open */
 
-.is-edit-mode .tab-item:not(.selected) {
+.is-edit-mode .tab-item {
 	opacity: 0;
-}
-
-/* show either the view or edit contents */
-
-.tab-item .tab-edit-contents {
-	display: none;
-}
-.tab-item.selected .tab-edit-contents {
-	display: flex;
-	height: 100%;
-	align-items: center;
-}
-.tab-item.selected .tab-view-contents {
-	display: none;
-}
-
-/* tab inputs */
-
-.tab-item .tab-input {
-	line-height: 1.15em;
-	font-size: 1.15em;
-	-webkit-appearance: none;
-	background: none;
-	border: none;
-	color: inherit;
-	flex: 1;
-	height: 1.5em;
-	outline: none;
-	-webkit-user-select: auto;
-	-webkit-app-region: no-drag;
-}
-.tab-item .tab-input::-webkit-input-placeholder {
-	color: inherit;
-	opacity: 0.5;
-	line-height: 1.25em;
 }
 
 /* show the overlay in edit mode */

--- a/css/tabBar.css
+++ b/css/tabBar.css
@@ -104,12 +104,16 @@ body.linux.menu-bar-hidden #menu-button {
 #navbar #tabs {
 	display: flex;
 	flex: 1;
+	position: relative;
+	overflow: hidden;
+}
+#tabs #tabs-inner {
+	display: flex;
+	flex: 1;
 	overflow-x: auto;
 	overflow-y: hidden;
 }
-body.is-edit-mode #navbar #tabs {
-	overflow: hidden;
-}
+
 .tab-item {
 	flex: 1;
 	min-width: 125px;
@@ -170,38 +174,30 @@ body.is-edit-mode #navbar #tabs {
 
 /* style tab scrollbar */
 
-#navbar #tabs::-webkit-scrollbar {
+#navbar #tabs-inner::-webkit-scrollbar {
 	height: 0.25em;
 }
-#navbar #tabs::-webkit-scrollbar-track {
+.is-edit-mode #navbar #tabs-inner::-webkit-scrollbar {
+	height: 0
+}
+#navbar #tabs-inner::-webkit-scrollbar-track {
 	background-color: rgba(0, 0, 0, 0.05);
 }
-#navbar #tabs::-webkit-scrollbar-thumb {
+#navbar #tabs-inner::-webkit-scrollbar-thumb {
 	background-color: rgba(0, 0, 0, 0.175);
 	border-radius: 0.25em;
 }
-.dark-theme #navbar #tabs::-webkit-scrollbar-track {
+.dark-theme #navbar #tabs-inner::-webkit-scrollbar-track {
 	background-color: rgba(255, 255, 255, 0.25);
 }
-.dark-theme #navbar #tabs::-webkit-scrollbar-thumb {
+.dark-theme #navbar #tabs-inner::-webkit-scrollbar-thumb {
 	background-color: rgba(255, 255, 255, 0.6);
 }
 
 /* when an input is selected, hide other tabs */
 
 .is-edit-mode .tab-item:not(.selected) {
-	min-width: 0;
-	max-width: 0;
-	width: 0;
-	height: 0;
-	padding: 0;
-	overflow: hidden;
-}
-
-/* the background isn't necessary when there is only one tab */
-
-.is-edit-mode .tab-item {
-	background: none !important;
+	opacity: 0;
 }
 
 /* show either the view or edit contents */

--- a/css/tabEditor.css
+++ b/css/tabEditor.css
@@ -1,0 +1,31 @@
+#tab-editor {
+    padding: 0 0.55em;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+	display: flex;
+	height: 100%;
+    align-items: center;
+    transform-origin: top left;
+	z-index: 1;
+}
+
+#tab-editor-input {
+    background: none;
+	line-height: 1.15em;
+	font-size: 1.15em;
+	-webkit-appearance: none;
+	border: none;
+	color: inherit;
+	flex: 1;
+	height: 1.5em;
+	outline: none;
+	-webkit-user-select: auto;
+	-webkit-app-region: no-drag;
+}
+#tab-editor-input::-webkit-input-placeholder {
+	color: inherit;
+	opacity: 0.5;
+	line-height: 1.25em;
+}

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
 	<link rel="stylesheet" href="css/base.css" />
 	<link rel="stylesheet" href="css/windowsCaptionButtons.css" />
 	<link rel="stylesheet" href="css/tabBar.css" />
+	<link rel="stylesheet" href="css/tabEditor.css" />
 	<link rel="stylesheet" href="css/taskOverlay.css" />
 	<link rel="stylesheet" href="css/webviews.css" />
 	<link rel="stylesheet" href="css/searchbar.css" />
@@ -53,7 +54,12 @@
 		<div id="navbar" class="theme-background-color theme-text-color windowDragHandle" tabindex="-1">
 			<button id="menu-button" class="fa fa-ellipsis-v navbar-action-button" data-label="openMenu" tabindex="-1"></i>
 			<button id="back-button" hidden class="fa fa-angle-left navbar-action-button" data-label="goBack" tabindex="-1"></button>
-			<div id="tabs"></div>
+			<div id="tabs">
+				<div id="tab-editor" hidden>
+					<input id="tab-editor-input" class="mousetrap"/>
+				</div>
+				<div id="tabs-inner"></div>
+			</div>
 			<button id="add-tab-button" class="fa fa-plus navbar-action-button" data-label="newTabAction" tabindex="-1"></button>
 			<i class="fa fa-bars navbar-action-button invisible"></i>
 		</div>

--- a/js/browserUI.js
+++ b/js/browserUI.js
@@ -3,6 +3,8 @@
 var webviews = require('webviews.js')
 var urlParser = require('util/urlParser.js')
 var focusMode = require('focusMode.js')
+var tabEditor = require('navbar/tabEditor.js')
+var searchbar = require('searchbar/searchbar.js')
 
 /* loads a page in a webview */
 
@@ -15,7 +17,7 @@ function navigate (tabId, newURL) {
 
   webviews.update(tabId, newURL)
 
-  tabBar.leaveEditMode()
+  tabEditor.hide()
 }
 
 /* creates a new task */
@@ -54,7 +56,7 @@ function addTab (tabId = tabs.add(), options = {}) {
       focusWebview: options.enterEditMode === false
     })
     if (options.enterEditMode !== false) {
-      tabBar.enterEditMode(tabId)
+      tabEditor.show(tabId)
     }
   } else {
     tabBar.getTab(tabId).scrollIntoView()
@@ -172,7 +174,7 @@ function switchToTab (id, options) {
     return
   }
 
-  tabBar.leaveEditMode()
+  tabEditor.hide()
 
   tabs.setSelected(id)
   tabBar.setActiveTab(id)
@@ -222,6 +224,21 @@ webviews.bindEvent('new-window', function (webview, tabId, e, url, frameName, di
 
 webviews.bindIPC('close-window', function (webview, tabId, args) {
   closeTab(tabId)
+})
+
+searchbar.events.on('url-selected', function (data) {
+  if (data.background) {
+    var newTab = tabs.add({
+      url: data.url,
+      private: tabs.get(tabs.getSelected()).private
+    })
+    addTab(newTab, {
+      enterEditMode: false,
+      openInBackground: true
+    })
+  } else {
+    navigate(tabs.getSelected(), data.url)
+  }
 })
 
 module.exports = {

--- a/js/default.js
+++ b/js/default.js
@@ -2,6 +2,7 @@ window.userDataPath = process.argv.filter(a => a.startsWith('--user-data-path=')
 
 window.electron = require('electron')
 window.fs = require('fs')
+window.EventEmitter = require('events')
 window.ipc = electron.ipcRenderer
 window.remote = electron.remote
 window.Dexie = require('dexie')

--- a/js/defaultKeybindings.js
+++ b/js/defaultKeybindings.js
@@ -3,6 +3,7 @@ var webviews = require('webviews.js')
 var browserUI = require('browserUI.js')
 var focusMode = require('focusMode.js')
 var modalMode = require('modalMode.js')
+var tabEditor = require('navbar/tabEditor.js')
 
 const defaultKeybindings = {
   initialize: function () {
@@ -52,12 +53,12 @@ const defaultKeybindings = {
     })
 
     keybindings.defineShortcut('enterEditMode', function (e) {
-      tabBar.enterEditMode(tabs.getSelected())
+      tabEditor.show(tabs.getSelected())
       return false
     })
 
     keybindings.defineShortcut('runShortcut', function (e) {
-      tabBar.enterEditMode(tabs.getSelected(), '!')
+      tabEditor.show(tabs.getSelected(), '!')
     })
 
     keybindings.defineShortcut('closeTab', function (e) {
@@ -83,8 +84,8 @@ const defaultKeybindings = {
     })
 
     keybindings.defineShortcut('addToFavorites', function (e) {
-      tabBar.getTab(tabs.getSelected()).querySelector('.bookmarks-button').click()
-      tabBar.enterEditMode(tabs.getSelected(), null, false) // we need to show the bookmarks button, which is only visible in edit mode
+      tabEditor.show(tabs.getSelected(), null, false) // we need to show the bookmarks button, which is only visible in edit mode
+      tabEditor.container.querySelector('.bookmarks-button').click()
     })
 
     // cmd+x should switch to tab x. Cmd+9 should switch to the last tab
@@ -118,7 +119,7 @@ const defaultKeybindings = {
     })
 
     keybindings.defineShortcut({ keys: 'esc' }, function (e) {
-      tabBar.leaveEditMode()
+      tabEditor.hide()
 
       // exit full screen mode
       webviews.callAsync(tabs.getSelected(), 'executeJavaScript', 'if(document.webkitIsFullScreen){document.webkitExitFullscreen()}')

--- a/js/menuRenderer.js
+++ b/js/menuRenderer.js
@@ -7,6 +7,7 @@ var focusMode = require('focusMode.js')
 var modalMode = require('modalMode.js')
 var findinpage = require('findinpage.js')
 var PDFViewer = require('pdfViewer.js')
+var tabEditor = require('navbar/tabEditor.js')
 
 module.exports = {
   initialize: function () {
@@ -48,15 +49,15 @@ module.exports = {
 
     ipc.on('showReadingList', function () {
         // open the searchbar with "!readinglist " as the input
-      tabBar.enterEditMode(tabs.getSelected(), '!readinglist ')
+      tabEditor.show(tabs.getSelected(), '!readinglist ')
     })
 
     ipc.on('showBookmarks', function () {
-      tabBar.enterEditMode(tabs.getSelected(), '!bookmarks ')
+      tabEditor.show(tabs.getSelected(), '!bookmarks ')
     })
 
     ipc.on('showHistory', function () {
-      tabBar.enterEditMode(tabs.getSelected(), '!history ')
+      tabEditor.show(tabs.getSelected(), '!history ')
     })
 
     ipc.on('duplicateTab', function (e) {

--- a/js/navbar/bookmarkStar.js
+++ b/js/navbar/bookmarkStar.js
@@ -5,21 +5,21 @@ const searchbar = require('searchbar/searchbar.js')
 const searchbarPlugins = require('searchbar/searchbarPlugins.js')
 
 const bookmarkStar = {
-  create: function (tabId) {
+  create: function () {
     const star = document.createElement('button')
     star.className = 'fa fa-star-o tab-icon bookmarks-button' // alternative icon is fa-bookmark
     star.setAttribute('title', l('addBookmark'))
     star.setAttribute('aria-label', l('addBookmark'))
 
     star.addEventListener('click', function (e) {
-      bookmarkStar.onClick(tabId, star)
+      bookmarkStar.onClick(star)
     })
-
-    bookmarkStar.update(tabId, star)
 
     return star
   },
-  onClick: function (tabId, star) {
+  onClick: function (star) {
+    var tabId = star.getAttribute('data-tab')
+
     searchbarPlugins.clearAll()
 
     star.classList.toggle('fa-star')
@@ -27,15 +27,21 @@ const bookmarkStar = {
 
     places.toggleBookmarked(tabId, function (isBookmarked) {
       if (isBookmarked) {
+        // since the update happens asynchronously, and star.update() could be called after onClick but before the update, it's possible for the classes to get out of sync with the actual bookmark state. Updating them here fixes tis.
+        star.classList.add('fa-star')
+        star.classList.remove('fa-star-o')
         var editorInsertionPoint = document.createElement('div')
         searchbarPlugins.getContainer('simpleBookmarkTagInput').appendChild(editorInsertionPoint)
         bookmarkEditor.show(tabs.get(tabs.getSelected()).url, editorInsertionPoint, null, {simplified: true})
       } else {
+        star.classList.remove('fa-star')
+        star.classList.add('fa-star-o')
         searchbar.showResults('')
       }
     })
   },
   update: function (tabId, star) {
+    star.setAttribute('data-tab', tabId)
     const currentURL = tabs.get(tabId).url
 
     if (!currentURL) { // no url, can't be bookmarked

--- a/js/navbar/tabBar.js
+++ b/js/navbar/tabBar.js
@@ -37,10 +37,9 @@ window.tabBar = {
     var tabData = tabs.get(tabId)
 
     var tabEl = tabBar.getTab(tabId)
-    var viewContents = tabEl.querySelector('.tab-view-contents')
 
     var tabTitle = tabData.title || l('newTabLabel')
-    var titleEl = viewContents.querySelector('.title')
+    var titleEl = tabEl.querySelector('.title')
     titleEl.textContent = tabTitle
 
     tabEl.title = tabTitle
@@ -48,13 +47,13 @@ window.tabBar = {
       tabEl.title += ' (' + l('privateTab') + ')'
     }
 
-    viewContents.querySelectorAll('.permission-request-icon').forEach(el => el.remove())
+    tabEl.querySelectorAll('.permission-request-icon').forEach(el => el.remove())
 
     permissionRequests.getButtons(tabId).reverse().forEach(function (button) {
-      viewContents.insertBefore(button, viewContents.children[0])
+      tabEl.insertBefore(button, tabEl.children[0])
     })
 
-    var secIcon = viewContents.getElementsByClassName('icon-tab-not-secure')[0]
+    var secIcon = tabEl.getElementsByClassName('icon-tab-not-secure')[0]
     if (tabData.secure === false) {
       secIcon.hidden = false
     } else {
@@ -88,15 +87,12 @@ window.tabBar = {
       tabEl.title += ' (' + l('privateTab') + ')'
     }
 
-    var viewContents = document.createElement('div')
-    viewContents.className = 'tab-view-contents'
-
     permissionRequests.getButtons(data.id).forEach(function (button) {
-      viewContents.appendChild(button)
+      tabEl.appendChild(button)
     })
 
-    viewContents.appendChild(readerView.getButton(data.id))
-    viewContents.appendChild(progressBar.create())
+    tabEl.appendChild(readerView.getButton(data.id))
+    tabEl.appendChild(progressBar.create())
 
     // icons
 
@@ -130,7 +126,7 @@ window.tabBar = {
     secIcon.hidden = data.secure !== false
     iconArea.appendChild(secIcon)
 
-    viewContents.appendChild(iconArea)
+    tabEl.appendChild(iconArea)
 
     // title
 
@@ -138,12 +134,10 @@ window.tabBar = {
     title.className = 'title'
     title.textContent = tabTitle
 
-    viewContents.appendChild(title)
-
-    tabEl.appendChild(viewContents)
+    tabEl.appendChild(title)
 
     // click to enter edit mode or switch to a tab
-    viewContents.addEventListener('click', function (e) {
+    tabEl.addEventListener('click', function (e) {
       if (tabs.getSelected() !== data.id) { // else switch to tab if it isn't focused
         browserUI.switchToTab(data.id)
       } else { // the tab is focused, edit tab instead

--- a/js/navbar/tabEditor.js
+++ b/js/navbar/tabEditor.js
@@ -1,0 +1,139 @@
+var searchbar = require('searchbar/searchbar.js')
+var webviews = require('webviews.js')
+var modalMode = require('modalMode.js')
+var urlParser = require('util/urlParser.js')
+var bookmarkStar = require('navbar/bookmarkStar.js')
+
+const tabEditor = {
+  container: document.getElementById('tab-editor'),
+  input: document.getElementById('tab-editor-input'),
+  star: null,
+  show: function (tabId, editingValue, showSearchbar) {
+    /* Edit mode is not available in modal mode. */
+    if (modalMode.enabled()) {
+      return
+    }
+
+    tabEditor.container.hidden = false
+
+    bookmarkStar.update(tabId, tabEditor.star)
+
+    webviews.requestPlaceholder('editMode')
+
+    document.body.classList.add('is-edit-mode')
+
+    var currentURL = urlParser.getSourceURL(tabs.get(tabId).url)
+    if (currentURL === 'min://newtab') {
+      currentURL = ''
+    }
+
+    tabEditor.input.value = editingValue || currentURL
+    tabEditor.input.focus()
+    if (!editingValue) {
+      tabEditor.input.select()
+    }
+
+    searchbar.show(tabEditor.input)
+
+    if (showSearchbar !== false) {
+      if (editingValue) {
+        searchbar.showResults(editingValue, null)
+      } else {
+        searchbar.showResults('', null)
+      }
+    }
+
+    /* animation */
+    if (tabs.count() > 1) {
+      requestAnimationFrame(function () {
+
+        var item = document.querySelector(`.tab-item[data-tab="${tabId}"]`)
+        var originCoordinates = item.getBoundingClientRect()
+
+        var finalCoordinates = document.querySelector('#tabs').getBoundingClientRect()
+
+        var translateX = Math.min(Math.round(originCoordinates.x - finalCoordinates.x) * 0.5, window.innerWidth)
+
+        tabEditor.container.style.opacity = 0
+        tabEditor.container.style.transform = `translateX(${translateX}px)`
+        requestAnimationFrame(function () {
+          tabEditor.container.style.transition = '0.15s all'
+          tabEditor.container.style.opacity = 1
+          tabEditor.container.style.transform = ''
+        })
+      })
+    }
+  },
+  hide: function () {
+    tabEditor.container.hidden = true
+    tabEditor.container.removeAttribute('style')
+
+    tabEditor.input.blur()
+    searchbar.hide()
+
+    document.body.classList.remove('is-edit-mode')
+
+    webviews.hidePlaceholder('editMode')
+  },
+  initialize: function () {
+    tabEditor.input.setAttribute('placeholder', l('searchbarPlaceholder'))
+
+    tabEditor.star = bookmarkStar.create()
+    tabEditor.container.appendChild(tabEditor.star)
+
+    tabEditor.input.addEventListener('keydown', function (e) {
+      if (e.keyCode === 9 || e.keyCode === 40) { // if the tab or arrow down key was pressed
+        searchbar.focusItem()
+        e.preventDefault()
+      }
+    })
+
+    // keypress doesn't fire on delete key - use keyup instead
+    tabEditor.input.addEventListener('keyup', function (e) {
+      if (e.keyCode === 8) {
+        searchbar.showResults(this.value, e)
+      }
+    })
+
+    tabEditor.input.addEventListener('keypress', function (e) {
+      if (e.keyCode === 13) { // return key pressed; update the url
+        if (this.getAttribute('data-autocomplete') && this.getAttribute('data-autocomplete').toLowerCase() === this.value.toLowerCase()) {
+          // special case: if the typed input is capitalized differently from the actual URL that was autocompleted (but is otherwise the same), then we want to open the actual URL instead of what was typed.
+          // see https://github.com/minbrowser/min/issues/314#issuecomment-276678613
+          searchbar.openURL(this.getAttribute('data-autocomplete'), e)
+        } else {
+          searchbar.openURL(this.value, e)
+        }
+      } else if (e.keyCode === 9) {
+        return
+        // tab key, do nothing - in keydown listener
+      } else if (e.keyCode === 16) {
+        return
+        // shift key, do nothing
+      } else if (e.keyCode === 8) {
+        return
+        // delete key is handled in keyUp
+      } else { // show the searchbar
+        searchbar.showResults(this.value, e)
+      }
+
+      // on keydown, if the autocomplete result doesn't change, we move the selection instead of regenerating it to avoid race conditions with typing. Adapted from https://github.com/patrickburke/jquery.inlineComplete
+
+      var v = e.key
+      var sel = this.value.substring(this.selectionStart, this.selectionEnd).indexOf(v)
+
+      if (v && sel === 0) {
+        this.selectionStart += 1
+        e.preventDefault()
+      }
+    })
+
+    document.getElementById('webviews').addEventListener('click', function () {
+      tabEditor.hide()
+    })
+  }
+}
+
+tabEditor.initialize()
+
+module.exports = tabEditor

--- a/js/searchbar/bangsPlugin.js
+++ b/js/searchbar/bangsPlugin.js
@@ -1,3 +1,5 @@
+var tabEditor = require('navbar/tabEditor.js')
+
 var searchbar = require('searchbar/searchbar.js')
 var searchbarPlugins = require('searchbar/searchbarPlugins.js')
 var searchbarAutocomplete = require('searchbar/searchbarAutocomplete.js')
@@ -195,11 +197,11 @@ function initialize () {
 
       if ((!bang || !bang.isAction) && url.split(' ').length === 1 && !url.endsWith(' ')) {
         // the bang is non-custom or a custom bang that requires search text, so add a space after it
-        tabBar.enterEditMode(tabs.getSelected(), url + ' ')
+        tabEditor.show(tabs.getSelected(), url + ' ')
         return true
       } else if (bang) {
         // there is a custom bang that is an action or has search text, so it can be run
-        tabBar.leaveEditMode()
+        tabEditor.hide()
         bang.fn(url.replace(bang.phrase, '').trimLeft())
         return true // override the default action
       }

--- a/js/searchbar/bookmarkManager.js
+++ b/js/searchbar/bookmarkManager.js
@@ -5,6 +5,7 @@ var places = require('places/places.js')
 var urlParser = require('util/urlParser.js')
 var formatRelativeDate = require('util/relativeDate.js')
 
+var tabEditor = require('navbar/tabEditor.js')
 var bookmarkEditor = require('searchbar/bookmarkEditor.js')
 
 const maxTagSuggestions = 12
@@ -85,7 +86,7 @@ function showBookmarks (text, input, event) {
 
       parsedText.tags.forEach(function (tag) {
         tagBar.appendChild(bookmarkEditor.getTagElement(tag, true, function () {
-          tabBar.enterEditMode(tabs.getSelected(), '!bookmarks ' + text.replace('#' + tag, '').trim())
+          tabEditor.show(tabs.getSelected(), '!bookmarks ' + text.replace('#' + tag, '').trim())
         }, {autoRemove: false}))
       })
       // it doesn't make sense to display tag suggestions if there's a search, since the suggestions are generated without taking the search into account
@@ -93,7 +94,7 @@ function showBookmarks (text, input, event) {
         suggestedTags.forEach(function (suggestion, index) {
           var el = bookmarkEditor.getTagElement(suggestion, false, function () {
             var needsSpace = text.slice(-1) !== ' ' && text.slice(-1) !== ''
-            tabBar.enterEditMode(tabs.getSelected(), '!bookmarks ' + text + (needsSpace ? ' #' : '#') + suggestion + ' ')
+            tabEditor.show(tabs.getSelected(), '!bookmarks ' + text + (needsSpace ? ' #' : '#') + suggestion + ' ')
           })
           if (index >= maxTagSuggestions) {
             el.classList.add('overflowing')

--- a/js/searchbar/searchbarPlugins.js
+++ b/js/searchbar/searchbarPlugins.js
@@ -118,7 +118,7 @@ const searchbarPlugins = {
     var container = document.createElement('div')
     container.classList.add('searchbar-plugin-container')
     container.setAttribute('data-plugin', name)
-    searchbar.insertBefore(container, searchbar.childNodes[object.index + 1])
+    searchbar.insertBefore(container, searchbar.childNodes[object.index + 2])
 
     plugins.push({
       name: name,

--- a/js/sessionRestore.js
+++ b/js/sessionRestore.js
@@ -1,4 +1,5 @@
 var browserUI = require('browserUI.js')
+var tabEditor = require('navbar/tabEditor.js')
 
 window.sessionRestore = {
   savePath: userDataPath + (platformType === 'windows' ? '\\sessionRestore.json' : '/sessionRestore.json'),
@@ -88,7 +89,7 @@ window.sessionRestore = {
       if (tasks.getSelected().tabs.isEmpty() || (!data.saveTime || Date.now() - data.saveTime < 30000)) {
         browserUI.switchToTask(data.state.selectedTask)
         if (tasks.getSelected().tabs.isEmpty()) {
-          tabBar.enterEditMode(tasks.getSelected().tabs.getSelected())
+          tabEditor.show(tasks.getSelected().tabs.getSelected())
         }
       } else {
         window.createdNewTaskOnStartup = true
@@ -96,7 +97,7 @@ window.sessionRestore = {
         var lastTask = tasks.byIndex(tasks.getLength() - 1)
         if (lastTask && lastTask.tabs.isEmpty() && !lastTask.name) {
           browserUI.switchToTask(lastTask.id)
-          tabBar.enterEditMode(lastTask.tabs.getSelected())
+          tabEditor.show(lastTask.tabs.getSelected())
         } else {
           browserUI.addTask()
         }

--- a/js/taskOverlay/taskOverlay.js
+++ b/js/taskOverlay/taskOverlay.js
@@ -1,6 +1,7 @@
 var webviews = require('webviews.js')
 var keybindings = require('keybindings.js')
 var browserUI = require('browserUI.js')
+var tabEditor = require('navbar/tabEditor.js')
 var focusMode = require('focusMode.js')
 var modalMode = require('modalMode.js')
 
@@ -76,7 +77,7 @@ window.taskOverlay = {
 
     document.body.classList.add('task-overlay-is-shown')
 
-    tabBar.leaveEditMode()
+    tabEditor.hide()
 
     this.isShown = true
     taskSwitcherButton.classList.add('active')
@@ -198,7 +199,7 @@ function addTaskFromMenu () {
   taskOverlay.show()
   setTimeout(function () {
     taskOverlay.hide()
-    tabBar.enterEditMode(tabs.getSelected())
+    tabEditor.show(tabs.getSelected())
   }, 600)
 }
 


### PR DESCRIPTION
* Fixes #906 
* Makes the tab bar code a bit easier to understand by separating the editor from the tabs
* Since the new animations only use transforms and opacity changes, they should be a bit smoother