### PR TITLE
Some content blocking improvements

### DIFF
--- a/ext/filterLists/updateEasylist.js
+++ b/ext/filterLists/updateEasylist.js
@@ -41,7 +41,13 @@ makeRequest(easylistOptions, function (easylist) {
   makeRequest(easyprivacyOptions, function (easyprivacy) {
     var data = easylist + easyprivacy
 
-    data = data.replace(/.*##.+\n/g, '')
+    data = data.split('\n').filter(function (line) {
+      return (
+        !line.includes('##') && // element hiding rules
+        !line.includes('#@') && // element hiding exceptions
+        !line.trim().startsWith('!') // comments
+      )
+    }).join('\n')
 
     fs.writeFileSync(filePath, data)
   })

--- a/localization/languages/ar.json
+++ b/localization/languages/ar.json
@@ -135,9 +135,10 @@
         "settingsContentBlockingExceptions": "سيظل مسموحًا بعرض الاعلانات على هده المواقع",
         "settingsBlockScriptsToggle": "منع السكريبت",
         "settingsBlockImagesToggle": "منع الصور",
-        "settingsEasyListCredit": {
-             "unsafeHTML": " استنادا الى EasyList و EasyPrivacy, التي تم انشائها من طرف <a target=\"_blank\" href=\"https://easylist.to/\"> EasyList المؤلفون ل</a> (<a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/3.0/legalcode\">مشاهدة الترخيص</a>)." 
-            },
+        "settingsBlockedRequestCount": {
+            "unsafeHTML": null //missing translation
+        },
+        "settingsCustomizeFiltersLink": null, //missing translation
         "settingsAppearanceHeading": "تفضيلات",
         "settingsEnableDarkMode": null, //"Enable dark mode:" missing translation
         "settingsDarkModeNever": null, //"Never" missing translation

--- a/localization/languages/bg.json
+++ b/localization/languages/bg.json
@@ -135,9 +135,10 @@
         "settingsContentBlockingExceptions": "Реклами ще бъдат позволени на тези уеб сайтове:",
         "settingsBlockScriptsToggle": "Блокиране на скриптове",
         "settingsBlockImagesToggle": "Блокиране на изображения",
-        "settingsEasyListCredit": {
-            "unsafeHTML": "Базирано на EasyList и EasyPrivacy, създадено от <a target=\"_blank\" href=\"https://easylist.to/\">EasyList авторите</a> (<a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/3.0/legalcode\">вижте лиценз</a>)."
+        "settingsBlockedRequestCount": {
+            "unsafeHTML": null //missing translation
         },
+        "settingsCustomizeFiltersLink": null, //missing translation
         "settingsAppearanceHeading": "Изглед",
         "settingsEnableDarkMode": "Активиране на тъмен режим:",
         "settingsDarkModeNever": "Никога",

--- a/localization/languages/bn.json
+++ b/localization/languages/bn.json
@@ -135,9 +135,10 @@
       "settingsContentBlockingExceptions": null, //missing translation
       "settingsBlockScriptsToggle":"স্ক্রিপ্ট ব্লক করুন",
       "settingsBlockImagesToggle":"ইমেজ ব্লক করুন",
-      "settingsEasyListCredit": {
+      "settingsBlockedRequestCount": {
         "unsafeHTML": null //missing translation
-      },
+    },
+    "settingsCustomizeFiltersLink": null, //missing translation
       "settingsAppearanceHeading":"চেহারা",
       "settingsEnableDarkMode": null, //"Enable dark mode:" missing translation
       "settingsDarkModeNever": null, //"Never" missing translation

--- a/localization/languages/cs.json
+++ b/localization/languages/cs.json
@@ -132,9 +132,10 @@
         "settingsContentBlockingToggle": "Blokovat trackery a reklamy",
         "settingsBlockScriptsToggle": "Blokovat skripty",
         "settingsBlockImagesToggle": "Blokovat obrázky",
-        "settingsEasyListCredit": {
+        "settingsBlockedRequestCount": {
             "unsafeHTML": null //missing translation
         },
+        "settingsCustomizeFiltersLink": null, //missing translation
         "settingsAppearanceHeading": "Vzhled",
         "settingsEnableDarkMode": null, //"Enable dark mode:" missing translation
         "settingsDarkModeNever": null, //"Never" missing translation

--- a/localization/languages/de.json
+++ b/localization/languages/de.json
@@ -135,9 +135,10 @@
         "settingsContentBlockingExceptions": null, //missing translation
         "settingsBlockScriptsToggle": "Scripte blockieren",
         "settingsBlockImagesToggle": "Bilder blockieren",
-        "settingsEasyListCredit": {
+        "settingsBlockedRequestCount": {
             "unsafeHTML": null //missing translation
         },
+        "settingsCustomizeFiltersLink": null, //missing translation
         "settingsAppearanceHeading": "Aussehen",
         "settingsEnableDarkMode": "Dunkelmodus einschalten:", 
         "settingsDarkModeNever": "Nein", 

--- a/localization/languages/en-US.json
+++ b/localization/languages/en-US.json
@@ -135,9 +135,10 @@
         "settingsContentBlockingExceptions": "Ads will still be allowed on these websites:",
         "settingsBlockScriptsToggle": "Block scripts",
         "settingsBlockImagesToggle": "Block images",
-        "settingsEasyListCredit": {
-            "unsafeHTML": "Based on EasyList and EasyPrivacy, created by <a target=\"_blank\" href=\"https://easylist.to/\">The EasyList authors</a> (<a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/3.0/legalcode\">view license</a>)."
+        "settingsBlockedRequestCount": {
+            "unsafeHTML": "So far, Min has blocked <strong></strong> ads and trackers."
         },
+        "settingsCustomizeFiltersLink": "Customize filters",
         "settingsAppearanceHeading": "Appearance",
         "settingsEnableDarkMode": "Enable dark mode:",
         "settingsDarkModeNever": "Never",

--- a/localization/languages/es.json
+++ b/localization/languages/es.json
@@ -135,9 +135,10 @@
         "settingsContentBlockingExceptions": null, //missing translation
         "settingsBlockScriptsToggle": "Bloquear scripts",
         "settingsBlockImagesToggle": "Bloquear imágenes",
-        "settingsEasyListCredit": {
+        "settingsBlockedRequestCount": {
             "unsafeHTML": null //missing translation
         },
+        "settingsCustomizeFiltersLink": null, //missing translation
         "settingsAppearanceHeading": "Apariencia",
         "settingsEnableDarkMode": "Habilitar modo oscuro:", 
         "settingsDarkModeNever": "Nunca", // googled

--- a/localization/languages/fa.json
+++ b/localization/languages/fa.json
@@ -135,9 +135,10 @@
         "settingsContentBlockingExceptions": null, //missing translation
         "settingsBlockScriptsToggle": "مسدود کردن اسکریپت ها",
         "settingsBlockImagesToggle": "مسدود کردن تصاویر",
-        "settingsEasyListCredit": {
+        "settingsBlockedRequestCount": {
             "unsafeHTML": null //missing translation
         },
+        "settingsCustomizeFiltersLink": null, //missing translation
         "settingsAppearanceHeading": "ظاهر",
         "settingsEnableDarkMode": null, //"Enable dark mode:" missing translation
         "settingsDarkModeNever": null, //"Never" missing translation

--- a/localization/languages/fr.json
+++ b/localization/languages/fr.json
@@ -135,9 +135,10 @@
         "settingsContentBlockingExceptions": "Les publicités resteront activées sur les sites suivants :",
         "settingsBlockScriptsToggle": "Scripts bloqués",
         "settingsBlockImagesToggle": "Images bloquées",
-        "settingsEasyListCredit": {
-            "unsafeHTML": "Basé sur EasyList et EasyPrivacy, créé par <a target=\"_blank\" href=\"https://easylist.to/\">Les auteurs de Easylist</a> (<a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/3.0/legalcode\">voir la license</a>)."
+        "settingsBlockedRequestCount": {
+            "unsafeHTML": null //missing translation
         },
+        "settingsCustomizeFiltersLink": null, //missing translation
         "settingsAppearanceHeading": "Apparence",
         "settingsEnableDarkMode": "Activer le mode nuit:", //"Enable dark mode:" missing translation
         "settingsDarkModeNever": "Jamais", // googled

--- a/localization/languages/hu.json
+++ b/localization/languages/hu.json
@@ -135,9 +135,10 @@
         "settingsContentBlockingExceptions": null, //missing translation
         "settingsBlockScriptsToggle": "Szkriptek tiltása",
         "settingsBlockImagesToggle": "Képek tiltása",
-        "settingsEasyListCredit": {
+        "settingsBlockedRequestCount": {
             "unsafeHTML": null //missing translation
         },
+        "settingsCustomizeFiltersLink": null, //missing translation
         "settingsAppearanceHeading": "Megjelenés",
         "settingsEnableDarkMode": "Kapcsolja be a sötét nézetet:", 
         "settingsDarkModeNever": null, //"Never" missing translation

--- a/localization/languages/it.json
+++ b/localization/languages/it.json
@@ -135,9 +135,10 @@
         "settingsContentBlockingExceptions": "Consenti pubblicità sui seguenti siti:", 
         "settingsBlockScriptsToggle": "Blocca script",
         "settingsBlockImagesToggle": "Blocca immagini",
-        "settingsEasyListCredit": {
-            "unsafeHTML": "Basato su EasyList and EasyPrivacy, creato da <a target=\"_blank\" href=\"https://easylist.to/\">Gli autori di EasyList</a> (<a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/3.0/legalcode\">mostra licenza</a>)." 
+        "settingsBlockedRequestCount": {
+            "unsafeHTML": null //missing translation
         },
+        "settingsCustomizeFiltersLink": null, //missing translation
         "settingsAppearanceHeading": "Aspetto",
         "settingsEnableDarkMode": "Abilita dark mode:", 
         "settingsDarkModeNever": null, //"Never" missing translation

--- a/localization/languages/ja.json
+++ b/localization/languages/ja.json
@@ -136,9 +136,9 @@
         "settingsBlockScriptsToggle": "スクリプトをブロック",
         "settingsBlockImagesToggle": "画像をブロック",
         "settingsBlockedRequestCount": {
-            "unsafeHTML": null //missing translation
+            "unsafeHTML": "これまでのところ、Minは<strong></strong>の広告とトラッカーをブロックしています。"
         },
-        "settingsCustomizeFiltersLink": null, //missing translation
+        "settingsCustomizeFiltersLink": "フィルターをカスタマイズする",
         "settingsAppearanceHeading": "外観",
         "settingsEnableDarkMode": "ダークモードを使用:",
         "settingsDarkModeNever": "決して",

--- a/localization/languages/ja.json
+++ b/localization/languages/ja.json
@@ -135,9 +135,10 @@
         "settingsContentBlockingExceptions": "これらのウェブサイトでは広告は引き続き許可されます:",
         "settingsBlockScriptsToggle": "スクリプトをブロック",
         "settingsBlockImagesToggle": "画像をブロック",
-        "settingsEasyListCredit": {
-            "unsafeHTML": "<a target=\"_blank\" href=\"https://easylist.to/\"> EasyListの作成者</a>によって作成されたEasyListおよびEasyPrivacyに基づいています（<a target=\"_blank\" href=\"https：//creativecommons.org/licenses/by-sa/3.0/legalcode\">ライセンスを表示</a>)。"
+        "settingsBlockedRequestCount": {
+            "unsafeHTML": null //missing translation
         },
+        "settingsCustomizeFiltersLink": null, //missing translation
         "settingsAppearanceHeading": "外観",
         "settingsEnableDarkMode": "ダークモードを使用:",
         "settingsDarkModeNever": "決して",

--- a/localization/languages/ko.json
+++ b/localization/languages/ko.json
@@ -135,9 +135,10 @@
         "settingsContentBlockingExceptions": "다음의 누리집에서 광고 허용",
         "settingsBlockScriptsToggle": "명령(스크립트) 차단",
         "settingsBlockImagesToggle": "그림 차단",
-        "settingsEasyListCredit": {
-            "unsafeHTML": "이지리스트(EasyList)와 이지프라이버시(EasyPrivacy)를 기반으로 합니다. <a target=\"_blank\" href=\"https://easylist.to/\">EasyList</a> (<a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/3.0/legalcode\">이용 규약(라이선스) 보기</a>)."
+        "settingsBlockedRequestCount": {
+            "unsafeHTML": null //missing translation
         },
+        "settingsCustomizeFiltersLink": null, //missing translation
         "settingsAppearanceHeading": "외형",
         "settingsEnableDarkMode": "어두운 외형(Dark Mode) 사용:",
         "settingsDarkModeNever": "사용하지 않음",

--- a/localization/languages/lt.json
+++ b/localization/languages/lt.json
@@ -135,9 +135,10 @@
         "settingsContentBlockingExceptions": "Reklamos vis dar bus leidžiamos šiose svetainėse:",
         "settingsBlockScriptsToggle": "Blokuoti scenarijus",
         "settingsBlockImagesToggle": "Blokuoti paveikslus",
-        "settingsEasyListCredit": {
-            "unsafeHTML": "Pagrįstas EasyList ir EasyPrivacy, sukurtas <a target=\"_blank\" href=\"https://easylist.to/\">EasyList autorių</a> (<a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/3.0/legalcode\">rodyti licenciją</a>)."
+        "settingsBlockedRequestCount": {
+            "unsafeHTML": null //missing translation
         },
+        "settingsCustomizeFiltersLink": null, //missing translation
         "settingsAppearanceHeading": "Išvaizda",
         "settingsEnableDarkMode": "Įjungti tamsią veikseną: ",
         "settingsDarkModeNever": null, //"Never" missing translation

--- a/localization/languages/pl.json
+++ b/localization/languages/pl.json
@@ -135,9 +135,10 @@
         "settingsContentBlockingExceptions": "Zezwalaj na reklamy w tych witrynach:",
         "settingsBlockScriptsToggle": "Zablokuj skrypty",
         "settingsBlockImagesToggle": "Zablokuj obrazy",
-        "settingsEasyListCredit": {
-            "unsafeHTML": "Oparte na EasyList i EasyPrivacy stworzone przez <a target=\"_blank\" href=\"https://easylist.to/\">autorów EasyList</a> (<a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/3.0/legalcode\">wyświetl licencję</a>)."
+        "settingsBlockedRequestCount": {
+            "unsafeHTML": null //missing translation
         },
+        "settingsCustomizeFiltersLink": null, //missing translation
         "settingsAppearanceHeading": "Wygląd",
         "settingsEnableDarkMode": "Włącz tryb ciemny:",
         "settingsDarkModeNever": "Nigdy",

--- a/localization/languages/pt-BR.json
+++ b/localization/languages/pt-BR.json
@@ -135,7 +135,10 @@
         "settingsContentBlockingExceptions": "Permitir anúncios nos sites:",
         "settingsBlockScriptsToggle": "Bloquear scripts",
         "settingsBlockImagesToggle": "Bloquear imagens",
-        "settingsEasyListCredit": {"unsafeHTML": "Com base na EasyList e EasyPrivacy, criadas por <a target=\"_blank\" href=\"https://easylist.to/\">The EasyList authors</a> (<a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/3.0/legalcode\">view license</a>)."},
+        "settingsBlockedRequestCount": {
+            "unsafeHTML": null //missing translation
+        },
+        "settingsCustomizeFiltersLink": null, //missing translation
         "settingsAppearanceHeading": "Aparência",
         "settingsEnableDarkMode": "Habilitar modo dark:",
         "settingsDarkModeNever": "Nunca", 

--- a/localization/languages/pt-PT.json
+++ b/localization/languages/pt-PT.json
@@ -135,9 +135,10 @@
         "settingsContentBlockingExceptions": "Permitir anúncios nestes sites:",
         "settingsBlockScriptsToggle": "Bloquear scripts",
         "settingsBlockImagesToggle": "Bloquear imagens",
-        "settingsEasyListCredit": {
-            "unsafeHTML": "Baseado em EasyList e EasyPrivacy, criadas por <a target=\"_blank\" href=\"https://easylist.to/\">The EasyList authors</a> (<a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/3.0/legalcode\">Ver licença</a>)."
+        "settingsBlockedRequestCount": {
+            "unsafeHTML": null //missing translation
         },
+        "settingsCustomizeFiltersLink": null, //missing translation
         "settingsAppearanceHeading": "Aparência",
         "settingsEnableDarkMode": "Ativar modo escuro:",
         "settingsDarkModeNever": "Nunca",

--- a/localization/languages/ru.json
+++ b/localization/languages/ru.json
@@ -136,9 +136,9 @@
         "settingsBlockScriptsToggle": "Блокировать скрипты",
         "settingsBlockImagesToggle": "Блокировать изображения",
         "settingsBlockedRequestCount": {
-            "unsafeHTML": null //missing translation
+            "unsafeHTML": "На данный момент Min заблокировал <strong></strong> объявлений и трекеров"
         },
-        "settingsCustomizeFiltersLink": null, //missing translation
+        "settingsCustomizeFiltersLink": "Настроить фильтры",
         "settingsAppearanceHeading": "Внешний вид",
         "settingsEnableDarkMode": "Использовать темную тему:",
         "settingsDarkModeNever": "Нет",

--- a/localization/languages/ru.json
+++ b/localization/languages/ru.json
@@ -135,9 +135,10 @@
         "settingsContentBlockingExceptions": "Реклама по-прежнему будет разрешена на этих сайтах:",
         "settingsBlockScriptsToggle": "Блокировать скрипты",
         "settingsBlockImagesToggle": "Блокировать изображения",
-        "settingsEasyListCredit": {
-            "unsafeHTML": "На основе EasyList и EasyPrivacy, созданных <a target=\"_blank\" href=\"https://easylist.to/\">авторами EasyList</a> (<a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/3.0/legalcode\">просмотреть лицензию</a>)."
+        "settingsBlockedRequestCount": {
+            "unsafeHTML": null //missing translation
         },
+        "settingsCustomizeFiltersLink": null, //missing translation
         "settingsAppearanceHeading": "Внешний вид",
         "settingsEnableDarkMode": "Использовать темную тему:",
         "settingsDarkModeNever": "Нет",

--- a/localization/languages/tr_TR.json
+++ b/localization/languages/tr_TR.json
@@ -135,9 +135,10 @@
         "settingsContentBlockingExceptions": "Bu websitelerinde reklamlara izin verildi",
         "settingsBlockScriptsToggle": "Scriptleri engelle",
         "settingsBlockImagesToggle": "Resimleri engelle",
-        "settingsEasyListCredit": {
-            "unsafeHTML": "EasyList ve EasyPrivacy temel alınmıştır, <a target=\"_blank\" href=\"https://easylist.to/\">The EasyList yaratıcıları</a> tarafından oluşturuldu.(<a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/3.0/legalcode\">lisansı görüntüle</a>)."
+        "settingsBlockedRequestCount": {
+            "unsafeHTML": null //missing translation
         },
+        "settingsCustomizeFiltersLink": null, //missing translation
         "settingsAppearanceHeading": "Görünüm",
         "settingsEnableDarkMode": "Koyu modu etkinleştir:",
         "settingsDarkModeNever": null, //"Never" missing translation

--- a/localization/languages/uk.json
+++ b/localization/languages/uk.json
@@ -136,9 +136,9 @@
         "settingsBlockScriptsToggle": "Блокувати скрипти",
         "settingsBlockImagesToggle": "Блокувати зображення",
         "settingsBlockedRequestCount": {
-            "unsafeHTML": null //missing translation
+            "unsafeHTML": "Наразі Min заблокував <strong></strong> реклам і трекерів."
         },
-        "settingsCustomizeFiltersLink": null, //missing translation
+        "settingsCustomizeFiltersLink": "Налаштувати фільтри",
         "settingsAppearanceHeading": "Зовнішній вигляд",
         "settingsDarkModeToggle": "Увімкнути темний режим",
         "settingsEnableDarkMode": "Увімкнути темний режим: ",

--- a/localization/languages/uk.json
+++ b/localization/languages/uk.json
@@ -135,9 +135,10 @@
         "settingsContentBlockingExceptions": "Дозволити рекламу на цих сайтах:",
         "settingsBlockScriptsToggle": "Блокувати скрипти",
         "settingsBlockImagesToggle": "Блокувати зображення",
-        "settingsEasyListCredit": {
-            "unsafeHTML": "На основі EasyList і EasyPrivacy, створених <a target=\"_blank\" href=\"https://easylist.to/\">авторами EasyList</a> (<a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/3.0/legalcode\">переглянути ліцензію</a>)."
+        "settingsBlockedRequestCount": {
+            "unsafeHTML": null //missing translation
         },
+        "settingsCustomizeFiltersLink": null, //missing translation
         "settingsAppearanceHeading": "Зовнішній вигляд",
         "settingsDarkModeToggle": "Увімкнути темний режим",
         "settingsEnableDarkMode": "Увімкнути темний режим: ",

--- a/localization/languages/uz.json
+++ b/localization/languages/uz.json
@@ -137,9 +137,10 @@
 		"settingsContentBlockingExceptions": "Reklamalar ushbu sahifalarda ruxsat beriladi:",
 		"settingsBlockScriptsToggle": "Skriptlarni bloklash",
 		"settingsBlockImagesToggle": "Rasmlarni bloklash",
-		"settingsEasyListCredit": {
-			"unsafeHTML": "EasyList va EasyPrivacy asosida, <a target=\"_blank\" href=\"https://easylist.to/\">The EasyList mualliflary</a> tomonidan yaratilgan (<a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/3.0/legalcode\">litsenziyani ko'rish</a>)."
-		},
+        "settingsBlockedRequestCount": {
+            "unsafeHTML": null //missing translation
+        },
+        "settingsCustomizeFiltersLink": null, //missing translation
 		"settingsEnableDarkMode": "Ko'rinish:",
         "settingsDarkModeNever": null, //"Never" missing translation
         "settingsDarkModeNight": null, //"At night" missing translation

--- a/localization/languages/vi.json
+++ b/localization/languages/vi.json
@@ -131,9 +131,10 @@
         "settingsContentBlockingExceptions": "Quảng cáo vẫn còn cho phép trên trang web này:",
         "settingsBlockScriptsToggle": "Chận mã script",
         "settingsBlockImagesToggle": "Chận ảnh",
-        "settingsEasyListCredit": {
-            "unsafeHTML": "Dựa trên EasyList và EasyPrivacy, tạo bởi <a target=\"_blank\" href=\"https://easylist.to/\">các tác giả EasyList</a> (<a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/3.0/legalcode\">xem giấy phép</a>)."
+        "settingsBlockedRequestCount": {
+            "unsafeHTML": null //missing translation
         },
+        "settingsCustomizeFiltersLink": null, //missing translation
         "settingsAppearanceHeading": "Giao diện",
         "settingsEnableDarkMode": "Bật chế độ tối:",
         "settingsDarkModeNever": null, //"Never" missing translation

--- a/localization/languages/zh-CN.json
+++ b/localization/languages/zh-CN.json
@@ -135,9 +135,10 @@
         "settingsContentBlockingExceptions": "下列站点的广告将被允许",
         "settingsBlockScriptsToggle": "阻止脚本运行",
         "settingsBlockImagesToggle": "阻止加载图片",
-        "settingsEasyListCredit": {
-            "unsafeHTML": "基于 EasyList 和 EasyPrivacy, 由 <a target=\"_blank\" href=\"https://easylist.to/\">EasyList作者</a> 制作（<a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/3.0/legalcode\">查看许可协议</a>）."
+        "settingsBlockedRequestCount": {
+            "unsafeHTML": null //missing translation
         },
+        "settingsCustomizeFiltersLink": null, //missing translation
         "settingsAppearanceHeading": "外观",
         "settingsEnableDarkMode": null, //"Enable dark mode:" missing translation
         "settingsDarkModeNever": null, //"Never" missing translation

--- a/localization/languages/zh-TW.json
+++ b/localization/languages/zh-TW.json
@@ -135,9 +135,10 @@
         "settingsContentBlockingExceptions": "不要在這些網站阻擋廣告：",
         "settingsBlockScriptsToggle": "阻擋 Javascript 腳本運行",
         "settingsBlockImagesToggle": "阻擋圖片",
-        "settingsEasyListCredit": {
-            "unsafeHTML": "基於 EasyList 和 EasyPrivacy，由<a target=\"_blank\" href=\"https://easylist.to/\">EasyList 作者</a>創作 （<a target=\"_blank\" href=\"https://creativecommons.org/licenses/by-sa/3.0/legalcode\">查看憑證</a>）"
+        "settingsBlockedRequestCount": {
+            "unsafeHTML": null //missing translation
         },
+        "settingsCustomizeFiltersLink": null, //missing translation
         "settingsAppearanceHeading": "外觀",
         "settingsEnableDarkMode": "啟用深色模式：",
         "settingsDarkModeNever": "永不",

--- a/main/filtering.js
+++ b/main/filtering.js
@@ -45,7 +45,7 @@ function initFilterList () {
   // discard old data if the list is being re-initialized
   parsedFilterData = {}
 
-  var data = require('fs').readFile(__dirname + '/ext/filterLists/easylist+easyprivacy-noelementhiding.txt', 'utf8', function (err, data) {
+  fs.readFile(__dirname + '/ext/filterLists/easylist+easyprivacy-noelementhiding.txt', 'utf8', function (err, data) {
     if (err) {
       return
     }
@@ -53,6 +53,12 @@ function initFilterList () {
     // data = data.replace(/.*##.+\n/g, '') // remove element hiding rules
 
     parser.parse(data, parsedFilterData)
+  })
+
+  fs.readFile(app.getPath('userData') + '/customFilters.txt', 'utf8', function (err, data) {
+    if (!err && data) {
+      parser.parse(data, parsedFilterData)
+    }
   })
 }
 

--- a/pages/settings/index.html
+++ b/pages/settings/index.html
@@ -20,7 +20,12 @@
 
 	<div class="settings-container" id="privacy-settings-container">
 		<h3 data-string="settingsPrivacyHeading"></h3>
-		<div class="settings-info-subheading container-subheading" data-string="settingsEasyListCredit" data-allowHTML></div>
+
+		<div class="settings-info-subheading" id="content-blocking-statistics">
+			<i class="i carbon:manage-protection"></i>
+			<span data-string="settingsBlockedRequestCount" data-allowHTML id="content-blocking-blocked-requests">
+			</span>
+		</div>
 
 		<div class="setting-section" id="tracking-level-container">
 			<div class="setting-option">
@@ -40,8 +45,11 @@
 				<div><label for="content-blocking-exceptions" data-string="settingsContentBlockingExceptions"></label> &nbsp;
 					<input type="text" id="content-blocking-exceptions" style="width: 100%; max-width: 500px">
 				</div>
+				<a id="customize-filters-link" href="https://github.com/minbrowser/min/wiki/Content-blocking-settings">Customize filters</a>
 			</div>
 		</div>
+
+		<div id="content-type-blocking"></div>
 	</div>
 	
 	<div class="settings-container" id="appearance-settings-container">
@@ -125,7 +133,7 @@
 		<div class="settings-info-subheading" data-string="settingsKeyboardShortcutsHelp"></div>
 
 		<div class="setting-section">
-			<ul id="key-map-list" class="setting-section"></ul>
+			<ul id="key-map-list"></ul>
 		</div>
 	</div>
 

--- a/pages/settings/settings.css
+++ b/pages/settings/settings.css
@@ -5,9 +5,8 @@ html {
 
 .settings-info-subheading {
 	opacity: 0.666;
-}
-.settings-info-subheading.container-subheading {
-	padding-bottom: 1em;
+	margin-top: -0.1em;
+	margin-bottom: 1em;
 }
 
 .yellow-background {
@@ -103,15 +102,29 @@ html {
 	}
 }
 
-#content-blocking-information {
-	padding: 0.5em;
-	margin: 0.75em 0.5em 0.25em 1.08em;
-	background-color: #f8f8f8;
-	border-radius: 3px;
+#content-blocking-statistics i {
+	font-size: 1.1em;
+    vertical-align: text-bottom;
+    margin-right: 0.15em;
 }
 
-.dark-mode #content-blocking-information {
-	background-color: #141414;
+#tracking-level-container .setting-option.selected:not(:first-child) {
+	border: 1px solid #ccc;
+	border-radius: 3px;
+	padding: 0.5em 0.5em;
+	margin-left: -0.5em;
+	margin-top: 0.5em;
+	margin-bottom: 0.5em;
+}
+
+#content-blocking-information {
+	margin: 0.75em 0.5em 0 1.58em;
+}
+
+#customize-filters-link {
+	display: block;
+	margin-top: 0.66em;
+	opacity: 0.8;
 }
 
 .dark-mode input {

--- a/pages/settings/settings.js
+++ b/pages/settings/settings.js
@@ -1,6 +1,6 @@
 document.title = l('settingsPreferencesHeading') + ' | Min'
 
-var container = document.getElementById('privacy-settings-container')
+var contentTypeBlockingContainer = document.getElementById('content-type-blocking')
 var banner = document.getElementById('restart-required-banner')
 var siteThemeCheckbox = document.getElementById('checkbox-site-theme')
 var userscriptsCheckbox = document.getElementById('checkbox-userscripts')
@@ -19,6 +19,18 @@ var trackingLevelContainer = document.getElementById('tracking-level-container')
 var trackingLevelOptions = Array.from(trackingLevelContainer.querySelectorAll('input[name=blockingLevel]'))
 var blockingExceptionsContainer = document.getElementById('content-blocking-information')
 var blockingExceptionsInput = document.getElementById('content-blocking-exceptions')
+var blockedRequestCount = document.querySelector('#content-blocking-blocked-requests strong')
+
+settings.listen('filteringBlockedCount', function (value) {
+  var count = value || 0
+  var valueStr
+  if (count > 50000) {
+    valueStr = new Intl.NumberFormat(navigator.locale, { notation: 'compact', maximumSignificantDigits: 4 }).format(count)
+  } else {
+    valueStr = new Intl.NumberFormat().format(count)
+  }
+  blockedRequestCount.textContent = valueStr
+})
 
 function updateBlockingLevelUI (level) {
   var radio = trackingLevelOptions[level]
@@ -30,6 +42,11 @@ function updateBlockingLevelUI (level) {
     blockingExceptionsContainer.hidden = false
     radio.parentNode.appendChild(blockingExceptionsContainer)
   }
+
+  if (document.querySelector('#tracking-level-container .setting-option.selected')) {
+    document.querySelector('#tracking-level-container .setting-option.selected').classList.remove('selected')
+  }
+  radio.parentNode.classList.add('selected')
 }
 
 function changeBlockingLevelSetting (level) {
@@ -123,7 +140,7 @@ for (var contentType in contentTypes) {
       section.appendChild(checkbox)
       section.appendChild(label)
 
-      container.appendChild(section)
+      contentTypeBlockingContainer.appendChild(section)
 
       checkbox.addEventListener('change', function (e) {
         settings.get('filtering', function (value) {


### PR DESCRIPTION
* Show a count of the requests blocked by Min:

<img width="1008" alt="Screen Shot 2020-08-17 at 12 37 15 PM" src="https://user-images.githubusercontent.com/10314059/90426241-656b6d00-e086-11ea-9808-23c65e18e8de.png">

* Add support for creating a `customFilters.txt` file that will be used in addition to the standard list (fixes #1200)

The "customize filters" link will go to a wiki article that I'll publish after the next release, which will include the Easylist license information and explain how to create custom filters.

One interesting issue is how custom filters interact with the existing filtering settings for the default list. Right now, if you add a custom filter but have "block third-party requests" set, your custom filter will only apply to third-party requests, which could be unexpected. We could ignore the settings for custom filters, but that might be confusing as well - e.g. if you add a site to the exception list, some resources on it could still be blocked due to custom filters. Or we could add another section to the preferences just for custom filters, but that would take up more space, and I'm guessing only a small number of people will use it.

My plan for now is to just document this in the wiki article, and suggest that you enable "block all requests" if you want to use custom filters.