### PR TITLE
Follow the changed OS name "Raspberry Pi OS".

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ In order to build Min from source, follow the installation instructions above, t
 * ```npm run buildWindows```
 * ```npm run buildMac```
 * ```npm run buildDebian```
-* ```npm run buildRaspbian``` (for Raspberry Pi)
+* ```npm run buildRaspi``` (for Raspberry Pi, Raspberry Pi OS)
 * ```npm run buildRedhat```
 
 Depending on the platform you are building for, you may need to install additional dependencies:

--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
     "buildWindows": "npm run build && node ./scripts/buildWindows.js",
     "buildMac": "npm run build && node ./scripts/buildMac.js",
     "buildDebian": "npm run build && node ./scripts/buildDebian.js",
-    "buildRaspbian": "npm run build && node ./scripts/buildDebian.js --raspbian",
+    "buildRaspi": "npm run build && node ./scripts/buildDebian.js --raspi",
     "buildRedhat": "npm run build && node ./scripts/buildRedhat.js",
-    "buildAll": "npm run buildWindows && npm run buildMac && npm run buildDebian && npm run buildRedhat && npm run buildRaspbian",
+    "buildAll": "npm run buildWindows && npm run buildMac && npm run buildDebian && npm run buildRedhat && npm run buildRaspi",
     "updateFilters": "node ./ext/filterLists/updateEasylist.js"
   },
   "repository": {

--- a/scripts/buildDebian.js
+++ b/scripts/buildDebian.js
@@ -2,13 +2,13 @@ const debianInstaller = require('electron-installer-debian')
 
 const packageFile = require('./../package.json')
 const version = packageFile.version
-const isRaspbian = process.argv.some(arg => arg === '--raspbian')
+const isRaspi = process.argv.some(arg => arg === '--raspi')
 
-require('./createPackage.js')((isRaspbian) ? 'raspbian' : 'linux').then(function (appPaths) {
+require('./createPackage.js')((isRaspi) ? 'raspi' : 'linux').then(function (appPaths) {
   var installerOptions = {
     src: appPaths[0],
     dest: 'dist/app',
-    arch: (isRaspbian) ? 'armhf' : 'amd64',
+    arch: (isRaspi) ? 'armhf' : 'amd64',
     productName: 'Min',
     genericName: 'Web Browser',
     version: version,

--- a/scripts/createPackage.js
+++ b/scripts/createPackage.js
@@ -57,7 +57,7 @@ var platformOptions = {
     platform: 'linux',
     arch: 'x64'
   },
-  raspbian: {
+  raspi: {
     name: 'min', // name must be lowercase to run correctly after installation
     platform: 'linux',
     arch: 'armv7l',


### PR DESCRIPTION
With 8GB RAM released, Raspbian has been renamed to Raspberry Pi OS.

https://www.raspberrypi.org/downloads/raspbian/