### PR TITLE
Fix: shift+letter not registering as single letter shortcut

### DIFF
--- a/js/keybindings.js
+++ b/js/keybindings.js
@@ -5,35 +5,48 @@ There are three possible ways that keybindings can be handled.
   - If a BrowserView is focused, shortcuts are handled by the before-input-event listener.
   */
 
-const Mousetrap = require('mousetrap')
-const keyMapModule = require('util/keyMap.js')
+const Mousetrap = require("mousetrap");
+const keyMapModule = require("util/keyMap.js");
 
-var webviews = require('webviews.js')
-var modalMode = require('modalMode.js')
-var settings = require('util/settings/settings.js')
+var webviews = require("webviews.js");
+var modalMode = require("modalMode.js");
+var settings = require("util/settings/settings.js");
 
-var keyMap = keyMapModule.userKeyMap(settings.get('keyMap'))
+var keyMap = keyMapModule.userKeyMap(settings.get("keyMap"));
 
-var shortcutsList = []
-var registeredMousetrapBindings = {}
+var shortcutsList = [];
+var registeredMousetrapBindings = {};
 
 /*
 Determines whether a shortcut can actually run
 single-letter shortcuts and shortcuts used for text editing can't run when an input is focused
 */
-function checkShortcutCanRun (combo, cb) {
-  if (/^\w$/.test(combo) || combo === 'mod+left' || combo === 'mod+right') {
-    webviews.callAsync(tabs.getSelected(), 'isFocused', function (err, isFocused) {
-      if (err || !tabs.get(tabs.getSelected()).url || !isFocused) {
-      // check whether an input is focused in the browser UI
-        if (document.activeElement.tagName === 'INPUT' || document.activeElement.tagName === 'TEXTAREA') {
-          cb(false)
-        } else {
-          cb(true)
-        }
-      } else {
-      // check whether an input is focused in the webview
-        webviews.callAsync(tabs.getSelected(), 'executeJavaScript', `
+function checkShortcutCanRun(combo, cb) {
+    if (
+        /^\w$/.test(combo.replace("shift+", "")) ||
+        combo === "mod+left" ||
+        combo === "mod+right"
+    ) {
+        webviews.callAsync(tabs.getSelected(), "isFocused", function (
+            err,
+            isFocused
+        ) {
+            if (err || !tabs.get(tabs.getSelected()).url || !isFocused) {
+                // check whether an input is focused in the browser UI
+                if (
+                    document.activeElement.tagName === "INPUT" ||
+                    document.activeElement.tagName === "TEXTAREA"
+                ) {
+                    cb(false);
+                } else {
+                    cb(true);
+                }
+            } else {
+                // check whether an input is focused in the webview
+                webviews.callAsync(
+                    tabs.getSelected(),
+                    "executeJavaScript",
+                    `
           document.activeElement.tagName === "INPUT"
           || document.activeElement.tagName === "TEXTAREA"
           || document.activeElement.tagName === "IFRAME"
@@ -47,119 +60,136 @@ function checkShortcutCanRun (combo, cb) {
             }
             return false;
           })()
-      `, function (err, isInputFocused) {
-        if (err) {
-          console.warn(err)
-          return
-        }
-        cb(isInputFocused === false)
-      })
-      }
-    })
-  } else {
-    cb(true)
-  }
+      `,
+                    function (err, isInputFocused) {
+                        if (err) {
+                            console.warn(err);
+                            return;
+                        }
+                        cb(isInputFocused === false);
+                    }
+                );
+            }
+        });
+    } else {
+        cb(true);
+    }
 }
 
-function defineShortcut (keysOrKeyMapName, fn, options = {}) {
-  if (keysOrKeyMapName.keys) {
-    var binding = keysOrKeyMapName.keys
-  } else {
-    var binding = keyMap[keysOrKeyMapName]
-  }
-
-  if (typeof binding === 'string') {
-    binding = [binding]
-  }
-
-  var shortcutCallback = function (e, combo) {
-    // Disable shortcuts for modal mode.
-    if (modalMode.enabled()) {
-      return
+function defineShortcut(keysOrKeyMapName, fn, options = {}) {
+    if (keysOrKeyMapName.keys) {
+        var binding = keysOrKeyMapName.keys;
+    } else {
+        var binding = keyMap[keysOrKeyMapName];
     }
 
-    checkShortcutCanRun(combo, function (canRun) {
-      if (canRun) {
-        fn(e, combo)
-      }
-    })
-  }
+    if (typeof binding === "string") {
+        binding = [binding];
+    }
 
-  binding.forEach(function (keys) {
-    shortcutsList.push({
-      combo: keys,
-      keys: keys.split('+'),
-      fn: shortcutCallback,
-      keyUp: options.keyUp
-    })
-    if (!registeredMousetrapBindings[keys]) {
-      // mousetrap only allows one listener for each key combination
-      // so register a single listener, and have it call all the other listeners that we have
-      Mousetrap.bind(keys, function (e, combo) {
+    var shortcutCallback = function (e, combo) {
+        // Disable shortcuts for modal mode.
+        if (modalMode.enabled()) {
+            return;
+        }
+
+        checkShortcutCanRun(combo, function (canRun) {
+            if (canRun) {
+                fn(e, combo);
+            }
+        });
+    };
+
+    binding.forEach(function (keys) {
+        shortcutsList.push({
+            combo: keys,
+            keys: keys.split("+"),
+            fn: shortcutCallback,
+            keyUp: options.keyUp,
+        });
+        if (!registeredMousetrapBindings[keys]) {
+            // mousetrap only allows one listener for each key combination
+            // so register a single listener, and have it call all the other listeners that we have
+            Mousetrap.bind(
+                keys,
+                function (e, combo) {
+                    shortcutsList.forEach(function (shortcut) {
+                        if (shortcut.combo === combo) {
+                            shortcut.fn(e, combo);
+                        }
+                    });
+                },
+                options.keyUp ? "keyup" : null
+            );
+            registeredMousetrapBindings[keys] = true;
+        }
+    });
+}
+
+function initialize() {
+    webviews.bindEvent("before-input-event", function (tabId, input) {
+        var expectedKeys = 1;
+        // account for additional keys that aren't in the input.key property
+        if (input.alt && input.key !== "Alt") {
+            expectedKeys++;
+        }
+        if (input.shift && input.key !== "Shift") {
+            expectedKeys++;
+        }
+        if (input.control && input.key !== "Control") {
+            expectedKeys++;
+        }
+        if (input.meta && input.key !== "Meta") {
+            expectedKeys++;
+        }
+
         shortcutsList.forEach(function (shortcut) {
-          if (shortcut.combo === combo) {
-            shortcut.fn(e, combo)
-          }
-        })
-      }, (options.keyUp ? 'keyup' : null))
-      registeredMousetrapBindings[keys] = true
-    }
-  })
+            if (
+                (shortcut.keyUp && input.type !== "keyUp") ||
+                (!shortcut.keyUp && input.type !== "keyDown")
+            ) {
+                return;
+            }
+            var matches = true;
+            var matchedKeys = 0;
+            shortcut.keys.forEach(function (key) {
+                if (
+                    !(
+                        key === input.key.toLowerCase() ||
+                        key === input.code.replace("Digit", "") ||
+                        (key === "esc" && input.key === "Escape") ||
+                        (key === "left" && input.key === "ArrowLeft") ||
+                        (key === "right" && input.key === "ArrowRight") ||
+                        (key === "up" && input.key === "ArrowUp") ||
+                        (key === "down" && input.key === "ArrowDown") ||
+                        (key === "alt" && (input.alt || input.key === "Alt")) ||
+                        (key === "option" &&
+                            (input.alt || input.key === "Alt")) ||
+                        (key === "shift" &&
+                            (input.shift || input.key === "Shift")) ||
+                        (key === "ctrl" &&
+                            (input.control || input.key === "Control")) ||
+                        (key === "mod" &&
+                            window.platformType === "mac" &&
+                            (input.meta || input.key === "Meta")) ||
+                        (key === "mod" &&
+                            window.platformType !== "mac" &&
+                            (input.control || input.key === "Control"))
+                    )
+                ) {
+                    matches = false;
+                } else {
+                    matchedKeys++;
+                }
+            });
+
+            if (matches && matchedKeys === expectedKeys) {
+                shortcut.fn(null, shortcut.combo);
+            }
+        });
+    });
 }
 
-function initialize () {
-  webviews.bindEvent('before-input-event', function (tabId, input) {
-    var expectedKeys = 1
-  // account for additional keys that aren't in the input.key property
-    if (input.alt && input.key !== 'Alt') {
-      expectedKeys++
-    }
-    if (input.shift && input.key !== 'Shift') {
-      expectedKeys++
-    }
-    if (input.control && input.key !== 'Control') {
-      expectedKeys++
-    }
-    if (input.meta && input.key !== 'Meta') {
-      expectedKeys++
-    }
+initialize();
 
-    shortcutsList.forEach(function (shortcut) {
-      if ((shortcut.keyUp && input.type !== 'keyUp') || (!shortcut.keyUp && input.type !== 'keyDown')) {
-        return
-      }
-      var matches = true
-      var matchedKeys = 0
-      shortcut.keys.forEach(function (key) {
-        if (!(
-        key === input.key.toLowerCase() ||
-        key === input.code.replace('Digit', '') ||
-        (key === 'esc' && input.key === 'Escape') ||
-        (key === 'left' && input.key === 'ArrowLeft') ||
-        (key === 'right' && input.key === 'ArrowRight') ||
-        (key === 'up' && input.key === 'ArrowUp') ||
-        (key === 'down' && input.key === 'ArrowDown') ||
-        (key === 'alt' && (input.alt || input.key === 'Alt')) ||
-        (key === 'option' && (input.alt || input.key === 'Alt')) ||
-        (key === 'shift' && (input.shift || input.key === 'Shift')) ||
-        (key === 'ctrl' && (input.control || input.key === 'Control')) ||
-        (key === 'mod' && window.platformType === 'mac' && (input.meta || input.key === 'Meta')) ||
-        (key === 'mod' && window.platformType !== 'mac' && (input.control || input.key === 'Control'))
-        )
-      ) {
-          matches = false
-        } else {
-          matchedKeys++
-        }
-      })
-
-      if (matches && matchedKeys === expectedKeys) {
-        shortcut.fn(null, shortcut.combo)
-      }
-    })
-  })
-}
-
-initialize()
-
-module.exports = {defineShortcut}
+module.exports = { defineShortcut };

--- a/js/keybindings.js
+++ b/js/keybindings.js
@@ -18,35 +18,22 @@ var shortcutsList = []
 var registeredMousetrapBindings = {}
 
 /*
-Determines whether a shortcut can actually run
+Determines whether a shortcut can actually ru
 single-letter shortcuts and shortcuts used for text editing can't run when an input is focused
 */
 function checkShortcutCanRun (combo, cb) {
-  if (
-    /^\w$/.test(combo.replace('shift+', '')) ||
-        combo === 'mod+left' ||
-        combo === 'mod+right'
-  ) {
-    webviews.callAsync(tabs.getSelected(), 'isFocused', function (
-      err,
-      isFocused
-    ) {
+  if (/^\w$/.test(combo.replace("shift+", "")) || combo === 'mod+left' || combo === 'mod+right') {
+    webviews.callAsync(tabs.getSelected(), 'isFocused', function (err, isFocused) {
       if (err || !tabs.get(tabs.getSelected()).url || !isFocused) {
-        // check whether an input is focused in the browser UI
-        if (
-          document.activeElement.tagName === 'INPUT' ||
-                    document.activeElement.tagName === 'TEXTAREA'
-        ) {
+      // check whether an input is focused in the browser UI
+        if (document.activeElement.tagName === 'INPUT' || document.activeElement.tagName === 'TEXTAREA') {
           cb(false)
         } else {
           cb(true)
         }
       } else {
-        // check whether an input is focused in the webview
-        webviews.callAsync(
-          tabs.getSelected(),
-          'executeJavaScript',
-                    `
+      // check whether an input is focused in the webview
+        webviews.callAsync(tabs.getSelected(), 'executeJavaScript', `
           document.activeElement.tagName === "INPUT"
           || document.activeElement.tagName === "TEXTAREA"
           || document.activeElement.tagName === "IFRAME"
@@ -60,15 +47,13 @@ function checkShortcutCanRun (combo, cb) {
             }
             return false;
           })()
-      `,
-                    function (err, isInputFocused) {
-                      if (err) {
-                        console.warn(err)
-                        return
-                      }
-                      cb(isInputFocused === false)
-                    }
-        )
+      `, function (err, isInputFocused) {
+        if (err) {
+          console.warn(err)
+          return
+        }
+        cb(isInputFocused === false)
+      })
       }
     })
   } else {
@@ -110,17 +95,13 @@ function defineShortcut (keysOrKeyMapName, fn, options = {}) {
     if (!registeredMousetrapBindings[keys]) {
       // mousetrap only allows one listener for each key combination
       // so register a single listener, and have it call all the other listeners that we have
-      Mousetrap.bind(
-        keys,
-        function (e, combo) {
-          shortcutsList.forEach(function (shortcut) {
-            if (shortcut.combo === combo) {
-              shortcut.fn(e, combo)
-            }
-          })
-        },
-        options.keyUp ? 'keyup' : null
-      )
+      Mousetrap.bind(keys, function (e, combo) {
+        shortcutsList.forEach(function (shortcut) {
+          if (shortcut.combo === combo) {
+            shortcut.fn(e, combo)
+          }
+        })
+      }, (options.keyUp ? 'keyup' : null))
       registeredMousetrapBindings[keys] = true
     }
   })
@@ -129,7 +110,7 @@ function defineShortcut (keysOrKeyMapName, fn, options = {}) {
 function initialize () {
   webviews.bindEvent('before-input-event', function (tabId, input) {
     var expectedKeys = 1
-    // account for additional keys that aren't in the input.key property
+  // account for additional keys that aren't in the input.key property
     if (input.alt && input.key !== 'Alt') {
       expectedKeys++
     }
@@ -144,39 +125,28 @@ function initialize () {
     }
 
     shortcutsList.forEach(function (shortcut) {
-      if (
-        (shortcut.keyUp && input.type !== 'keyUp') ||
-                (!shortcut.keyUp && input.type !== 'keyDown')
-      ) {
+      if ((shortcut.keyUp && input.type !== 'keyUp') || (!shortcut.keyUp && input.type !== 'keyDown')) {
         return
       }
       var matches = true
       var matchedKeys = 0
       shortcut.keys.forEach(function (key) {
-        if (
-          !(
-            key === input.key.toLowerCase() ||
-                        key === input.code.replace('Digit', '') ||
-                        (key === 'esc' && input.key === 'Escape') ||
-                        (key === 'left' && input.key === 'ArrowLeft') ||
-                        (key === 'right' && input.key === 'ArrowRight') ||
-                        (key === 'up' && input.key === 'ArrowUp') ||
-                        (key === 'down' && input.key === 'ArrowDown') ||
-                        (key === 'alt' && (input.alt || input.key === 'Alt')) ||
-                        (key === 'option' &&
-                            (input.alt || input.key === 'Alt')) ||
-                        (key === 'shift' &&
-                            (input.shift || input.key === 'Shift')) ||
-                        (key === 'ctrl' &&
-                            (input.control || input.key === 'Control')) ||
-                        (key === 'mod' &&
-                            window.platformType === 'mac' &&
-                            (input.meta || input.key === 'Meta')) ||
-                        (key === 'mod' &&
-                            window.platformType !== 'mac' &&
-                            (input.control || input.key === 'Control'))
-          )
-        ) {
+        if (!(
+        key === input.key.toLowerCase() ||
+        key === input.code.replace('Digit', '') ||
+        (key === 'esc' && input.key === 'Escape') ||
+        (key === 'left' && input.key === 'ArrowLeft') ||
+        (key === 'right' && input.key === 'ArrowRight') ||
+        (key === 'up' && input.key === 'ArrowUp') ||
+        (key === 'down' && input.key === 'ArrowDown') ||
+        (key === 'alt' && (input.alt || input.key === 'Alt')) ||
+        (key === 'option' && (input.alt || input.key === 'Alt')) ||
+        (key === 'shift' && (input.shift || input.key === 'Shift')) ||
+        (key === 'ctrl' && (input.control || input.key === 'Control')) ||
+        (key === 'mod' && window.platformType === 'mac' && (input.meta || input.key === 'Meta')) ||
+        (key === 'mod' && window.platformType !== 'mac' && (input.control || input.key === 'Control'))
+        )
+      ) {
           matches = false
         } else {
           matchedKeys++
@@ -192,4 +162,4 @@ function initialize () {
 
 initialize()
 
-module.exports = { defineShortcut }
+module.exports = {defineShortcut}n

--- a/js/keybindings.js
+++ b/js/keybindings.js
@@ -18,7 +18,7 @@ var shortcutsList = []
 var registeredMousetrapBindings = {}
 
 /*
-Determines whether a shortcut can actually ru
+Determines whether a shortcut can actually run
 single-letter shortcuts and shortcuts used for text editing can't run when an input is focused
 */
 function checkShortcutCanRun (combo, cb) {
@@ -162,4 +162,4 @@ function initialize () {
 
 initialize()
 
-module.exports = {defineShortcut}n
+module.exports = {defineShortcut}

--- a/js/keybindings.js
+++ b/js/keybindings.js
@@ -5,47 +5,47 @@ There are three possible ways that keybindings can be handled.
   - If a BrowserView is focused, shortcuts are handled by the before-input-event listener.
   */
 
-const Mousetrap = require("mousetrap");
-const keyMapModule = require("util/keyMap.js");
+const Mousetrap = require('mousetrap')
+const keyMapModule = require('util/keyMap.js')
 
-var webviews = require("webviews.js");
-var modalMode = require("modalMode.js");
-var settings = require("util/settings/settings.js");
+var webviews = require('webviews.js')
+var modalMode = require('modalMode.js')
+var settings = require('util/settings/settings.js')
 
-var keyMap = keyMapModule.userKeyMap(settings.get("keyMap"));
+var keyMap = keyMapModule.userKeyMap(settings.get('keyMap'))
 
-var shortcutsList = [];
-var registeredMousetrapBindings = {};
+var shortcutsList = []
+var registeredMousetrapBindings = {}
 
 /*
 Determines whether a shortcut can actually run
 single-letter shortcuts and shortcuts used for text editing can't run when an input is focused
 */
-function checkShortcutCanRun(combo, cb) {
-    if (
-        /^\w$/.test(combo.replace("shift+", "")) ||
-        combo === "mod+left" ||
-        combo === "mod+right"
+function checkShortcutCanRun (combo, cb) {
+  if (
+    /^\w$/.test(combo.replace('shift+', '')) ||
+        combo === 'mod+left' ||
+        combo === 'mod+right'
+  ) {
+    webviews.callAsync(tabs.getSelected(), 'isFocused', function (
+      err,
+      isFocused
     ) {
-        webviews.callAsync(tabs.getSelected(), "isFocused", function (
-            err,
-            isFocused
+      if (err || !tabs.get(tabs.getSelected()).url || !isFocused) {
+        // check whether an input is focused in the browser UI
+        if (
+          document.activeElement.tagName === 'INPUT' ||
+                    document.activeElement.tagName === 'TEXTAREA'
         ) {
-            if (err || !tabs.get(tabs.getSelected()).url || !isFocused) {
-                // check whether an input is focused in the browser UI
-                if (
-                    document.activeElement.tagName === "INPUT" ||
-                    document.activeElement.tagName === "TEXTAREA"
-                ) {
-                    cb(false);
-                } else {
-                    cb(true);
-                }
-            } else {
-                // check whether an input is focused in the webview
-                webviews.callAsync(
-                    tabs.getSelected(),
-                    "executeJavaScript",
+          cb(false)
+        } else {
+          cb(true)
+        }
+      } else {
+        // check whether an input is focused in the webview
+        webviews.callAsync(
+          tabs.getSelected(),
+          'executeJavaScript',
                     `
           document.activeElement.tagName === "INPUT"
           || document.activeElement.tagName === "TEXTAREA"
@@ -62,134 +62,134 @@ function checkShortcutCanRun(combo, cb) {
           })()
       `,
                     function (err, isInputFocused) {
-                        if (err) {
-                            console.warn(err);
-                            return;
-                        }
-                        cb(isInputFocused === false);
+                      if (err) {
+                        console.warn(err)
+                        return
+                      }
+                      cb(isInputFocused === false)
                     }
-                );
-            }
-        });
-    } else {
-        cb(true);
-    }
+        )
+      }
+    })
+  } else {
+    cb(true)
+  }
 }
 
-function defineShortcut(keysOrKeyMapName, fn, options = {}) {
-    if (keysOrKeyMapName.keys) {
-        var binding = keysOrKeyMapName.keys;
-    } else {
-        var binding = keyMap[keysOrKeyMapName];
+function defineShortcut (keysOrKeyMapName, fn, options = {}) {
+  if (keysOrKeyMapName.keys) {
+    var binding = keysOrKeyMapName.keys
+  } else {
+    var binding = keyMap[keysOrKeyMapName]
+  }
+
+  if (typeof binding === 'string') {
+    binding = [binding]
+  }
+
+  var shortcutCallback = function (e, combo) {
+    // Disable shortcuts for modal mode.
+    if (modalMode.enabled()) {
+      return
     }
 
-    if (typeof binding === "string") {
-        binding = [binding];
+    checkShortcutCanRun(combo, function (canRun) {
+      if (canRun) {
+        fn(e, combo)
+      }
+    })
+  }
+
+  binding.forEach(function (keys) {
+    shortcutsList.push({
+      combo: keys,
+      keys: keys.split('+'),
+      fn: shortcutCallback,
+      keyUp: options.keyUp
+    })
+    if (!registeredMousetrapBindings[keys]) {
+      // mousetrap only allows one listener for each key combination
+      // so register a single listener, and have it call all the other listeners that we have
+      Mousetrap.bind(
+        keys,
+        function (e, combo) {
+          shortcutsList.forEach(function (shortcut) {
+            if (shortcut.combo === combo) {
+              shortcut.fn(e, combo)
+            }
+          })
+        },
+        options.keyUp ? 'keyup' : null
+      )
+      registeredMousetrapBindings[keys] = true
+    }
+  })
+}
+
+function initialize () {
+  webviews.bindEvent('before-input-event', function (tabId, input) {
+    var expectedKeys = 1
+    // account for additional keys that aren't in the input.key property
+    if (input.alt && input.key !== 'Alt') {
+      expectedKeys++
+    }
+    if (input.shift && input.key !== 'Shift') {
+      expectedKeys++
+    }
+    if (input.control && input.key !== 'Control') {
+      expectedKeys++
+    }
+    if (input.meta && input.key !== 'Meta') {
+      expectedKeys++
     }
 
-    var shortcutCallback = function (e, combo) {
-        // Disable shortcuts for modal mode.
-        if (modalMode.enabled()) {
-            return;
+    shortcutsList.forEach(function (shortcut) {
+      if (
+        (shortcut.keyUp && input.type !== 'keyUp') ||
+                (!shortcut.keyUp && input.type !== 'keyDown')
+      ) {
+        return
+      }
+      var matches = true
+      var matchedKeys = 0
+      shortcut.keys.forEach(function (key) {
+        if (
+          !(
+            key === input.key.toLowerCase() ||
+                        key === input.code.replace('Digit', '') ||
+                        (key === 'esc' && input.key === 'Escape') ||
+                        (key === 'left' && input.key === 'ArrowLeft') ||
+                        (key === 'right' && input.key === 'ArrowRight') ||
+                        (key === 'up' && input.key === 'ArrowUp') ||
+                        (key === 'down' && input.key === 'ArrowDown') ||
+                        (key === 'alt' && (input.alt || input.key === 'Alt')) ||
+                        (key === 'option' &&
+                            (input.alt || input.key === 'Alt')) ||
+                        (key === 'shift' &&
+                            (input.shift || input.key === 'Shift')) ||
+                        (key === 'ctrl' &&
+                            (input.control || input.key === 'Control')) ||
+                        (key === 'mod' &&
+                            window.platformType === 'mac' &&
+                            (input.meta || input.key === 'Meta')) ||
+                        (key === 'mod' &&
+                            window.platformType !== 'mac' &&
+                            (input.control || input.key === 'Control'))
+          )
+        ) {
+          matches = false
+        } else {
+          matchedKeys++
         }
+      })
 
-        checkShortcutCanRun(combo, function (canRun) {
-            if (canRun) {
-                fn(e, combo);
-            }
-        });
-    };
-
-    binding.forEach(function (keys) {
-        shortcutsList.push({
-            combo: keys,
-            keys: keys.split("+"),
-            fn: shortcutCallback,
-            keyUp: options.keyUp,
-        });
-        if (!registeredMousetrapBindings[keys]) {
-            // mousetrap only allows one listener for each key combination
-            // so register a single listener, and have it call all the other listeners that we have
-            Mousetrap.bind(
-                keys,
-                function (e, combo) {
-                    shortcutsList.forEach(function (shortcut) {
-                        if (shortcut.combo === combo) {
-                            shortcut.fn(e, combo);
-                        }
-                    });
-                },
-                options.keyUp ? "keyup" : null
-            );
-            registeredMousetrapBindings[keys] = true;
-        }
-    });
+      if (matches && matchedKeys === expectedKeys) {
+        shortcut.fn(null, shortcut.combo)
+      }
+    })
+  })
 }
 
-function initialize() {
-    webviews.bindEvent("before-input-event", function (tabId, input) {
-        var expectedKeys = 1;
-        // account for additional keys that aren't in the input.key property
-        if (input.alt && input.key !== "Alt") {
-            expectedKeys++;
-        }
-        if (input.shift && input.key !== "Shift") {
-            expectedKeys++;
-        }
-        if (input.control && input.key !== "Control") {
-            expectedKeys++;
-        }
-        if (input.meta && input.key !== "Meta") {
-            expectedKeys++;
-        }
+initialize()
 
-        shortcutsList.forEach(function (shortcut) {
-            if (
-                (shortcut.keyUp && input.type !== "keyUp") ||
-                (!shortcut.keyUp && input.type !== "keyDown")
-            ) {
-                return;
-            }
-            var matches = true;
-            var matchedKeys = 0;
-            shortcut.keys.forEach(function (key) {
-                if (
-                    !(
-                        key === input.key.toLowerCase() ||
-                        key === input.code.replace("Digit", "") ||
-                        (key === "esc" && input.key === "Escape") ||
-                        (key === "left" && input.key === "ArrowLeft") ||
-                        (key === "right" && input.key === "ArrowRight") ||
-                        (key === "up" && input.key === "ArrowUp") ||
-                        (key === "down" && input.key === "ArrowDown") ||
-                        (key === "alt" && (input.alt || input.key === "Alt")) ||
-                        (key === "option" &&
-                            (input.alt || input.key === "Alt")) ||
-                        (key === "shift" &&
-                            (input.shift || input.key === "Shift")) ||
-                        (key === "ctrl" &&
-                            (input.control || input.key === "Control")) ||
-                        (key === "mod" &&
-                            window.platformType === "mac" &&
-                            (input.meta || input.key === "Meta")) ||
-                        (key === "mod" &&
-                            window.platformType !== "mac" &&
-                            (input.control || input.key === "Control"))
-                    )
-                ) {
-                    matches = false;
-                } else {
-                    matchedKeys++;
-                }
-            });
-
-            if (matches && matchedKeys === expectedKeys) {
-                shortcut.fn(null, shortcut.combo);
-            }
-        });
-    });
-}
-
-initialize();
-
-module.exports = { defineShortcut };
+module.exports = { defineShortcut }


### PR DESCRIPTION
Fixes issue #1231 

My approach simply discards "shift+" from the string that is being tested. I am not so experienced with regex so there is probably a better way to exclude shift+ instead of .replace.