### PR TITLE
Add setting for opening tabs in foreground 

### DIFF
--- a/js/browserUI.js
+++ b/js/browserUI.js
@@ -1,5 +1,6 @@
 /* common actions that affect different parts of the UI (webviews, tabstrip, etc) */
 
+var settings = require('util/settings/settings.js')
 var webviews = require('webviews.js')
 var focusMode = require('focusMode.js')
 var tabBar = require('navbar/tabBar.js')

--- a/js/browserUI.js
+++ b/js/browserUI.js
@@ -176,7 +176,7 @@ webviews.bindEvent('new-window', function (tabId, url, frameName, disposition) {
 
   addTab(newTab, {
     enterEditMode: false,
-    openInBackground: disposition === 'background-tab' // possibly open in background based on disposition
+    openInBackground: false
   })
 })
 

--- a/js/browserUI.js
+++ b/js/browserUI.js
@@ -176,7 +176,7 @@ webviews.bindEvent('new-window', function (tabId, url, frameName, disposition) {
 
   addTab(newTab, {
     enterEditMode: false,
-    openInBackground: false
+    openInBackground: disposition === 'background-tab' && !settings.get('openTabsInForeground')
   })
 })
 

--- a/localization/languages/ar.json
+++ b/localization/languages/ar.json
@@ -144,6 +144,7 @@
         "settingsAdditionalFeaturesHeading": "مميزات اضافية",
         "settingsUserscriptsToggle": "تمكين سكريبت المستخدم",
         "settingsSeparateTitlebarToggle": null, //missing translation
+		"settingsOpenTabsInForegroundToggle": null, //missing translation
 		"settingsUserscriptsExplanation": {"unsafeHTML": "يمكن سكريبت المستخدم من  تغير سلوك المواقع - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">معرفة المزيد</a>."},
         "settingsUserAgentToggle": null, //missing translation
         "settingsUpdateNotificationsToggle": null, //missing translation

--- a/localization/languages/bn.json
+++ b/localization/languages/bn.json
@@ -144,6 +144,7 @@
       "settingsAdditionalFeaturesHeading":"অতিরিক্ত বৈশিষ্ট্য",
       "settingsUserscriptsToggle":"ব্যবহারকারী স্ক্রিপ্ট সক্রিয় করুন",
       "settingsSeparateTitlebarToggle": null, //missing translation
+		"settingsOpenTabsInForegroundToggle": null, //missing translation
 		"settingsUserscriptsExplanation": {"unsafeHTML": "ব্যবহারকারীর স্ক্রিপ্ট আপনাকে ওয়েবসাইটের আচরণ পরিবর্তন করার অনুমতি দেয় - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\"> আরও শিখুন </a>"},
       "settingsUserAgentToggle": null, //missing translation
         "settingsUpdateNotificationsToggle": null, //missing translation

--- a/localization/languages/cs.json
+++ b/localization/languages/cs.json
@@ -141,6 +141,7 @@
         "settingsAdditionalFeaturesHeading": null, //missing translation
         "settingsUserscriptsToggle": null, //missing translation
         "settingsSeparateTitlebarToggle": null, //missing translation
+		"settingsOpenTabsInForegroundToggle": null, //missing translation
 		"settingsUserscriptsExplanation": null, //missing translation
         "settingsUserAgentToggle": null, //missing translation
         "settingsUpdateNotificationsToggle": null, //missing translation

--- a/localization/languages/de.json
+++ b/localization/languages/de.json
@@ -144,6 +144,7 @@
         "settingsAdditionalFeaturesHeading": null, //missing translation
         "settingsUserscriptsToggle": null, //missing translation
         "settingsSeparateTitlebarToggle": null, //missing translation
+		"settingsOpenTabsInForegroundToggle": null, //missing translation
 		"settingsUserscriptsExplanation": null, //missing translation
         "settingsUserAgentToggle": null, //missing translation
         "settingsUpdateNotificationsToggle": null, //missing translation

--- a/localization/languages/en-US.json
+++ b/localization/languages/en-US.json
@@ -144,6 +144,7 @@
         "settingsAdditionalFeaturesHeading": "Additional Features",
         "settingsUserscriptsToggle": "Enable user scripts",
         "settingsSeparateTitlebarToggle": "Use separate title bar",
+        "settingsOpenTabsInForegroundToggle": "Open new tabs in the foreground",
 		"settingsUserscriptsExplanation": {"unsafeHTML": "User scripts allow you to modify the behavior of websites - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">learn more</a>."},
         "settingsUserAgentToggle": "Use a custom user agent",
         "settingsUpdateNotificationsToggle": "Automatically check for updates",

--- a/localization/languages/es.json
+++ b/localization/languages/es.json
@@ -144,6 +144,7 @@
         "settingsAdditionalFeaturesHeading": null, //missing translation
         "settingsUserscriptsToggle": null, //missing translation
         "settingsSeparateTitlebarToggle": null, //missing translation
+		"settingsOpenTabsInForegroundToggle": null, //missing translation
 		"settingsUserscriptsExplanation": null, //missing translation
         "settingsUserAgentToggle": null, //missing translation
         "settingsUpdateNotificationsToggle": null, //missing translation

--- a/localization/languages/fa.json
+++ b/localization/languages/fa.json
@@ -144,6 +144,7 @@
         "settingsAdditionalFeaturesHeading": "امکانات اضافه",
         "settingsUserscriptsToggle": "فعال کردن اسکریپت های کاربر",
         "settingsSeparateTitlebarToggle": null, //missing translation
+		"settingsOpenTabsInForegroundToggle": null, //missing translation
 		"settingsUserscriptsExplanation": {"unsafeHTML": "اسکریپت های کاربر این اجازه را به شما می دهند تا رفتار سایت ها را تغییر دهید - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">اطلاعات بیشتر</a>."},
         "settingsUserAgentToggle": null, //missing translation
         "settingsUpdateNotificationsToggle": null, //missing translation

--- a/localization/languages/fr-FR.json
+++ b/localization/languages/fr-FR.json
@@ -144,6 +144,7 @@
         "settingsAdditionalFeaturesHeading": "Fonctionnalités supplémentaires",
         "settingsUserscriptsToggle": "Activer les scripts personnalisés",
         "settingsSeparateTitlebarToggle": null, //missing translation
+		"settingsOpenTabsInForegroundToggle": null, //missing translation
 		"settingsUserscriptsExplanation": {"unsafeHTML": "Les scripts personnalisés vous permettent de modifier le comportement des pages web - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">en savoir plus (en anglais)</a>."},
         "settingsUserAgentToggle": null, //missing translation
         "settingsUpdateNotificationsToggle": "Vérifier automatiquement pour des mises à jour",

--- a/localization/languages/fr.json
+++ b/localization/languages/fr.json
@@ -144,6 +144,7 @@
         "settingsAdditionalFeaturesHeading": "Fonctionnalités supplémentaires",
         "settingsUserscriptsToggle": "Activer les scripts personnalisés",
         "settingsSeparateTitlebarToggle": null, //missing translation
+		"settingsOpenTabsInForegroundToggle": null, //missing translation
 		"settingsUserscriptsExplanation": {"unsafeHTML": "Les scripts personnalisés vous permettent de modifier le comportement des pages web - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">en savoir plus (en anglais)</a>."},
         "settingsUserAgentToggle": null, //missing translation
         "settingsUpdateNotificationsToggle": "Vérifier automatiquement pour des mises à jour",

--- a/localization/languages/hu.json
+++ b/localization/languages/hu.json
@@ -144,6 +144,7 @@
         "settingsAdditionalFeaturesHeading": "További beállítások",
         "settingsUserscriptsToggle": "Felhasználói szkriptek",
         "settingsSeparateTitlebarToggle": null, //missing translation
+		"settingsOpenTabsInForegroundToggle": null, //missing translation
 		"settingsUserscriptsExplanation": "Felhasználói szkript magyarázat",
         "settingsUserAgentToggle": null, //missing translation
         "settingsUpdateNotificationsToggle": null, //missing translation

--- a/localization/languages/it.json
+++ b/localization/languages/it.json
@@ -144,6 +144,7 @@
         "settingsAdditionalFeaturesHeading": "Funzionalità aggiuntive",
         "settingsUserscriptsToggle": "Abilita script definiti dall'utente",
         "settingsSeparateTitlebarToggle": null, //missing translation
+		"settingsOpenTabsInForegroundToggle": null, //missing translation
 		"settingsUserscriptsExplanation": {"unsafeHTML": "Gli script definiti dall'utente ti permettono di modificare il comportamento dei siti - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">scopri di più</a>."},
         "settingsUserAgentToggle": null, //missing translation
         "settingsUpdateNotificationsToggle": "Controlla automaticamente la presenza di aggiornamenti", 

--- a/localization/languages/ja.json
+++ b/localization/languages/ja.json
@@ -144,6 +144,7 @@
         "settingsAdditionalFeaturesHeading": "追加機能",
         "settingsUserscriptsToggle": "ユーザースクリプトを有効にする",
         "settingsSeparateTitlebarToggle": null, //missing translation
+		"settingsOpenTabsInForegroundToggle": null, //missing translation
 		"settingsUserscriptsExplanation": {"unsafeHTML": "ユーザースクリプトを使用して、Webサイトの動作を変更できます -  <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">詳細</a>。"},
         "settingsUserAgentToggle": "カスタムユーザーエージェントを使用する",
         "settingsUpdateNotificationsToggle": "アップデートを自動的に確認する",

--- a/localization/languages/ko.json
+++ b/localization/languages/ko.json
@@ -144,6 +144,7 @@
         "settingsAdditionalFeaturesHeading": "추가 기능",
         "settingsUserscriptsToggle": "사용자 명령(스크립트) 사용",
         "settingsSeparateTitlebarToggle": "제목 표시줄과 도구 표시줄 사용",
+		"settingsOpenTabsInForegroundToggle": null, //missing translation
 		"settingsUserscriptsExplanation": {"unsafeHTML": "사용자 명령(스크립트)을 사용하면 누리집의 행동을 수정할 수 있습니다. - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">더보기</a>."},
         "settingsUserAgentToggle": "사용자 정의 에이전트(UserAgent) 사용",
         "settingsUpdateNotificationsToggle": "판올림 자동 확인",

--- a/localization/languages/lt.json
+++ b/localization/languages/lt.json
@@ -144,6 +144,7 @@
         "settingsAdditionalFeaturesHeading": "Papildomos ypatybės",
         "settingsUserscriptsToggle": "Įjungti naudotojo scenarijus",
         "settingsSeparateTitlebarToggle": null, //missing translation
+		"settingsOpenTabsInForegroundToggle": null, //missing translation
 		"settingsUserscriptsExplanation": {"unsafeHTML": "Naudotojo scenarijai leidžia jums modifikuoti internetinių svetainių elgseną - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">sužinokite daugiau</a>."},
         "settingsUserAgentToggle": null, //missing translation
         "settingsUpdateNotificationsToggle": "Automatiškai tikrinti ar yra atnaujinimų",

--- a/localization/languages/pl.json
+++ b/localization/languages/pl.json
@@ -144,6 +144,7 @@
         "settingsAdditionalFeaturesHeading": "Dodatkowe funkcje",
         "settingsUserscriptsToggle": "Włącz skrypty użytkownika",
         "settingsSeparateTitlebarToggle": "Użyj osobnego paska tytułu",
+		"settingsOpenTabsInForegroundToggle": null, //missing translation
 		"settingsUserscriptsExplanation": {"unsafeHTML": "Skrypty użytkownika pozwalają modyfikować zachowanie stron internetowych - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">learn more</a>."},
         "settingsUserAgentToggle": "Użyj niestandardowego klienta użytkownika",
         "settingsUpdateNotificationsToggle": "Automatycznie sprawdź dostępność aktualizacji",

--- a/localization/languages/pt-BR.json
+++ b/localization/languages/pt-BR.json
@@ -142,6 +142,7 @@
         "settingsAdditionalFeaturesHeading": "Recursos adicionais",
         "settingsUserscriptsToggle": "Habilitar scripts do usuário",
         "settingsSeparateTitlebarToggle": "Usar a barra de título separada",
+		"settingsOpenTabsInForegroundToggle": null, //missing translation
 		"settingsUserscriptsExplanation": {"unsafeHTML":"Scripts do usuário permitem modificar o comportamento do site - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">Saiba mais</a>."},
 	"settingsUserAgentToggle": "Usar agente de usuário personalizado",
         "settingsUpdateNotificationsToggle": "Verificar atualizações automaticamente",

--- a/localization/languages/pt-PT.json
+++ b/localization/languages/pt-PT.json
@@ -144,6 +144,7 @@
         "settingsAdditionalFeaturesHeading": "Outras funcionalidades",
         "settingsUserscriptsToggle": "Ativar scripts de utilizador",
         "settingsSeparateTitlebarToggle": "Utilizar barra de título separada",
+		"settingsOpenTabsInForegroundToggle": null, //missing translation
 		"settingsUserscriptsExplanation": {"unsafeHTML": "Os scripts permitem-lhe alterar o comportamento dos sites - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">Saber mais</a>."},
         "settingsUserAgentToggle": "Utilizar agente de utilizador personalizado",
         "settingsUpdateNotificationsToggle": "Procurar atualizações automaticamente",

--- a/localization/languages/ru.json
+++ b/localization/languages/ru.json
@@ -144,6 +144,7 @@
         "settingsAdditionalFeaturesHeading": "Дополнительные возможности",
         "settingsUserscriptsToggle": "Пользовательские скрипты",
         "settingsSeparateTitlebarToggle": "Использовать разделитель заголовка",
+		"settingsOpenTabsInForegroundToggle": null, //missing translation
 		"settingsUserscriptsExplanation": {"unsafeHTML": "Пользовательские скрипты позволяют изменять поведение сайтов - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">узнать больше</a>."},
         "settingsUserAgentToggle": "Использовать пользовательский user agent",
         "settingsUpdateNotificationsToggle": "Автоматически проверять наличие обновлений",

--- a/localization/languages/tr_TR.json
+++ b/localization/languages/tr_TR.json
@@ -144,6 +144,7 @@
         "settingsAdditionalFeaturesHeading": "Ek Özellikler",
         "settingsUserscriptsToggle": "Kullanıcı betiklerini etkinleştir",
         "settingsSeparateTitlebarToggle": null, //missing translation
+		"settingsOpenTabsInForegroundToggle": null, //missing translation
 		"settingsUserscriptsExplanation": {"unsafeHTML": "Kullancı betikleri size websitelerinin davranışını değiştirmenize izin verir - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">daha fazla bilgi için</a>."},
         "settingsUserAgentToggle": null, //missing translation
         "settingsUpdateNotificationsToggle": "Güncelleştirmeleri otomatik olarak denetle",

--- a/localization/languages/uk.json
+++ b/localization/languages/uk.json
@@ -145,6 +145,7 @@
         "settingsAdditionalFeaturesHeading": "Додаткові можливості",
         "settingsUserscriptsToggle": "Увімкнути скрипти користувача",
         "settingsSeparateTitlebarToggle": "Використовувати окремий рядок заголовка",
+		"settingsOpenTabsInForegroundToggle": null, //missing translation
 		"settingsUserscriptsExplanation": {"unsafeHTML": "Скрипти користувача дозволяють змінювати поведінку веб-сайтів - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">дізнатися більше</a>."},
         "settingsUserAgentToggle": "Використовувати власний агент користувача",
         "settingsUpdateNotificationsToggle": "Автоматично перевіряти наявність оновлень",

--- a/localization/languages/uz.json
+++ b/localization/languages/uz.json
@@ -146,6 +146,7 @@
 		"settingsAdditionalFeaturesHeading": "Qo'shimcha xususiyatlar",
 		"settingsUserscriptsToggle": "Foydalanuvchi skriptlarini yoqish",
 		"settingsSeparateTitlebarToggle": "Alohida sarlavha paneli ishlatish",
+		"settingsOpenTabsInForegroundToggle": null, //missing translation
 		"settingsUserscriptsExplanation": {
 			"unsafeHTML": "Foydalanuvchi skriptlari sahifa ishlashini o'zgartirishga yordam beradi - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">qo'shimcha ma'lumot</a>."
 		},

--- a/localization/languages/vi.json
+++ b/localization/languages/vi.json
@@ -140,6 +140,7 @@
         "settingsAdditionalFeaturesHeading": "Đặc tính hơn",
         "settingsUserscriptsToggle": "Bật mã script người dùng",
         "settingsSeparateTitlebarToggle": null, //missing translation
+		"settingsOpenTabsInForegroundToggle": null, //missing translation
 		"settingsUserscriptsExplanation": {"unsafeHTML": "Mã script người dùng có thể cho bạn thay đổi hành vi trang web - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">biết thêm</a>."},
         "settingsUserAgentToggle": null, //missing translation
         "settingsUpdateNotificationsToggle": "Tự động kiểm tra cập nhật",

--- a/localization/languages/zh-CN.json
+++ b/localization/languages/zh-CN.json
@@ -144,6 +144,7 @@
         "settingsAdditionalFeaturesHeading": "其他功能",
         "settingsUserscriptsToggle": "允许使用者指令",
         "settingsSeparateTitlebarToggle": null, //missing translation
+		"settingsOpenTabsInForegroundToggle": null, //missing translation
 		"settingsUserscriptsExplanation": {"unsafeHTML": "使用者指令允许您改变网站行为 - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">查看更多</a>."},
         "settingsUserAgentToggle": null, //missing translation
         "settingsUpdateNotificationsToggle": "自动检查更新",

--- a/localization/languages/zh-TW.json
+++ b/localization/languages/zh-TW.json
@@ -144,6 +144,7 @@
         "settingsAdditionalFeaturesHeading": "其他功能",
         "settingsUserscriptsToggle": "允許使用者指令",
         "settingsSeparateTitlebarToggle": "分割標題列",
+		"settingsOpenTabsInForegroundToggle": null, //missing translation
 		"settingsUserscriptsExplanation": {"unsafeHTML": "使用者指令允許您改變網站的行為 - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">查看更多</a>."},
         "settingsUserAgentToggle": "使用自訂使用者代理",
         "settingsUpdateNotificationsToggle": "自動檢查更新",

--- a/pages/settings/index.html
+++ b/pages/settings/index.html
@@ -85,7 +85,7 @@
 			<label for="checkbox-separate-titlebar" data-string="settingsSeparateTitlebarToggle"></label>
 		</div>
 
-		<div class="setting-section" hidden id='section-open-tabs-in-foreground'>
+		<div class="setting-section" id='section-open-tabs-in-foreground'>
 			<input type="checkbox" id="checkbox-open-tabs-in-foreground" />
 			<label for="checkbox-open-tabs-in-foreground" data-string="settingsOpenTabsInForegroundToggle"></label>
 		</div>

--- a/pages/settings/index.html
+++ b/pages/settings/index.html
@@ -85,6 +85,11 @@
 			<label for="checkbox-separate-titlebar" data-string="settingsSeparateTitlebarToggle"></label>
 		</div>
 
+		<div class="setting-section" hidden id='section-open-tabs-in-foreground'>
+			<input type="checkbox" id="checkbox-open-tabs-in-foreground" />
+			<label for="checkbox-open-tabs-in-foreground" data-string="settingsOpenTabsInForegroundToggle"></label>
+		</div>
+
 		<div class="setting-section" id='section-user-agent'>
 			<input type="checkbox" id="checkbox-user-agent" />
 			<label for="checkbox-user-agent" data-string="settingsUserAgentToggle"></label>

--- a/pages/settings/settings.js
+++ b/pages/settings/settings.js
@@ -229,7 +229,6 @@ settings.get('openTabsInForeground', function (value) {
 
 openTabsInForegroundCheckbox.addEventListener('change', function (e) {
   settings.set('openTabsInForeground', this.checked)
-  //showRestartRequiredBanner()
 })
 
 

--- a/pages/settings/settings.js
+++ b/pages/settings/settings.js
@@ -219,6 +219,8 @@ separateTitlebarCheckbox.addEventListener('change', function (e) {
   showRestartRequiredBanner()
 })
 
+/* tabs in foreground setting */
+
 settings.get('openTabsInForeground', function (value) {
   if (value === true) {
     openTabsInForegroundCheckbox.checked = true

--- a/pages/settings/settings.js
+++ b/pages/settings/settings.js
@@ -5,6 +5,7 @@ var banner = document.getElementById('restart-required-banner')
 var siteThemeCheckbox = document.getElementById('checkbox-site-theme')
 var userscriptsCheckbox = document.getElementById('checkbox-userscripts')
 var separateTitlebarCheckbox = document.getElementById('checkbox-separate-titlebar')
+var openTabsInForegroundCheckbox = document.getElementById('checkbox-open-tabs-in-foreground')
 var userAgentCheckbox = document.getElementById('checkbox-user-agent')
 var userAgentInput = document.getElementById('input-user-agent')
 
@@ -217,6 +218,18 @@ separateTitlebarCheckbox.addEventListener('change', function (e) {
   settings.set('useSeparateTitlebar', this.checked)
   showRestartRequiredBanner()
 })
+
+settings.get('openTabsInForeground', function (value) {
+  if (value === true) {
+    openTabsInForegroundCheckbox.checked = true
+  }
+})
+
+openTabsInForegroundCheckbox.addEventListener('change', function (e) {
+  settings.set('openTabsInForeground', this.checked)
+  //showRestartRequiredBanner()
+})
+
 
 /* user agent settting */
 


### PR DESCRIPTION
From issue https://github.com/minbrowser/min/issues/1072

Allows the user to open a new tab and switch to it with CTRL+left.
I'm not quite sure what `disposition` refers to. And this should probably be a user preference instead of a direct change (which I'm not sure how to do).