### PR TITLE
Add a light divider between tabs to increase contrast

### DIFF
--- a/css/tabBar.css
+++ b/css/tabBar.css
@@ -92,6 +92,9 @@ body.linux #menu-button {
 	top: var(--control-space-top) !important;
 	background: rgba(255, 255, 255, 0.8) !important;
 }
+.tab-item:not(:last-child) {
+	border-right: 1px solid rgba(255, 255, 255, 0.4);
+}
 .tab-item:not(.active):hover {
 	background-color: rgba(0, 0, 0, 0.03);
 }

--- a/css/tabBar.css
+++ b/css/tabBar.css
@@ -92,9 +92,15 @@ body.linux #menu-button {
 	top: var(--control-space-top) !important;
 	background: rgba(255, 255, 255, 0.8) !important;
 }
-.tab-item:not(:last-child) {
-	border-right: 1px solid rgba(255, 255, 255, 0.4);
+
+#navbar.show-dividers .tab-item:not(:last-child) {
+	border-right: 1px solid rgba(182, 182, 182, 0.5);
 }
+
+#navbar.show-dividers:before {
+	background: rgba(182, 182, 182, 0.5);
+}
+
 .tab-item:not(.active):hover {
 	background-color: rgba(0, 0, 0, 0.03);
 }

--- a/css/tabBar.css
+++ b/css/tabBar.css
@@ -94,7 +94,10 @@ body.linux #menu-button {
 }
 
 #navbar.show-dividers .tab-item:not(:last-child) {
-	border-right: 1px solid rgba(182, 182, 182, 0.5);
+	border-right: 1px solid rgba(0, 0, 0, 0.15);
+}
+.dark-theme #navbar.show-dividers .tab-item:not(:last-child) {
+	border-right-color: rgba(255, 255, 255, 0.4);
 }
 
 #navbar.show-dividers:before {

--- a/js/navbar/tabBar.js
+++ b/js/navbar/tabBar.js
@@ -1,6 +1,5 @@
 const webviews = require('webviews.js')
 const focusMode = require('focusMode.js')
-const urlParser = require('util/urlParser.js')
 const readerView = require('readerView.js')
 const tabAudio = require('tabAudio.js')
 const dragula = require('dragula')
@@ -13,6 +12,7 @@ const permissionRequests = require('navbar/permissionRequests.js')
 var lastTabDeletion = 0 // TODO get rid of this
 
 const tabBar = {
+  navBar: document.getElementById('navbar'),
   container: document.getElementById('tabs'),
   containerInner: document.getElementById('tabs-inner'),
   tabElementMap: {}, // tabId: tab element
@@ -188,8 +188,19 @@ const tabBar = {
       tabBar.containerInner.removeChild(tabEl)
       delete tabBar.tabElementMap[tabId]
     }
+  },
+  handleDividerPreference: function (dividerPreference) {
+    if (dividerPreference === true) {
+      tabBar.navBar.classList.add('show-dividers')
+    } else {
+      tabBar.navBar.classList.remove('show-dividers')
+    }
   }
 }
+
+settings.listen('showDividerBetweenTabs', function (dividerPreference) {
+  tabBar.handleDividerPreference(dividerPreference)
+})
 
 /* progress bar events */
 

--- a/localization/languages/ar.json
+++ b/localization/languages/ar.json
@@ -147,7 +147,7 @@
         "settingsDarkModeNight": null, //"At night" missing translation
         "settingsDarkModeAlways": null, //"Always" missing translation
         "settingsSiteThemeToggle": null, //missing translation
-        "settingsShowDividerToggle": "إظهار الحاجز بين علامات التبويب",
+        "settingsShowDividerToggle": null, // Missing translation
         "settingsAdditionalFeaturesHeading": "مميزات اضافية",
         "settingsUserscriptsToggle": "تمكين سكريبت المستخدم",
         "settingsSeparateTitlebarToggle": null, //missing translation

--- a/localization/languages/ar.json
+++ b/localization/languages/ar.json
@@ -147,6 +147,7 @@
         "settingsDarkModeNight": null, //"At night" missing translation
         "settingsDarkModeAlways": null, //"Always" missing translation
         "settingsSiteThemeToggle": null, //missing translation
+        "settingsShowDividerToggle": "إظهار الحاجز بين علامات التبويب",
         "settingsAdditionalFeaturesHeading": "مميزات اضافية",
         "settingsUserscriptsToggle": "تمكين سكريبت المستخدم",
         "settingsSeparateTitlebarToggle": null, //missing translation

--- a/localization/languages/bn.json
+++ b/localization/languages/bn.json
@@ -149,6 +149,7 @@
         "settingsSiteThemeToggle": null, //missing translation
         "settingsAdditionalFeaturesHeading": "অতিরিক্ত বৈশিষ্ট্য",
         "settingsUserscriptsToggle": "ব্যবহারকারী স্ক্রিপ্ট সক্রিয় করুন",
+        "settingsShowDividerToggle": "ট্যাবগুলির মধ্যে বিভাজক দেখান",
         "settingsSeparateTitlebarToggle": null, //missing translation
         "settingsOpenTabsInForegroundToggle": null, //missing translation
         "settingsUserscriptsExplanation": {

--- a/localization/languages/bn.json
+++ b/localization/languages/bn.json
@@ -149,7 +149,7 @@
         "settingsSiteThemeToggle": null, //missing translation
         "settingsAdditionalFeaturesHeading": "অতিরিক্ত বৈশিষ্ট্য",
         "settingsUserscriptsToggle": "ব্যবহারকারী স্ক্রিপ্ট সক্রিয় করুন",
-        "settingsShowDividerToggle": "ট্যাবগুলির মধ্যে বিভাজক দেখান",
+        "settingsShowDividerToggle": null, //missing translation
         "settingsSeparateTitlebarToggle": null, //missing translation
         "settingsOpenTabsInForegroundToggle": null, //missing translation
         "settingsUserscriptsExplanation": {

--- a/localization/languages/cs.json
+++ b/localization/languages/cs.json
@@ -149,6 +149,7 @@
         "settingsSiteThemeToggle": "Povolit motiv webu",
         "settingsAdditionalFeaturesHeading": "Další funkce",
         "settingsUserscriptsToggle": "Povolit uživatelské skripty",
+        "settingsShowDividerToggle": "Zobrazit dělič mezi kartami",
         "settingsSeparateTitlebarToggle": "Použít systémové záhlaví okna",
         "settingsOpenTabsInForegroundToggle": "Ihned přepínat na nově otevřené karty",
         "settingsUserscriptsExplanation": {

--- a/localization/languages/cs.json
+++ b/localization/languages/cs.json
@@ -149,7 +149,7 @@
         "settingsSiteThemeToggle": "Povolit motiv webu",
         "settingsAdditionalFeaturesHeading": "Další funkce",
         "settingsUserscriptsToggle": "Povolit uživatelské skripty",
-        "settingsShowDividerToggle": "Zobrazit dělič mezi kartami",
+        "settingsShowDividerToggle": null, //missing translation
         "settingsSeparateTitlebarToggle": "Použít systémové záhlaví okna",
         "settingsOpenTabsInForegroundToggle": "Ihned přepínat na nově otevřené karty",
         "settingsUserscriptsExplanation": {

--- a/localization/languages/de.json
+++ b/localization/languages/de.json
@@ -149,7 +149,7 @@
         "settingsSiteThemeToggle": null, //missing translation
         "settingsAdditionalFeaturesHeading": null, //missing translation
         "settingsUserscriptsToggle": null, //missing translation
-        "settingsShowDividerToggle": "Teiler zwischen Registerkarten anzeigen",
+        "settingsShowDividerToggle": null, // Missing translation
         "settingsSeparateTitlebarToggle": null, //missing translation
         "settingsOpenTabsInForegroundToggle": null, //missing translation
         "settingsUserscriptsExplanation": null, //missing translation

--- a/localization/languages/de.json
+++ b/localization/languages/de.json
@@ -149,6 +149,7 @@
         "settingsSiteThemeToggle": null, //missing translation
         "settingsAdditionalFeaturesHeading": null, //missing translation
         "settingsUserscriptsToggle": null, //missing translation
+        "settingsShowDividerToggle": "Teiler zwischen Registerkarten anzeigen",
         "settingsSeparateTitlebarToggle": null, //missing translation
         "settingsOpenTabsInForegroundToggle": null, //missing translation
         "settingsUserscriptsExplanation": null, //missing translation

--- a/localization/languages/en-US.json
+++ b/localization/languages/en-US.json
@@ -149,6 +149,7 @@
         "settingsSiteThemeToggle": "Enable site theme",
         "settingsAdditionalFeaturesHeading": "Additional Features",
         "settingsUserscriptsToggle": "Enable user scripts",
+        "settingsShowDividerToggle": "Show divider between tabs",
         "settingsSeparateTitlebarToggle": "Use separate title bar",
         "settingsOpenTabsInForegroundToggle": "Open new tabs in the foreground",
         "settingsUserscriptsExplanation": {

--- a/localization/languages/es.json
+++ b/localization/languages/es.json
@@ -149,6 +149,7 @@
         "settingsSiteThemeToggle": null, //missing translation
         "settingsAdditionalFeaturesHeading": null, //missing translation
         "settingsUserscriptsToggle": null, //missing translation
+        "settingsShowDividerToggle": "Mostrar divisor entre pestañas",
         "settingsSeparateTitlebarToggle": null, //missing translation
         "settingsOpenTabsInForegroundToggle": null, //missing translation
         "settingsUserscriptsExplanation": null, //missing translation

--- a/localization/languages/es.json
+++ b/localization/languages/es.json
@@ -149,7 +149,7 @@
         "settingsSiteThemeToggle": null, //missing translation
         "settingsAdditionalFeaturesHeading": null, //missing translation
         "settingsUserscriptsToggle": null, //missing translation
-        "settingsShowDividerToggle": "Mostrar divisor entre pestañas",
+        "settingsShowDividerToggle": null, // Missing translation
         "settingsSeparateTitlebarToggle": null, //missing translation
         "settingsOpenTabsInForegroundToggle": null, //missing translation
         "settingsUserscriptsExplanation": null, //missing translation

--- a/localization/languages/fa.json
+++ b/localization/languages/fa.json
@@ -149,7 +149,7 @@
         "settingsSiteThemeToggle": null, //missing translation
         "settingsAdditionalFeaturesHeading": "امکانات اضافه",
         "settingsUserscriptsToggle": "فعال کردن اسکریپت های کاربر",
-        "settingsShowDividerToggle": "تقسیم بین برگه ها را نشان دهید",
+        "settingsShowDividerToggle": null, // Missing translation
         "settingsSeparateTitlebarToggle": null, //missing translation
         "settingsOpenTabsInForegroundToggle": null, //missing translation
         "settingsUserscriptsExplanation": {

--- a/localization/languages/fa.json
+++ b/localization/languages/fa.json
@@ -149,6 +149,7 @@
         "settingsSiteThemeToggle": null, //missing translation
         "settingsAdditionalFeaturesHeading": "امکانات اضافه",
         "settingsUserscriptsToggle": "فعال کردن اسکریپت های کاربر",
+        "settingsShowDividerToggle": "تقسیم بین برگه ها را نشان دهید",
         "settingsSeparateTitlebarToggle": null, //missing translation
         "settingsOpenTabsInForegroundToggle": null, //missing translation
         "settingsUserscriptsExplanation": {

--- a/localization/languages/fr.json
+++ b/localization/languages/fr.json
@@ -149,7 +149,7 @@
         "settingsSiteThemeToggle": null, //missing translation
         "settingsAdditionalFeaturesHeading": "Fonctionnalités supplémentaires",
         "settingsUserscriptsToggle": "Activer les scripts personnalisés",
-        "settingsShowDividerToggle": "Afficher le séparateur entre les onglets",
+        "settingsShowDividerToggle": null, // Missing translation
         "settingsSeparateTitlebarToggle": null, //missing translation
         "settingsOpenTabsInForegroundToggle": null, //missing translation
         "settingsUserscriptsExplanation": {

--- a/localization/languages/fr.json
+++ b/localization/languages/fr.json
@@ -149,6 +149,7 @@
         "settingsSiteThemeToggle": null, //missing translation
         "settingsAdditionalFeaturesHeading": "Fonctionnalités supplémentaires",
         "settingsUserscriptsToggle": "Activer les scripts personnalisés",
+        "settingsShowDividerToggle": "Afficher le séparateur entre les onglets",
         "settingsSeparateTitlebarToggle": null, //missing translation
         "settingsOpenTabsInForegroundToggle": null, //missing translation
         "settingsUserscriptsExplanation": {

--- a/localization/languages/hu.json
+++ b/localization/languages/hu.json
@@ -149,7 +149,7 @@
         "settingsSiteThemeToggle": null, //missing translation
         "settingsAdditionalFeaturesHeading": "További beállítások",
         "settingsUserscriptsToggle": "Felhasználói szkriptek",
-        "settingsShowDividerToggle": "Az elválasztó megjelenítése a fülek között",
+        "settingsShowDividerToggle": null, // Missing translation
         "settingsSeparateTitlebarToggle": null, //missing translation
         "settingsOpenTabsInForegroundToggle": null, //missing translation
         "settingsUserscriptsExplanation": "Felhasználói szkript magyarázat",

--- a/localization/languages/hu.json
+++ b/localization/languages/hu.json
@@ -149,6 +149,7 @@
         "settingsSiteThemeToggle": null, //missing translation
         "settingsAdditionalFeaturesHeading": "További beállítások",
         "settingsUserscriptsToggle": "Felhasználói szkriptek",
+        "settingsShowDividerToggle": "Az elválasztó megjelenítése a fülek között",
         "settingsSeparateTitlebarToggle": null, //missing translation
         "settingsOpenTabsInForegroundToggle": null, //missing translation
         "settingsUserscriptsExplanation": "Felhasználói szkript magyarázat",

--- a/localization/languages/it.json
+++ b/localization/languages/it.json
@@ -149,6 +149,7 @@
         "settingsSiteThemeToggle": "Abilita tema adattivo (si adatta al sito)",
         "settingsAdditionalFeaturesHeading": "Funzionalità aggiuntive",
         "settingsUserscriptsToggle": "Abilita script definiti dall'utente",
+        "settingsShowDividerToggle": "Mostra il divisore tra le schede",
         "settingsSeparateTitlebarToggle": null, //missing translation
         "settingsOpenTabsInForegroundToggle": null, //missing translation
         "settingsUserscriptsExplanation": {

--- a/localization/languages/it.json
+++ b/localization/languages/it.json
@@ -149,7 +149,7 @@
         "settingsSiteThemeToggle": "Abilita tema adattivo (si adatta al sito)",
         "settingsAdditionalFeaturesHeading": "Funzionalità aggiuntive",
         "settingsUserscriptsToggle": "Abilita script definiti dall'utente",
-        "settingsShowDividerToggle": "Mostra il divisore tra le schede",
+        "settingsShowDividerToggle": null, // Missing translation
         "settingsSeparateTitlebarToggle": null, //missing translation
         "settingsOpenTabsInForegroundToggle": null, //missing translation
         "settingsUserscriptsExplanation": {

--- a/localization/languages/ja.json
+++ b/localization/languages/ja.json
@@ -149,7 +149,7 @@
         "settingsSiteThemeToggle": "サイトテーマを有効にする",
         "settingsAdditionalFeaturesHeading": "追加機能",
         "settingsUserscriptsToggle": "ユーザースクリプトを有効にする",
-        "settingsShowDividerToggle": "タブ間の仕切りを表示",
+        "settingsShowDividerToggle": null, // Missing translation
         "settingsSeparateTitlebarToggle": "別のタイトルバーを使用する",
         "settingsOpenTabsInForegroundToggle": "フォアグラウンドで新しいタブを開く",
         "settingsUserscriptsExplanation": {

--- a/localization/languages/ja.json
+++ b/localization/languages/ja.json
@@ -149,6 +149,7 @@
         "settingsSiteThemeToggle": "サイトテーマを有効にする",
         "settingsAdditionalFeaturesHeading": "追加機能",
         "settingsUserscriptsToggle": "ユーザースクリプトを有効にする",
+        "settingsShowDividerToggle": "タブ間の仕切りを表示",
         "settingsSeparateTitlebarToggle": "別のタイトルバーを使用する",
         "settingsOpenTabsInForegroundToggle": "フォアグラウンドで新しいタブを開く",
         "settingsUserscriptsExplanation": {

--- a/localization/languages/ko.json
+++ b/localization/languages/ko.json
@@ -149,7 +149,7 @@
         "settingsSiteThemeToggle": "누리집 색상 주제 사용",
         "settingsAdditionalFeaturesHeading": "추가 기능",
         "settingsUserscriptsToggle": "사용자 명령(스크립트) 사용",
-        "settingsShowDividerToggle": "탭 사이에 구분선 표시",
+        "settingsShowDividerToggle": null, // Missing translation
         "settingsSeparateTitlebarToggle": "제목 표시줄과 도구 표시줄 사용",
         "settingsOpenTabsInForegroundToggle": "작업을 열 때 전면(Foreground)으로 열기",
         "settingsUserscriptsExplanation": {

--- a/localization/languages/ko.json
+++ b/localization/languages/ko.json
@@ -149,6 +149,7 @@
         "settingsSiteThemeToggle": "누리집 색상 주제 사용",
         "settingsAdditionalFeaturesHeading": "추가 기능",
         "settingsUserscriptsToggle": "사용자 명령(스크립트) 사용",
+        "settingsShowDividerToggle": "탭 사이에 구분선 표시",
         "settingsSeparateTitlebarToggle": "제목 표시줄과 도구 표시줄 사용",
         "settingsOpenTabsInForegroundToggle": "작업을 열 때 전면(Foreground)으로 열기",
         "settingsUserscriptsExplanation": {

--- a/localization/languages/lt.json
+++ b/localization/languages/lt.json
@@ -149,7 +149,7 @@
         "settingsSiteThemeToggle": null, //missing translation
         "settingsAdditionalFeaturesHeading": "Papildomos ypatybės",
         "settingsUserscriptsToggle": "Įjungti naudotojo scenarijus",
-        "settingsShowDividerToggle": "Rodyti skirtuką tarp skirtukų",
+        "settingsShowDividerToggle": null, // Missing translation
         "settingsSeparateTitlebarToggle": null, //missing translation
         "settingsOpenTabsInForegroundToggle": null, //missing translation
         "settingsUserscriptsExplanation": {

--- a/localization/languages/lt.json
+++ b/localization/languages/lt.json
@@ -149,6 +149,7 @@
         "settingsSiteThemeToggle": null, //missing translation
         "settingsAdditionalFeaturesHeading": "Papildomos ypatybės",
         "settingsUserscriptsToggle": "Įjungti naudotojo scenarijus",
+        "settingsShowDividerToggle": "Rodyti skirtuką tarp skirtukų",
         "settingsSeparateTitlebarToggle": null, //missing translation
         "settingsOpenTabsInForegroundToggle": null, //missing translation
         "settingsUserscriptsExplanation": {

--- a/localization/languages/pl.json
+++ b/localization/languages/pl.json
@@ -149,6 +149,7 @@
         "settingsSiteThemeToggle": "Włącz motyw witryny",
         "settingsAdditionalFeaturesHeading": "Dodatkowe funkcje",
         "settingsUserscriptsToggle": "Włącz skrypty użytkownika",
+        "settingsShowDividerToggle": "Pokaż dzielnik między kartami",
         "settingsSeparateTitlebarToggle": "Użyj osobnego paska tytułu",
         "settingsOpenTabsInForegroundToggle": "Otwórz nowe karty na pierwszym planie",
         "settingsUserscriptsExplanation": {

--- a/localization/languages/pl.json
+++ b/localization/languages/pl.json
@@ -149,7 +149,7 @@
         "settingsSiteThemeToggle": "Włącz motyw witryny",
         "settingsAdditionalFeaturesHeading": "Dodatkowe funkcje",
         "settingsUserscriptsToggle": "Włącz skrypty użytkownika",
-        "settingsShowDividerToggle": "Pokaż dzielnik między kartami",
+        "settingsShowDividerToggle": null, // Missing translation
         "settingsSeparateTitlebarToggle": "Użyj osobnego paska tytułu",
         "settingsOpenTabsInForegroundToggle": "Otwórz nowe karty na pierwszym planie",
         "settingsUserscriptsExplanation": {

--- a/localization/languages/pt-BR.json
+++ b/localization/languages/pt-BR.json
@@ -149,7 +149,7 @@
         "settingsSiteThemeToggle": "Habilitar mudanças de cores na barra de endereços",
         "settingsAdditionalFeaturesHeading": "Recursos adicionais",
         "settingsUserscriptsToggle": "Habilitar scripts do usuário",
-        "settingsShowDividerToggle": "Mostrar divisor entre guias",
+        "settingsShowDividerToggle": null, // Missing translation
         "settingsSeparateTitlebarToggle": "Usar a barra de título separada",
         "settingsOpenTabsInForegroundToggle": "Abrir novas guias em primeiro plano",
         "settingsUserscriptsExplanation": {

--- a/localization/languages/pt-BR.json
+++ b/localization/languages/pt-BR.json
@@ -149,6 +149,7 @@
         "settingsSiteThemeToggle": "Habilitar mudanças de cores na barra de endereços",
         "settingsAdditionalFeaturesHeading": "Recursos adicionais",
         "settingsUserscriptsToggle": "Habilitar scripts do usuário",
+        "settingsShowDividerToggle": "Mostrar divisor entre guias",
         "settingsSeparateTitlebarToggle": "Usar a barra de título separada",
         "settingsOpenTabsInForegroundToggle": "Abrir novas guias em primeiro plano",
         "settingsUserscriptsExplanation": {

--- a/localization/languages/pt-PT.json
+++ b/localization/languages/pt-PT.json
@@ -149,7 +149,7 @@
         "settingsSiteThemeToggle": "Ativar tema do site",
         "settingsAdditionalFeaturesHeading": "Outras funcionalidades",
         "settingsUserscriptsToggle": "Ativar scripts de utilizador",
-        "settingsShowDividerToggle": "Mostrar divisor entre guias",
+        "settingsShowDividerToggle": null, // Missing translation
         "settingsSeparateTitlebarToggle": "Utilizar barra de título separada",
         "settingsOpenTabsInForegroundToggle": "Abrir novos separadores em primeiro plano",
         "settingsUserscriptsExplanation": {

--- a/localization/languages/pt-PT.json
+++ b/localization/languages/pt-PT.json
@@ -149,6 +149,7 @@
         "settingsSiteThemeToggle": "Ativar tema do site",
         "settingsAdditionalFeaturesHeading": "Outras funcionalidades",
         "settingsUserscriptsToggle": "Ativar scripts de utilizador",
+        "settingsShowDividerToggle": "Mostrar divisor entre guias",
         "settingsSeparateTitlebarToggle": "Utilizar barra de título separada",
         "settingsOpenTabsInForegroundToggle": "Abrir novos separadores em primeiro plano",
         "settingsUserscriptsExplanation": {

--- a/localization/languages/ru.json
+++ b/localization/languages/ru.json
@@ -149,7 +149,7 @@
         "settingsSiteThemeToggle": "Использовать тему сайта",
         "settingsAdditionalFeaturesHeading": "Дополнительные возможности",
         "settingsUserscriptsToggle": "Пользовательские скрипты",
-        "settingsShowDividerToggle": "Показать разделитель между вкладками",
+        "settingsShowDividerToggle": null, // Missing translation
         "settingsSeparateTitlebarToggle": "Использовать разделитель заголовка",
         "settingsOpenTabsInForegroundToggle": "Открывать новые вкладки на переднем плане",
         "settingsUserscriptsExplanation": {

--- a/localization/languages/ru.json
+++ b/localization/languages/ru.json
@@ -149,6 +149,7 @@
         "settingsSiteThemeToggle": "Использовать тему сайта",
         "settingsAdditionalFeaturesHeading": "Дополнительные возможности",
         "settingsUserscriptsToggle": "Пользовательские скрипты",
+        "settingsShowDividerToggle": "Показать разделитель между вкладками",
         "settingsSeparateTitlebarToggle": "Использовать разделитель заголовка",
         "settingsOpenTabsInForegroundToggle": "Открывать новые вкладки на переднем плане",
         "settingsUserscriptsExplanation": {

--- a/localization/languages/tr.json
+++ b/localization/languages/tr.json
@@ -155,7 +155,7 @@
         "settingsUserscriptsExplanation": {
             "unsafeHTML": "Kullancı betikleri size websitelerinin davranışını değiştirmenize izin verir - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">daha fazla bilgi için</a>."
         },
-        "settingsUserAgentToggle": "Özel kullanıcı aracısı kullan"
+        "settingsUserAgentToggle": "Özel kullanıcı aracısı kullan",
         "settingsUpdateNotificationsToggle": "Güncelleştirmeleri otomatik olarak denetle",
         "settingsSearchEngineHeading": "Arama Motoru",
         "settingsDefaultSearchEngine": "Bir varsayılan arama motoru seçin:",
@@ -235,7 +235,7 @@
         "downloadStateCompleted": "Tamamlandı",
         "downloadStateFailed": "Başarısız oldu",
         /* Update Notifications */
-        "updateNotificationTitle": "Min'in yeni bir sürümü mevcut"
+        "updateNotificationTitle": "Min'in yeni bir sürümü mevcut",
         /* Autofill settings */
         "settingsPasswordAutoFillHeadline": "Parola Otomatik Doldurma",
         "settingsSelectPasswordManager": "Desteklenen parola yöneticilerinden birini seçin:",

--- a/localization/languages/tr.json
+++ b/localization/languages/tr.json
@@ -149,7 +149,7 @@
         "settingsSiteThemeToggle": "Site temasını etkinleştir",
         "settingsAdditionalFeaturesHeading": "Ek Özellikler",
         "settingsUserscriptsToggle": "Kullanıcı betiklerini etkinleştir",
-        "settingsShowDividerToggle": "Sekmeler arasındaki ayırıcıyı göster",
+        "settingsShowDividerToggle": null, //missing translation
         "settingsSeparateTitlebarToggle": "Ayrılmış başlık çubuğu kullan",
         "settingsOpenTabsInForegroundToggle": "Yeni sekmeleri önplanda aç",
         "settingsUserscriptsExplanation": {

--- a/localization/languages/tr.json
+++ b/localization/languages/tr.json
@@ -149,6 +149,7 @@
         "settingsSiteThemeToggle": "Site temasını etkinleştir",
         "settingsAdditionalFeaturesHeading": "Ek Özellikler",
         "settingsUserscriptsToggle": "Kullanıcı betiklerini etkinleştir",
+        "settingsShowDividerToggle": "Sekmeler arasındaki ayırıcıyı göster",
         "settingsSeparateTitlebarToggle": "Ayrılmış başlık çubuğu kullan",
         "settingsOpenTabsInForegroundToggle": "Yeni sekmeleri önplanda aç",
         "settingsUserscriptsExplanation": {

--- a/localization/languages/uk.json
+++ b/localization/languages/uk.json
@@ -150,7 +150,7 @@
         "settingsSiteThemeToggle": "Увімкнути тему сайту",
         "settingsAdditionalFeaturesHeading": "Додаткові можливості",
         "settingsUserscriptsToggle": "Увімкнути скрипти користувача",
-        "settingsShowDividerToggle": "Показати роздільник між вкладками",
+        "settingsShowDividerToggle": null, // Missing translation
         "settingsSeparateTitlebarToggle": "Використовувати окремий рядок заголовка",
         "settingsOpenTabsInForegroundToggle": "Відкриватии нові вкладки на передньому плані",
         "settingsUserscriptsExplanation": {

--- a/localization/languages/uk.json
+++ b/localization/languages/uk.json
@@ -18,7 +18,7 @@
         "copyLink": "Копіювати посилання",
         "copyEmailAddress": "Копіювати адресу електронної пошти",
         "selectAll": "Вибрати все",
-        "undo": "Скасувати",
+        "undo": "   ",
         "redo": "Повторити",
         "cut": "Вирізати",
         "copy": "Копіювати", //this is a verb (as in "copy the currently-selected text")
@@ -150,6 +150,7 @@
         "settingsSiteThemeToggle": "Увімкнути тему сайту",
         "settingsAdditionalFeaturesHeading": "Додаткові можливості",
         "settingsUserscriptsToggle": "Увімкнути скрипти користувача",
+        "settingsShowDividerToggle": "Показати роздільник між вкладками",
         "settingsSeparateTitlebarToggle": "Використовувати окремий рядок заголовка",
         "settingsOpenTabsInForegroundToggle": "Відкриватии нові вкладки на передньому плані",
         "settingsUserscriptsExplanation": {

--- a/localization/languages/uk.json
+++ b/localization/languages/uk.json
@@ -18,7 +18,7 @@
         "copyLink": "Копіювати посилання",
         "copyEmailAddress": "Копіювати адресу електронної пошти",
         "selectAll": "Вибрати все",
-        "undo": "   ",
+        "undo": "Скасувати",
         "redo": "Повторити",
         "cut": "Вирізати",
         "copy": "Копіювати", //this is a verb (as in "copy the currently-selected text")

--- a/localization/languages/uz.json
+++ b/localization/languages/uz.json
@@ -149,7 +149,7 @@
         "settingsSiteThemeToggle": "Sahifa mavzusini yoqish",
         "settingsAdditionalFeaturesHeading": "Qo'shimcha xususiyatlar",
         "settingsUserscriptsToggle": "Foydalanuvchi skriptlarini yoqish",
-        "settingsShowDividerToggle": "Yorliqlar orasidagi bo'linishni ko'rsating",
+        "settingsShowDividerToggle": null, //missing translation
         "settingsSeparateTitlebarToggle": "Alohida sarlavha paneli ishlatish",
         "settingsOpenTabsInForegroundToggle": null, //missing translation
         "settingsUserscriptsExplanation": {

--- a/localization/languages/uz.json
+++ b/localization/languages/uz.json
@@ -149,6 +149,7 @@
         "settingsSiteThemeToggle": "Sahifa mavzusini yoqish",
         "settingsAdditionalFeaturesHeading": "Qo'shimcha xususiyatlar",
         "settingsUserscriptsToggle": "Foydalanuvchi skriptlarini yoqish",
+        "settingsShowDividerToggle": "Yorliqlar orasidagi bo'linishni ko'rsating",
         "settingsSeparateTitlebarToggle": "Alohida sarlavha paneli ishlatish",
         "settingsOpenTabsInForegroundToggle": null, //missing translation
         "settingsUserscriptsExplanation": {

--- a/localization/languages/vi.json
+++ b/localization/languages/vi.json
@@ -143,6 +143,7 @@
         "settingsSiteThemeToggle": "Bật chủ đề trang",
         "settingsAdditionalFeaturesHeading": "Đặc tính hơn",
         "settingsUserscriptsToggle": "Bật mã script người dùng",
+        "settingsShowDividerToggle": "Hiển thị dải phân cách giữa các tab",
         "settingsSeparateTitlebarToggle": null, //missing translation
         "settingsOpenTabsInForegroundToggle": null, //missing translation
         "settingsUserscriptsExplanation": {

--- a/localization/languages/vi.json
+++ b/localization/languages/vi.json
@@ -143,7 +143,7 @@
         "settingsSiteThemeToggle": "Bật chủ đề trang",
         "settingsAdditionalFeaturesHeading": "Đặc tính hơn",
         "settingsUserscriptsToggle": "Bật mã script người dùng",
-        "settingsShowDividerToggle": "Hiển thị dải phân cách giữa các tab",
+        "settingsShowDividerToggle": null, // Missing translation
         "settingsSeparateTitlebarToggle": null, //missing translation
         "settingsOpenTabsInForegroundToggle": null, //missing translation
         "settingsUserscriptsExplanation": {

--- a/localization/languages/zh-CN.json
+++ b/localization/languages/zh-CN.json
@@ -149,7 +149,7 @@
         "settingsSiteThemeToggle": "启用网站主题",
         "settingsAdditionalFeaturesHeading": "其他功能",
         "settingsUserscriptsToggle": "允许使用者指令",
-        "settingsShowDividerToggle": "显示标签之间的分隔线",
+        "settingsShowDividerToggle": null, // Missing translation
         "settingsSeparateTitlebarToggle": null, //missing translation
         "settingsOpenTabsInForegroundToggle": null, //missing translation
         "settingsUserscriptsExplanation": {

--- a/localization/languages/zh-CN.json
+++ b/localization/languages/zh-CN.json
@@ -149,6 +149,7 @@
         "settingsSiteThemeToggle": "启用网站主题",
         "settingsAdditionalFeaturesHeading": "其他功能",
         "settingsUserscriptsToggle": "允许使用者指令",
+        "settingsShowDividerToggle": "显示标签之间的分隔线",
         "settingsSeparateTitlebarToggle": null, //missing translation
         "settingsOpenTabsInForegroundToggle": null, //missing translation
         "settingsUserscriptsExplanation": {

--- a/localization/languages/zh-TW.json
+++ b/localization/languages/zh-TW.json
@@ -149,6 +149,7 @@
         "settingsSiteThemeToggle": "啟用網站主題",
         "settingsAdditionalFeaturesHeading": "其他功能",
         "settingsUserscriptsToggle": "允許使用者指令",
+        "settingsShowDividerToggle": "顯示標籤之間的分隔線",
         "settingsSeparateTitlebarToggle": "分割標題列",
         "settingsOpenTabsInForegroundToggle": null, //missing translation
         "settingsUserscriptsExplanation": {

--- a/localization/languages/zh-TW.json
+++ b/localization/languages/zh-TW.json
@@ -149,7 +149,7 @@
         "settingsSiteThemeToggle": "啟用網站主題",
         "settingsAdditionalFeaturesHeading": "其他功能",
         "settingsUserscriptsToggle": "允許使用者指令",
-        "settingsShowDividerToggle": "顯示標籤之間的分隔線",
+        "settingsShowDividerToggle": null, // Missing translation
         "settingsSeparateTitlebarToggle": "分割標題列",
         "settingsOpenTabsInForegroundToggle": null, //missing translation
         "settingsUserscriptsExplanation": {

--- a/pages/settings/index.html
+++ b/pages/settings/index.html
@@ -75,7 +75,12 @@
 		<div class="setting-section">
 			<input type="checkbox" id="checkbox-site-theme" />
 			<label for="checkbox-site-theme" data-string="settingsSiteThemeToggle"></label>
-		</div> 
+		</div>
+
+		<div class="setting-section">
+			<input type="checkbox" id="checkbox-show-divider" />
+			<label for="checkbox-show-divider" data-string="settingsShowDividerToggle"></label>
+		</div>
 	</div>
 
 	<div class="settings-container" id="additional-settings-container">

--- a/pages/settings/settings.js
+++ b/pages/settings/settings.js
@@ -3,6 +3,7 @@ document.title = l('settingsPreferencesHeading') + ' | Min'
 var contentTypeBlockingContainer = document.getElementById('content-type-blocking')
 var banner = document.getElementById('restart-required-banner')
 var siteThemeCheckbox = document.getElementById('checkbox-site-theme')
+var showDividerCheckbox = document.getElementById('checkbox-show-divider')
 var userscriptsCheckbox = document.getElementById('checkbox-userscripts')
 var separateTitlebarCheckbox = document.getElementById('checkbox-separate-titlebar')
 var openTabsInForegroundCheckbox = document.getElementById('checkbox-open-tabs-in-foreground')
@@ -217,6 +218,18 @@ settings.get('userscriptsEnabled', function (value) {
 
 userscriptsCheckbox.addEventListener('change', function (e) {
   settings.set('userscriptsEnabled', this.checked)
+})
+
+/* show divider between tabs setting */
+
+settings.get('showDividerBetweenTabs', function (value) {
+  if (value === true) {
+    showDividerCheckbox.checked = true
+  }
+})
+
+showDividerCheckbox.addEventListener('change', function (e) {
+  settings.set('showDividerBetweenTabs', this.checked)
 })
 
 /* separate titlebar setting */


### PR DESCRIPTION
It was quite hard for me to see how many tabs I had open so I added a light divider between the tabs to improve that contrast.

**Before**
<img width="1678" alt="Screenshot 2020-07-04 at 13 32 06" src="https://user-images.githubusercontent.com/45388384/86511577-cf8fc180-bdfa-11ea-9fe2-dd6dbe78aac4.png">

**After**
<img width="1680" alt="Screenshot 2020-07-04 at 13 28 07" src="https://user-images.githubusercontent.com/45388384/86511585-dae2ed00-bdfa-11ea-9fbb-936140b1e514.png">

If this doesn't suit the idea of having a minimalistic browser I could probaly make this an optional feature in the users preferences.
Let me know what you think 😁
