### PR TITLE
Fix switch-task-button size

### DIFF
--- a/css/taskOverlay.css
+++ b/css/taskOverlay.css
@@ -18,10 +18,10 @@
 }
 
 #switch-task-button svg {
-	width: 0.8em;
-	height: 0.8em;
+	width: 15px;
+	height: 12px;
 	display: block;
-    margin-top: 2px;
+	margin-top: 1px;
 }
 #task-overlay {
 	display: flex;


### PR DESCRIPTION
On the Linux the SVG image in the button for switching tasks looks affected by interpolation. Other buttons are affected as well, but it is not so obvious.

Default:
![Snímek z 2020-09-02 16-03-56](https://user-images.githubusercontent.com/17854950/91994033-6662f680-ed36-11ea-90ce-563583a6221a.png)

Fixed:
![Snímek z 2020-09-02 16-03-31](https://user-images.githubusercontent.com/17854950/91994065-6fec5e80-ed36-11ea-8fb9-e11933b65621.png)
