### PR TITLE
Chrome-like search suggestions behaviour

### DIFF
--- a/js/searchbar/searchbar.js
+++ b/js/searchbar/searchbar.js
@@ -12,6 +12,20 @@ function openURLInBackground (url) { // used to open a url in the background, wi
   }
 }
 
+var inputUpdater = {
+  input: null,
+  updateInput: function () {    
+    var currentText = searchbar.el.querySelector('.searchbar-item:focus .title') 
+      searchbar.associatedInput.value = currentText.innerHTML
+  },
+  saveInitialInput: function() {
+     this.input =  searchbar.associatedInput.value
+  },
+  restoreInitialInput: function() {
+    searchbar.associatedInput.value = this.input
+  }
+}
+
 var searchbar = {
   el: document.getElementById('searchbar'),
   associatedInput: null,
@@ -48,7 +62,7 @@ var searchbar = {
 
     var allItems = [].slice.call(searchbar.el.querySelectorAll('.searchbar-item:not(.unfocusable)'))
     var currentItem = searchbar.el.querySelector('.searchbar-item:focus, .searchbar-item.fakefocus')
-
+   
     var index = allItems.indexOf(currentItem)
     var logicalNextItem = allItems[(previous) ? index - 1 : index + 1]
 
@@ -60,14 +74,16 @@ var searchbar = {
 
     if (currentItem && logicalNextItem) { // an item is focused and there is another item after it, move onto the next one
       logicalNextItem.focus()
+      inputUpdater.updateInput()
     } else if (currentItem) { // the last item is focused, focus the searchbar again
+      inputUpdater.restoreInitialInput()
       searchbar.associatedInput.focus()
       return
     } else if (allItems[0]) { // no item is focused.
+      inputUpdater.saveInitialInput()
       allItems[0].focus()
+      inputUpdater.updateInput()
     }
-    // Updates the searchbar text with the selected item
-    searchbar.associatedInput.value = currentText;
   },
   openURL: function (url, event) {
     var hasURLHandler = searchbarPlugins.runURLHandlers(url)

--- a/js/searchbar/searchbar.js
+++ b/js/searchbar/searchbar.js
@@ -78,7 +78,7 @@ var searchbar = {
     } else if (currentItem || modify) { // the last item is focused, focus the searchbar again
       searchbar.associatedInput.focus()
       if (modify) {
-        searchbar.saveInitialInput()
+        inputUpdater.saveInitialInput()
       } else {
         inputUpdater.restoreInitialInput()
       }

--- a/js/searchbar/searchbar.js
+++ b/js/searchbar/searchbar.js
@@ -59,7 +59,7 @@ var searchbar = {
   focusItem: function (options) {
     options = options || {} // fallback if options is null
     var previous = options.focusPrevious
-
+    var modify = options.modifyInput
     var allItems = [].slice.call(searchbar.el.querySelectorAll('.searchbar-item:not(.unfocusable)'))
     var currentItem = searchbar.el.querySelector('.searchbar-item:focus, .searchbar-item.fakefocus')
    
@@ -72,12 +72,16 @@ var searchbar = {
       fakefocus.classList.remove('fakefocus')
     }
 
-    if (currentItem && logicalNextItem) { // an item is focused and there is another item after it, move onto the next one
+    if (currentItem && logicalNextItem && modify !== true) { // an item is focused and there is another item after it, move onto the next one
       logicalNextItem.focus()
       inputUpdater.updateInput()
-    } else if (currentItem) { // the last item is focused, focus the searchbar again
-      inputUpdater.restoreInitialInput()
+    } else if (currentItem || modify) { // the last item is focused, focus the searchbar again
       searchbar.associatedInput.focus()
+      if (modify) {
+        searchbar.saveInitialInput()
+      } else {
+        inputUpdater.restoreInitialInput()
+      }
       return
     } else if (allItems[0]) { // no item is focused.
       inputUpdater.saveInitialInput()
@@ -117,6 +121,10 @@ searchbar.el.addEventListener('keydown', function (e) {
     e.preventDefault()
     searchbar.focusItem({
       focusPrevious: true
+    })
+  } else if (e.keyCode === 32) {
+    searchbar.focusItem({
+      modifyInput: true
     })
   }
 })

--- a/js/searchbar/searchbar.js
+++ b/js/searchbar/searchbar.js
@@ -66,6 +66,8 @@ var searchbar = {
     } else if (allItems[0]) { // no item is focused.
       allItems[0].focus()
     }
+    // Updates the searchbar text with the selected item
+    searchbar.associatedInput.value = currentText;
   },
   openURL: function (url, event) {
     var hasURLHandler = searchbarPlugins.runURLHandlers(url)


### PR DESCRIPTION
Hello again! 
I think the ability to complete search suggestions is really important in browsing experience. Sadly Min does not have this feature yet. Let's say I want to search "Ryan Gosling movies" in Min. I have to type in the whole string as DuckDuckGo suggests only these items with "Ryan":
![image](https://user-images.githubusercontent.com/56982278/81723121-0d233e80-948b-11ea-964e-424eff08a335.png)
Not really handy. 
I've decided to fix that. Here's how it works.
As I navigate through the items, search bar updates automatically:
![image](https://user-images.githubusercontent.com/56982278/81723954-49a36a00-948c-11ea-8f98-4e3ef1b8f21b.png)

When I return to the bar, it restores the initial request, which is 'Ryan'.

And when I hit the `space` key, the focus returns to the search bar and now I have ability to complete my request.
(фильмы = movies)
![image](https://user-images.githubusercontent.com/56982278/81723696-eb768700-948b-11ea-9845-43d8deee7e9c.png)
I think it makes the experiense better. 

TODO: I think hitting the arrow up key in the searchbar should make the last suggestion in focus.