### PR TITLE
Show other tabs in focus mode

### DIFF
--- a/css/tabBar.css
+++ b/css/tabBar.css
@@ -275,19 +275,8 @@ body.dark-mode #overlay {
 	display: inline-block;
 }
 
-/* hide other tabs in focus mode */
-
-body.is-focus-mode .tab-item:not(.active) {
-	display: none;
-}
 body.is-focus-mode .navbar-action-button:not(#menu-button) {
 	display: none;
-}
-
-/* since only one tab is shown in focus mode, the highlight isn't needed */
-
-body.is-focus-mode .tab-item {
-	background: none !important;
 }
 
 /* progress bar */

--- a/js/browserUI.js
+++ b/js/browserUI.js
@@ -154,12 +154,6 @@ function switchToTask (id) {
 function switchToTab (id, options) {
   options = options || {}
 
-  /* tab switching disabled in focus mode */
-  if (focusMode.enabled()) {
-    focusMode.warn()
-    return
-  }
-
   tabEditor.hide()
 
   tabs.setSelected(id)
@@ -170,6 +164,11 @@ function switchToTab (id, options) {
 }
 
 webviews.bindEvent('new-window', function (tabId, url, frameName, disposition) {
+  /* disabled in focus mode */
+  if (focusMode.enabled()) {
+    focusMode.warn()
+    return
+  }
   var newTab = tabs.add({
     url: url,
     private: tabs.get(tabId).private // inherit private status from the current tab

--- a/localization/languages/ar.json
+++ b/localization/languages/ar.json
@@ -78,8 +78,8 @@
         /* Focus mode */  
         "isFocusMode": "أنت في وضع التركيز.",
         "closeDialog": "تم", //used as a label for the button that closes the dialog
-        "focusModeExplanation1": "في وضع التركيز , جميع التبوييات ما عادا المفتوحة الان مخفية , لا يمكنك فتح علامة جديدة",
-        "focusModeExplanation2": "يمكنك الخروج من وضع التركيز عبر الغاء تحديد \"وضع التركيز\" في القائمة",
+        "focusModeExplanation1": null, //missing translation "In focus mode, you can't create new tabs or switch tasks."
+        "focusModeExplanation2": null, //missing translation "You can leave focus mode by unchecking \"focus mode\" in the view menu."
         /* relative dates */
         "timeRangeJustNow": "الآن",
         "timeRangeMinutes": "قبل عدة دقائق",

--- a/localization/languages/cs.json
+++ b/localization/languages/cs.json
@@ -78,8 +78,8 @@
         /* Focus mode */
         "isFocusMode": "Jste v režimu zaměření.",
         "closeDialog": "OK", //used as a label for the button that closes the dialog
-        "focusModeExplanation1": "V režimu zaměření jsou všechny karty kromě aktuální skryté a nelze vytvářet nové karty.",
-        "focusModeExplanation2": "Můžete opustit režim zaměření odškrtnutím \"Režim zaměření\" v nabídce zobrazení.",
+        "focusModeExplanation1": null, //missing translation "In focus mode, you can't create new tabs or switch tasks."
+        "focusModeExplanation2": null, //missing translation "You can leave focus mode by unchecking \"focus mode\" in the view menu."
         /* relative dates */
         "timeRangeJustNow": null, //missing translation
         "timeRangeMinutes": null, //missing translation

--- a/localization/languages/de.json
+++ b/localization/languages/de.json
@@ -78,8 +78,8 @@
         /* Focus mode */
         "isFocusMode": "Fokus-Mode eingeschaltet.",
         "closeDialog": "OK", //used as a label for the button that closes the dialog
-        "focusModeExplanation1": "Im Fokus-Mode sind alle außer dem aktuellen Tab versteckt und es können keine neuen Tabs geöffnet werden.",
-        "focusModeExplanation2": "Der Fokus-Mode kann im Menü 'Anzeige' durch Klick auf \"fokus-mode\" verlassen werden.",
+        "focusModeExplanation1": null, //missing translation "In focus mode, you can't create new tabs or switch tasks."
+        "focusModeExplanation2": null, //missing translation "You can leave focus mode by unchecking \"focus mode\" in the view menu."
         /* relative dates */
         "timeRangeJustNow": null, //missing translation
         "timeRangeMinutes": null, //missing translation

--- a/localization/languages/en-US.json
+++ b/localization/languages/en-US.json
@@ -78,7 +78,7 @@
         /* Focus mode */
         "isFocusMode": "You're in Focus Mode.",
         "closeDialog": "OK", //used as a label for the button that closes the dialog
-        "focusModeExplanation1": "In focus mode, all tabs except the current one are hidden, and you can't create new tabs.",
+        "focusModeExplanation1": "In focus mode, you can't create new tabs or switch tasks.",
         "focusModeExplanation2": "You can leave focus mode by unchecking \"focus mode\" in the view menu.",
         /* relative dates */
         "timeRangeJustNow": "Just now",

--- a/localization/languages/es.json
+++ b/localization/languages/es.json
@@ -78,8 +78,8 @@
         /* Focus mode */
         "isFocusMode": "Estás en el modo de enfoque.",
         "closeDialog": "Aceptar", //used as a label for the button that closes the dialog
-        "focusModeExplanation1": "En el modo de enfoque, todas las pestañas excepto la actual están ocultas, y no puedes crear nuevas pestañas.",
-        "focusModeExplanation2": "Pues salir del modo de enfoque desmarcando \"Modo de enfoque\" en el menú Ver.",
+        "focusModeExplanation1": null, //missing translation "In focus mode, you can't create new tabs or switch tasks."
+        "focusModeExplanation2": null, //missing translation "You can leave focus mode by unchecking \"focus mode\" in the view menu."
         /* relative dates */
         "timeRangeJustNow": null, //missing translation
         "timeRangeMinutes": null, //missing translation

--- a/localization/languages/fa.json
+++ b/localization/languages/fa.json
@@ -78,8 +78,8 @@
         /* Focus mode */
         "isFocusMode": "شما در حالت تمرکز هستید",
         "closeDialog": "تایید", //used as a label for the button that closes the dialog
-        "focusModeExplanation1": "در حالت تمرکز تمام برگه ها به جز برگه فعلی مخفی شده و شما قادر به ایجاد برگه جدید نیستید.",
-        "focusModeExplanation2": "شما می توانید با غیرفعال کردن گزینه \"حالت تمرکز\" در منوی نمایش از حالت تمرکز خارج شوید.",
+        "focusModeExplanation1": null, //missing translation "In focus mode, you can't create new tabs or switch tasks."
+        "focusModeExplanation2": null, //missing translation "You can leave focus mode by unchecking \"focus mode\" in the view menu."
         /* relative dates */
         "timeRangeJustNow": "همین الان",
         "timeRangeMinutes": "دقایقی پیش",

--- a/localization/languages/fr-FR.json
+++ b/localization/languages/fr-FR.json
@@ -78,8 +78,8 @@
         /* Focus mode */
         "isFocusMode": "Vous êtes en mode Focus.",
         "closeDialog": "D'accord", //used as a label for the button that closes the dialog
-        "focusModeExplanation1": "En mode Focus, tous les onglets à l'exception de celui actif sont cachés, et vous pouvez créer de nouveaux onglets.",
-        "focusModeExplanation2": "Vous pouvez quitter le mode focus en choisissant \"Mode Focus\" dans le menu Voir.",
+        "focusModeExplanation1": null, //missing translation "In focus mode, you can't create new tabs or switch tasks."
+        "focusModeExplanation2": null, //missing translation "You can leave focus mode by unchecking \"focus mode\" in the view menu."
         /* relative dates */
         "timeRangeJustNow": "À l'instant",
         "timeRangeMinutes": "Il y a quelques minutes",

--- a/localization/languages/fr.json
+++ b/localization/languages/fr.json
@@ -78,8 +78,8 @@
         /* Focus mode */
         "isFocusMode": "Vous êtes en mode Focus.",
         "closeDialog": "D'accord", //used as a label for the button that closes the dialog
-        "focusModeExplanation1": "En mode Focus, tous les onglets à l'exception de celui actif sont cachés, et vous pouvez créer de nouveaux onglets.",
-        "focusModeExplanation2": "Vous pouvez quitter le mode focus en choisissant \"Mode Focus\" dans le menu Voir.",
+        "focusModeExplanation1": null, //missing translation "In focus mode, you can't create new tabs or switch tasks."
+        "focusModeExplanation2": null, //missing translation "You can leave focus mode by unchecking \"focus mode\" in the view menu."
         /* relative dates */
         "timeRangeJustNow": "À l'instant",
         "timeRangeMinutes": "Il y a quelques minutes",

--- a/localization/languages/hu.json
+++ b/localization/languages/hu.json
@@ -78,8 +78,8 @@
         /* Focus mode */
         "isFocusMode": "Most fókusz módban van.",
         "closeDialog": "OK", //used as a label for the button that closes the dialog
-        "focusModeExplanation1": "Fókusz módban csak a jelenlegi fül jelenik meg, nem tudsz új fület nyitni vagy másik fülre lépni.",
-        "focusModeExplanation2": "Elhagyhatod a \"focus mode\" a megtekintés menü kipipálásával.",
+        "focusModeExplanation1": null, //missing translation "In focus mode, you can't create new tabs or switch tasks."
+        "focusModeExplanation2": null, //missing translation "You can leave focus mode by unchecking \"focus mode\" in the view menu."
         /* relative dates */
         "timeRangeJustNow": "Idő intervalum, éppen most",
         "timeRangeMinutes": "Idő intervalum, perc",

--- a/localization/languages/it.json
+++ b/localization/languages/it.json
@@ -78,8 +78,8 @@
         /* Focus mode */
         "isFocusMode": "Sei in Modalità Focus.",
         "closeDialog": "OK", //used as a label for the button that closes the dialog
-        "focusModeExplanation1": "In Modalità Focus, tutte le schede eccetto quella corrente vengono nascoste, e non puoi crearne di nuove.",
-        "focusModeExplanation2": "Puoi uscire dalla Modalità Focus deselezionando \"Modalità Focus\" nel menù Vista.",
+        "focusModeExplanation1": null, //missing translation "In focus mode, you can't create new tabs or switch tasks."
+        "focusModeExplanation2": null, //missing translation "You can leave focus mode by unchecking \"focus mode\" in the view menu."
         /* relative dates */
         "timeRangeJustNow": "Proprio ora",
         "timeRangeMinutes": "Pochi minuti fa",

--- a/localization/languages/ja.json
+++ b/localization/languages/ja.json
@@ -78,8 +78,8 @@
         /* Focus mode */
         "isFocusMode": "フォーカスモード中です",
         "closeDialog": "OK", //used as a label for the button that closes the dialog
-        "focusModeExplanation1": "フォーカスモード中は、現在選択中のタブを除くすべてのタブが非表示になり、新規タブの作成もできなくなります。",
-        "focusModeExplanation2": "\"表示\"メニューから\"フォーカスモード\"のチェックを外すことで、フォーカスモードを終了できます。",
+        "focusModeExplanation1": null, //missing translation "In focus mode, you can't create new tabs or switch tasks."
+        "focusModeExplanation2": null, //missing translation "You can leave focus mode by unchecking \"focus mode\" in the view menu."
         /* relative dates */
         "timeRangeJustNow": "ちょうど今",
         "timeRangeMinutes": "数分前に",

--- a/localization/languages/ko.json
+++ b/localization/languages/ko.json
@@ -78,8 +78,8 @@
         /* Focus mode */
         "isFocusMode": "집중 지원 상태입니다.",
         "closeDialog": "닫기", //used as a label for the button that closes the dialog
-        "focusModeExplanation1": "집중 지원에서는 현재 작업을 제외한 모든 작업이 숨겨지고, 새 작업을 만들 수 없습니다.",
-        "focusModeExplanation2": "보기 일람에서 \"집중 지원\"의 선택을 해제하여 종료할 수 있습니다.",
+        "focusModeExplanation1": null, //missing translation "In focus mode, you can't create new tabs or switch tasks."
+        "focusModeExplanation2": null, //missing translation "You can leave focus mode by unchecking \"focus mode\" in the view menu."
         /* relative dates */
         "timeRangeJustNow": "방금",
         "timeRangeMinutes": "몇분 전",

--- a/localization/languages/lt.json
+++ b/localization/languages/lt.json
@@ -78,8 +78,8 @@
         /* Focus mode */
         "isFocusMode": "Jūs esate susitelkimo veiksenoje.",
         "closeDialog": "Gerai", //used as a label for the button that closes the dialog
-        "focusModeExplanation1": "Susitelkimo veiksenoje, visos kortelės išskyrus esamą yra paslepiamos ir jūs negalite sukurti naujų kortelių.",
-        "focusModeExplanation2": "Galite išeiti iš susitelkimo veiksenos rodinio meniu nuimdami žymėjimą nuo \"Susitelkimo veiksena\".",
+        "focusModeExplanation1": null, //missing translation "In focus mode, you can't create new tabs or switch tasks."
+        "focusModeExplanation2": null, //missing translation "You can leave focus mode by unchecking \"focus mode\" in the view menu."
         /* relative dates */
         "timeRangeJustNow": "Ką tik",
         "timeRangeMinutes": "Prieš kelias minutes",

--- a/localization/languages/pl.json
+++ b/localization/languages/pl.json
@@ -78,8 +78,8 @@
         /* Focus mode */
         "isFocusMode": "Jesteś w trybie ostrości.",
         "closeDialog": "OK", //used as a label for the button that closes the dialog
-        "focusModeExplanation1": "W trybie ustawiania ostrości wszystkie karty oprócz bieżącego są ukryte i nie można tworzyć nowych kart.",
-        "focusModeExplanation2": "Możesz wyłączyć tryb ostrości, odznaczając \"tryb ostrości\" w menu widoku.",
+        "focusModeExplanation1": null, //missing translation "In focus mode, you can't create new tabs or switch tasks."
+        "focusModeExplanation2": null, //missing translation "You can leave focus mode by unchecking \"focus mode\" in the view menu."
         /* relative dates */
         "timeRangeJustNow": "Przed chwilą",
         "timeRangeMinutes": "Kilka minut temu",

--- a/localization/languages/pt-BR.json
+++ b/localization/languages/pt-BR.json
@@ -78,8 +78,8 @@
         /* Focus mode */
         "isFocusMode": "Você está no modo concentração.",
         "closeDialog": "OK", //used as a label for the button that closes the dialog
-        "focusModeExplanation1": "No modo concentração, todas as abas com exceção da atual ficam escondidas e você não pode criar novas abas.",
-        "focusModeExplanation2": "Você pode desativar o modo concentração desmarcando a caixa \"modo concentração\" no menu visualizar.",
+        "focusModeExplanation1": null, //missing translation "In focus mode, you can't create new tabs or switch tasks."
+        "focusModeExplanation2": null, //missing translation "You can leave focus mode by unchecking \"focus mode\" in the view menu."
         /* relative dates */
         "timeRangeJustNow":"Agora mesmo",
         "timeRangeMinutes": "Há alguns minutos atrás",

--- a/localization/languages/pt-PT.json
+++ b/localization/languages/pt-PT.json
@@ -78,8 +78,8 @@
         /* Focus mode */
         "isFocusMode": "Está no modo de foco.",
         "closeDialog": "OK", //used as a label for the button that closes the dialog
-        "focusModeExplanation1": "Neste modo, todos os separadores estão ocultos à exceção do atual e não será possível criar novos separadores.",
-        "focusModeExplanation2": "Pode desativar este modo desmarcando a caixa \"Modo de foco\" no menu Ver.",
+        "focusModeExplanation1": null, //missing translation "In focus mode, you can't create new tabs or switch tasks."
+        "focusModeExplanation2": null, //missing translation "You can leave focus mode by unchecking \"focus mode\" in the view menu."
         /* relative dates */
         "timeRangeJustNow": "Agora mesmo",
         "timeRangeMinutes": "Há alguns minutos",

--- a/localization/languages/ru.json
+++ b/localization/languages/ru.json
@@ -78,8 +78,8 @@
         /* Focus mode */
         "isFocusMode": "Вы в режиме фокусировки",
         "closeDialog": "OK", //used as a label for the button that closes the dialog
-        "focusModeExplanation1": "В режиме фокусировки все вкладки, кроме текущей, спрятаны, а создание новой — невозможно.",
-        "focusModeExplanation2": "Чтобы вернуться в обычный режим, снимите флажок с пункта \"Режим фокусировки\" в меню \"Вид\".",
+        "focusModeExplanation1": null, //missing translation "In focus mode, you can't create new tabs or switch tasks."
+        "focusModeExplanation2": null, //missing translation "You can leave focus mode by unchecking \"focus mode\" in the view menu."
         /* relative dates */
         "timeRangeJustNow": "Только что",
         "timeRangeMinutes": "Несколько минут назад",

--- a/localization/languages/tr_TR.json
+++ b/localization/languages/tr_TR.json
@@ -78,8 +78,8 @@
         /* Focus mode */
         "isFocusMode": "Odak Modundasınız.",
         "closeDialog": "Tamam", //used as a label for the button that closes the dialog
-        "focusModeExplanation1": "Odak modunda, geçerli olan sekme dışındaki tüm sekmeler gizlenir ve yeni sekmeler oluşturamazsınız.",
-        "focusModeExplanation2": "Görüntüleme modunda \"odak modu\" nun işaretini kaldırarak odak modundan çıkabilirsiniz.",
+        "focusModeExplanation1": null, //missing translation "In focus mode, you can't create new tabs or switch tasks."
+        "focusModeExplanation2": null, //missing translation "You can leave focus mode by unchecking \"focus mode\" in the view menu."
         /* relative dates */
         "timeRangeJustNow": "Şu anda",
         "timeRangeMinutes": "Birkaç dakika önce",

--- a/localization/languages/uk.json
+++ b/localization/languages/uk.json
@@ -78,8 +78,8 @@
         /* Focus mode */
         "isFocusMode": "Ви в режимі фокусування",
         "closeDialog": "OK", //used as a label for the button that closes the dialog
-        "focusModeExplanation1": "В режимі фокусування всі вкладки, окрім поточної, приховані, і ви не можете створювати нові вкладки.",
-        "focusModeExplanation2": "Режим фокусування можна залишити, знявши прапорець \"Режим фокусування\" у меню \"Вигляд\".",
+        "focusModeExplanation1": null, //missing translation "In focus mode, you can't create new tabs or switch tasks."
+        "focusModeExplanation2": null, //missing translation "You can leave focus mode by unchecking \"focus mode\" in the view menu."
         /* relative dates */
         "timeRangeJustNow": "Зараз",
         "timeRangeMinutes": "Кілька хвилин тому",

--- a/localization/languages/uz.json
+++ b/localization/languages/uz.json
@@ -80,8 +80,8 @@
 		/* Focus mode */
 		"isFocusMode": "Siz Fokus Rejimidasiz",
 		"closeDialog": "OK", //used as a label for the button that closes the dialog
-		"focusModeExplanation1": "Fokus Rejimida, barcha varaqlar bunisidan tashqari, yashirib qo'yilgan va yangi varaqlar yarata olmaysiz.",
-		"focusModeExplanation2": "Siz Fokus Rejimidan ko'rinish menyusidagi \"focus mode\" dan belgini olib tashlab chiqib ketishingiz mumkin.",
+		"focusModeExplanation1": null, //missing translation "In focus mode, you can't create new tabs or switch tasks."
+		"focusModeExplanation2": null, //missing translation "You can leave focus mode by unchecking \"focus mode\" in the view menu."
 		/* relative dates */
 		"timeRangeJustNow": "Hozirgina",
 		"timeRangeMinutes": "Bir necha daqiqa oldin",

--- a/localization/languages/vi.json
+++ b/localization/languages/vi.json
@@ -74,8 +74,8 @@
         /* Focus mode */
         "isFocusMode": "Bạn trong chế độ tập trung.",
         "closeDialog": "OK", //used as a label for the button that closes the dialog
-        "focusModeExplanation1": "Trong chế độ tập trung, các tab trừ tab hiện tại sẽ bị ẩn, và bạn không có thể mở tab mới.",
-        "focusModeExplanation2": "Bạn có thể thoát chế độ tập trung bởi cách bỏ chọn \"Chế độ tập trung\" trong menu Xem.",
+        "focusModeExplanation1": null, //missing translation "In focus mode, you can't create new tabs or switch tasks."
+        "focusModeExplanation2": null, //missing translation "You can leave focus mode by unchecking \"focus mode\" in the view menu."
         /* relative dates */
         "timeRangeJustNow": "Vừa nãy",
         "timeRangeMinutes": "Vài phút trước",

--- a/localization/languages/zh-CN.json
+++ b/localization/languages/zh-CN.json
@@ -78,8 +78,8 @@
         /* Focus mode */
         "isFocusMode": "当前处于焦点模式",
         "closeDialog": "确定", //used as a label for the button that closes the dialog
-        "focusModeExplanation1": "在焦点模式中，隐藏除当前标签页之外的其它所有标签页，且不能新建标签页。",
-        "focusModeExplanation2": "您可以通过菜单\"视图->焦点模式\"退出焦点模式。",
+        "focusModeExplanation1": null, //missing translation "In focus mode, you can't create new tabs or switch tasks."
+        "focusModeExplanation2": null, //missing translation "You can leave focus mode by unchecking \"focus mode\" in the view menu."
         /* relative dates */
         "timeRangeJustNow": "几秒前",
         "timeRangeMinutes": "几分钟前",

--- a/localization/languages/zh-TW.json
+++ b/localization/languages/zh-TW.json
@@ -78,8 +78,8 @@
         /* Focus mode */
         "isFocusMode": "已進入專心模式",
         "closeDialog": "確定", //used as a label for the button that closes the dialog
-        "focusModeExplanation1": "在專心模式，只會顯示正在瀏覽的分頁，且不能新增分頁。",
-        "focusModeExplanation2": "您可以取消勾選 \"選單 > 檢視 > 專心模式\" 退出專心模式。",
+        "focusModeExplanation1": null, //missing translation "In focus mode, you can't create new tabs or switch tasks."
+        "focusModeExplanation2": null, //missing translation "You can leave focus mode by unchecking \"focus mode\" in the view menu."
         /* relative dates */
         "timeRangeJustNow": "剛剛", 
         "timeRangeMinutes": "幾分鐘前",


### PR DESCRIPTION
With this change, focus mode will show all open tabs in the current task (instead of just the current one), and let you switch between them. You still can't switch tasks or create new tabs. This should hopefully make it useful in a wider range of situations.