### PR TITLE
Partial Tampermonkey syntax support

### DIFF
--- a/js/userscripts.js
+++ b/js/userscripts.js
@@ -4,7 +4,57 @@ var webviews = require('webviews.js')
 var settings = require('util/settings/settings.js')
 
 var userScriptsEnabled = false
-var domainScriptMap = {}
+var scriptList = [] // {options: {}, content}
+
+function parseTampermonkeyFeatures (content) {
+  var parsedFeatures = {}
+  var foundFeatures = false
+
+  var lines = content.split('\n')
+
+  var isInFeatures = false
+  for (var i = 0; i < lines.length; i++) {
+    if (lines[i] === '// ==UserScript==') {
+      isInFeatures = true
+      continue
+    }
+    if (lines[i] === '// ==/UserScript==') {
+      isInFeatures = false
+      break
+    }
+    if (isInFeatures && lines[i].startsWith('//')) {
+      foundFeatures = true
+      var feature = lines[i].replace('//', '').trim()
+      var featureName = feature.split(' ')[0]
+      var featureValue = feature.replace(featureName + ' ', '')
+      featureName = featureName.replace('@', '')
+      if (parsedFeatures[featureName]) {
+        parsedFeatures[featureName].push(featureValue)
+      } else {
+        parsedFeatures[featureName] = [featureValue]
+      }
+    }
+  }
+  if (foundFeatures) {
+    return parsedFeatures
+  } else {
+    return null
+  }
+}
+
+// checks if a URL matches a wildcard pattern
+function urlMatchesPattern (url, pattern) {
+  var idx = -1
+  var parts = pattern.split('*')
+  for (var i = 0; i < parts.length; i++) {
+    idx = url.indexOf(parts[i], idx)
+    if (idx === -1) {
+      return false
+    }
+    idx += parts[i].length
+  }
+  return idx !== -1
+}
 
 if (settings.get('userscriptsEnabled') === true) {
   userScriptsEnabled = true
@@ -34,7 +84,28 @@ if (settings.get('userscriptsEnabled') === true) {
           if (!domain) {
             return
           }
-          domainScriptMap[domain] = file
+
+          var tampermonkeyFeatures = parseTampermonkeyFeatures(file)
+          if (tampermonkeyFeatures) {
+            scriptList.push({options: tampermonkeyFeatures, content: file})
+          } else {
+            // legacy script
+            if (domain === 'global') {
+              scriptList.push({
+                options: {
+                  match: ['*']
+                },
+                content: file
+              })
+            } else {
+              scriptList.push({
+                options: {
+                  match: ['*://' + domain]
+                },
+                content: file
+              })
+            }
+          }
         })
       }
     })
@@ -55,21 +126,12 @@ webviews.bindEvent('dom-ready', function (tabId) {
     if (err) {
       return
     }
-    try {
-      var domain = new URL(src).hostname
-      if (domain.startsWith('www.')) {
-        domain = domain.slice(4)
+    scriptList.forEach(function (script) {
+      if ((script.options.match && script.options.match.some(pattern => urlMatchesPattern(src, pattern))) || (script.options.include && script.options.include.some(pattern => urlMatchesPattern(src, pattern)))) {
+        if (!script.options.exclude || !script.options.exclude.some(pattern => urlMatchesPattern(src, pattern))) {
+          webviews.callAsync(tabId, 'executeJavaScript', [script.content, false, null])
+        }
       }
-      // global script
-      if (domainScriptMap.global) {
-        webviews.callAsync(tabId, 'executeJavaScript', [domainScriptMap.global, false, null])
-      }
-      // domain-specific scripts
-      if (domainScriptMap[domain]) {
-        webviews.callAsync(tabId, 'executeJavaScript', [domainScriptMap[domain], false, null])
-      }
-    } catch (e) {
-      console.warn(e)
-    }
+    })
   })
 })

--- a/js/userscripts.js
+++ b/js/userscripts.js
@@ -14,11 +14,11 @@ function parseTampermonkeyFeatures (content) {
 
   var isInFeatures = false
   for (var i = 0; i < lines.length; i++) {
-    if (lines[i] === '// ==UserScript==') {
+    if (lines[i].trim() === '// ==UserScript==') {
       isInFeatures = true
       continue
     }
-    if (lines[i] === '// ==/UserScript==') {
+    if (lines[i].trim() === '// ==/UserScript==') {
       isInFeatures = false
       break
     }
@@ -26,7 +26,7 @@ function parseTampermonkeyFeatures (content) {
       foundFeatures = true
       var feature = lines[i].replace('//', '').trim()
       var featureName = feature.split(' ')[0]
-      var featureValue = feature.replace(featureName + ' ', '')
+      var featureValue = feature.replace(featureName + ' ', '').trim()
       featureName = featureName.replace('@', '')
       if (parsedFeatures[featureName]) {
         parsedFeatures[featureName].push(featureValue)


### PR DESCRIPTION
Currently, only `include`, `matches`, and `exclude` are supported, but this should be enough to use at least a few basic scripts without modification.