### PR TITLE
Added shortcut to mute a tab

### DIFF
--- a/css/tabBar.css
+++ b/css/tabBar.css
@@ -215,6 +215,13 @@ body.dark-mode #overlay {
 	font-size: 1.6em !important;
 }
 
+/* audio button */
+.tab-item .tab-audio-button {
+	vertical-align: text-bottom;
+	padding: 0 0.5em 0 0;
+	font-size: 1.1em !important;
+}
+
 /* reader button */
 
 .tab-item .reader-button {

--- a/css/tabBar.css
+++ b/css/tabBar.css
@@ -221,9 +221,6 @@ body.dark-mode #overlay {
 	padding: 0 0.5em 0 0;
 	font-size: 1.1em !important;
 }
-.tab-audio-button.hidden {
-    display: none;
-}
 
 /* reader button */
 

--- a/css/tabBar.css
+++ b/css/tabBar.css
@@ -221,6 +221,9 @@ body.dark-mode #overlay {
 	padding: 0 0.5em 0 0;
 	font-size: 1.1em !important;
 }
+.tab-audio-button.hidden {
+    display: none;
+}
 
 /* reader button */
 

--- a/js/navbar/tabBar.js
+++ b/js/navbar/tabBar.js
@@ -2,6 +2,7 @@ const webviews = require('webviews.js')
 const focusMode = require('focusMode.js')
 const urlParser = require('util/urlParser.js')
 const readerView = require('readerView.js')
+const tabAudio = require('tabAudio.js')
 const dragula = require('dragula')
 const settings = require('util/settings/settings.js')
 
@@ -48,6 +49,7 @@ const tabBar = {
     tabEl.setAttribute('role', 'tab')
 
     tabEl.appendChild(readerView.getButton(data.id))
+    tabEl.appendChild(tabAudio.getButton(data.id))
     tabEl.appendChild(progressBar.create())
 
     // icons
@@ -139,6 +141,11 @@ const tabBar = {
       tabEl.title += ' (' + l('privateTab') + ')'
     }
 
+    // update tab audio icon
+    var audioButton = tabEl.querySelector('.tab-audio-button')
+    tabAudio.updateButton(tabId, audioButton)
+
+
     tabEl.querySelectorAll('.permission-request-icon').forEach(el => el.remove())
 
     permissionRequests.getButtons(tabId).reverse().forEach(function (button) {
@@ -196,7 +203,8 @@ webviews.bindEvent('did-stop-loading', function (tabId) {
 })
 
 tasks.on('tab-updated', function (id, key) {
-  if (key === 'title' || key === 'secure' || key === 'url') {
+  updateKeys = ['title', 'secure', 'url', 'muted', 'hasAudio']
+  if (updateKeys.includes(key)) {
     tabBar.updateTab(id)
   }
 })

--- a/js/navbar/tabBar.js
+++ b/js/navbar/tabBar.js
@@ -145,7 +145,6 @@ const tabBar = {
     var audioButton = tabEl.querySelector('.tab-audio-button')
     tabAudio.updateButton(tabId, audioButton)
 
-
     tabEl.querySelectorAll('.permission-request-icon').forEach(el => el.remove())
 
     permissionRequests.getButtons(tabId).reverse().forEach(function (button) {
@@ -203,7 +202,7 @@ webviews.bindEvent('did-stop-loading', function (tabId) {
 })
 
 tasks.on('tab-updated', function (id, key) {
-  updateKeys = ['title', 'secure', 'url', 'muted', 'hasAudio']
+  var updateKeys = ['title', 'secure', 'url', 'muted', 'hasAudio']
   if (updateKeys.includes(key)) {
     tabBar.updateTab(id)
   }

--- a/js/sessionRestore.js
+++ b/js/sessionRestore.js
@@ -80,6 +80,11 @@ window.sessionRestore = {
       // add the saved tasks
 
       data.state.tasks.forEach(function (task) {
+        // reset tab hasAudio and muted
+        task.tabs.forEach(function(tab) {
+            tab.hasAudio = false
+            tab.muted = false
+        })
         // restore the task item
         tasks.add(task)
       })

--- a/js/tabAudio.js
+++ b/js/tabAudio.js
@@ -1,13 +1,9 @@
 var webviews = require('webviews.js')
 var keybindings = require('keybindings.js')
-var getView = remote.getGlobal('getView')
 
 var tabAudio = {
   muteIcon: 'carbon:volume-mute-filled',
   volumeIcon: 'carbon:volume-up-filled',
-  setWebViewMuted: function (tabId, muted) {
-    webviews.callAsync(tabId, 'setAudioMuted', muted)
-  },
   getButton: function (tabId) {
     var button = document.createElement('button')
     button.className = 'tab-icon tab-audio-button i'
@@ -47,7 +43,7 @@ var tabAudio = {
     var tab = tabs.get(tabId)
     // can be muted if has audio, can be unmuted if muted
     if (tab.hasAudio || tab.muted) {
-      tabAudio.setWebViewMuted(tabId, !tab.muted)
+      webviews.callAsync(tabId, 'setAudioMuted', !tab.muted)
       tabs.update(tabId, { muted: !tab.muted })
     }
   },
@@ -55,6 +51,7 @@ var tabAudio = {
     keybindings.defineShortcut('toggleTabAudio', function () {
       tabAudio.toggleAudio(tabs.getSelected())
     })
+
     webviews.bindEvent('media-started-playing', function (tabId) {
       tabs.update(tabId, { hasAudio: true })
     })

--- a/js/tabAudio.js
+++ b/js/tabAudio.js
@@ -1,0 +1,75 @@
+var webviews = require('webviews.js')
+var keybindings = require('keybindings.js')
+var getView = remote.getGlobal('getView')
+
+
+var tabAudio = {
+    muteIcon: "carbon:volume-mute-filled",
+    volumeIcon: "carbon:volume-up-filled",
+    setWebViewMuted: function(tabId, muted) {
+        const webView = getView(tabId)
+        if (webView) {
+            webView.webContents.setAudioMuted(muted)
+        }
+    },
+    getButton: function(tabId) {
+        var button = document.createElement('button')
+        button.className = 'tab-icon tab-audio-button i'
+
+        button.setAttribute('data-tab', tabId)
+        button.setAttribute('role', 'button')
+
+        button.addEventListener('click', function (e) {
+            e.stopPropagation()
+            tabAudio.toggleAudio(tabId)
+         
+        })
+
+        tabAudio.updateButton(tabId, button)
+
+        return button
+    },
+    updateButton: function(tabId, button) {
+        // make sure tab data is synced with webview muted
+        tabAudio.setWebViewMuted(tabId, tabs.get(tabId).muted)
+
+        var button = button || document.querySelector('.tab-audio-button[data-tab="{id}"]'.replace('{id}', tabId))
+        var tab = tabs.get(tabId)
+
+        var muteIcon = tabAudio.muteIcon
+        var volumeIcon = tabAudio.volumeIcon
+
+        if (tab.muted) {
+            button.classList.remove(volumeIcon)
+            button.classList.add(muteIcon)
+        } else if (tab.hasAudio) {
+            button.classList.add(volumeIcon)
+            button.classList.remove(muteIcon)
+        } else {
+            button.classList.remove(volumeIcon)
+            button.classList.remove(muteIcon)
+        }
+    },
+    toggleAudio: function(tabId) {
+        var tab = tabs.get(tabId)
+        tabAudio.setWebViewMuted(tabId, !tab.muted)
+        tabs.update(tabId, {muted: !tab.muted})
+    },
+    initialize: function() {
+        keybindings.defineShortcut('toggleTabAudio', function() {
+            tabAudio.toggleAudio(tabs.getSelected())
+        })
+        webviews.bindEvent('media-started-playing', function (tabId) {
+            console.log('started playing', tabId)
+            tabs.update(tabId, {hasAudio: true})
+        })
+        webviews.bindEvent('media-paused', function (tabId) {
+            console.log('media paused', tabId)
+            tabs.update(tabId, {hasAudio: false})
+        })
+    }
+}
+
+tabAudio.initialize()
+
+module.exports = tabAudio

--- a/js/tabAudio.js
+++ b/js/tabAudio.js
@@ -2,68 +2,66 @@ var webviews = require('webviews.js')
 var keybindings = require('keybindings.js')
 var getView = remote.getGlobal('getView')
 
-
 var tabAudio = {
-    muteIcon: "carbon:volume-mute-filled",
-    volumeIcon: "carbon:volume-up-filled",
-    setWebViewMuted: function(tabId, muted) {
-        webviews.callAsync(tabId, "setAudioMuted", muted)
-    },
-    getButton: function(tabId) {
-        var button = document.createElement('button')
-        button.className = 'tab-icon tab-audio-button i'
+  muteIcon: 'carbon:volume-mute-filled',
+  volumeIcon: 'carbon:volume-up-filled',
+  setWebViewMuted: function (tabId, muted) {
+    webviews.callAsync(tabId, 'setAudioMuted', muted)
+  },
+  getButton: function (tabId) {
+    var button = document.createElement('button')
+    button.className = 'tab-icon tab-audio-button i'
 
-        button.setAttribute('data-tab', tabId)
-        button.setAttribute('role', 'button')
+    button.setAttribute('data-tab', tabId)
+    button.setAttribute('role', 'button')
 
-        button.addEventListener('click', function (e) {
-            e.stopPropagation()
-            tabAudio.toggleAudio(tabId)
-         
-        })
+    button.addEventListener('click', function (e) {
+      e.stopPropagation()
+      tabAudio.toggleAudio(tabId)
+    })
 
-        tabAudio.updateButton(tabId, button)
+    tabAudio.updateButton(tabId, button)
 
-        return button
-    },
-    updateButton: function(tabId, button) {
-        var button = button || document.querySelector('.tab-audio-button[data-tab="{id}"]'.replace('{id}', tabId))
-        var tab = tabs.get(tabId)
+    return button
+  },
+  updateButton: function (tabId, button) {
+    var button = button || document.querySelector('.tab-audio-button[data-tab="{id}"]'.replace('{id}', tabId))
+    var tab = tabs.get(tabId)
 
-        var muteIcon = tabAudio.muteIcon
-        var volumeIcon = tabAudio.volumeIcon
+    var muteIcon = tabAudio.muteIcon
+    var volumeIcon = tabAudio.volumeIcon
 
-        if (tab.muted) {
-            button.classList.remove("hidden")
-            button.classList.remove(volumeIcon)
-            button.classList.add(muteIcon)
-        } else if (tab.hasAudio) {
-            button.classList.remove("hidden")
-            button.classList.add(volumeIcon)
-            button.classList.remove(muteIcon)
-        } else {
-            button.classList.add("hidden")
-        }
-    },
-    toggleAudio: function(tabId) {
-        var tab = tabs.get(tabId)
-        // can be muted if has audio, can be unmuted if muted
-        if (tab.hasAudio || tab.muted) {
-            tabAudio.setWebViewMuted(tabId, !tab.muted)
-            tabs.update(tabId, {muted: !tab.muted})
-        }
-    },
-    initialize: function() {
-        keybindings.defineShortcut('toggleTabAudio', function() {
-            tabAudio.toggleAudio(tabs.getSelected())
-        })
-        webviews.bindEvent('media-started-playing', function (tabId) {
-            tabs.update(tabId, {hasAudio: true})
-        })
-        webviews.bindEvent('media-paused', function (tabId) {
-            tabs.update(tabId, {hasAudio: false})
-        })
+    if (tab.muted) {
+      button.hidden = false
+      button.classList.remove(volumeIcon)
+      button.classList.add(muteIcon)
+    } else if (tab.hasAudio) {
+      button.hidden = false
+      button.classList.add(volumeIcon)
+      button.classList.remove(muteIcon)
+    } else {
+      button.hidden = true
     }
+  },
+  toggleAudio: function (tabId) {
+    var tab = tabs.get(tabId)
+    // can be muted if has audio, can be unmuted if muted
+    if (tab.hasAudio || tab.muted) {
+      tabAudio.setWebViewMuted(tabId, !tab.muted)
+      tabs.update(tabId, { muted: !tab.muted })
+    }
+  },
+  initialize: function () {
+    keybindings.defineShortcut('toggleTabAudio', function () {
+      tabAudio.toggleAudio(tabs.getSelected())
+    })
+    webviews.bindEvent('media-started-playing', function (tabId) {
+      tabs.update(tabId, { hasAudio: true })
+    })
+    webviews.bindEvent('media-paused', function (tabId) {
+      tabs.update(tabId, { hasAudio: false })
+    })
+  }
 }
 
 tabAudio.initialize()

--- a/js/tabAudio.js
+++ b/js/tabAudio.js
@@ -8,10 +8,6 @@ var tabAudio = {
     volumeIcon: "carbon:volume-up-filled",
     setWebViewMuted: function(tabId, muted) {
         webviews.callAsync(tabId, "setAudioMuted", muted)
-        // const webView = getView(tabId)
-        // if (webView) {
-        //     webView.webContents.setAudioMuted(muted)
-        // }
     },
     getButton: function(tabId) {
         var button = document.createElement('button')
@@ -38,31 +34,33 @@ var tabAudio = {
         var volumeIcon = tabAudio.volumeIcon
 
         if (tab.muted) {
+            button.classList.remove("hidden")
             button.classList.remove(volumeIcon)
             button.classList.add(muteIcon)
         } else if (tab.hasAudio) {
+            button.classList.remove("hidden")
             button.classList.add(volumeIcon)
             button.classList.remove(muteIcon)
         } else {
-            button.classList.remove(volumeIcon)
-            button.classList.remove(muteIcon)
+            button.classList.add("hidden")
         }
     },
     toggleAudio: function(tabId) {
         var tab = tabs.get(tabId)
-        tabAudio.setWebViewMuted(tabId, !tab.muted)
-        tabs.update(tabId, {muted: !tab.muted})
+        // can be muted if has audio, can be unmuted if muted
+        if (tab.hasAudio || tab.muted) {
+            tabAudio.setWebViewMuted(tabId, !tab.muted)
+            tabs.update(tabId, {muted: !tab.muted})
+        }
     },
     initialize: function() {
         keybindings.defineShortcut('toggleTabAudio', function() {
             tabAudio.toggleAudio(tabs.getSelected())
         })
         webviews.bindEvent('media-started-playing', function (tabId) {
-            console.log('started playing', tabId)
             tabs.update(tabId, {hasAudio: true})
         })
         webviews.bindEvent('media-paused', function (tabId) {
-            console.log('media paused', tabId)
             tabs.update(tabId, {hasAudio: false})
         })
     }

--- a/js/tabAudio.js
+++ b/js/tabAudio.js
@@ -31,9 +31,6 @@ var tabAudio = {
         return button
     },
     updateButton: function(tabId, button) {
-        // make sure tab data is synced with webview muted
-        tabAudio.setWebViewMuted(tabId, tabs.get(tabId).muted)
-
         var button = button || document.querySelector('.tab-audio-button[data-tab="{id}"]'.replace('{id}', tabId))
         var tab = tabs.get(tabId)
 

--- a/js/tabAudio.js
+++ b/js/tabAudio.js
@@ -7,10 +7,11 @@ var tabAudio = {
     muteIcon: "carbon:volume-mute-filled",
     volumeIcon: "carbon:volume-up-filled",
     setWebViewMuted: function(tabId, muted) {
-        const webView = getView(tabId)
-        if (webView) {
-            webView.webContents.setAudioMuted(muted)
-        }
+        webviews.callAsync(tabId, "setAudioMuted", muted)
+        // const webView = getView(tabId)
+        // if (webView) {
+        //     webView.webContents.setAudioMuted(muted)
+        // }
     },
     getButton: function(tabId) {
         var button = document.createElement('button')

--- a/js/tabState/tab.js
+++ b/js/tabState/tab.js
@@ -20,7 +20,7 @@ class TabList {
       scrollPosition: tab.scrollPosition || 0,
       selected: tab.selected || false,
       muted: tab.muted || false,
-      hasAudio: tab.hasAudio || false
+      hasAudio: false
     }
 
     if (options.atEnd) {

--- a/js/tabState/tab.js
+++ b/js/tabState/tab.js
@@ -18,7 +18,9 @@ class TabList {
       themeColor: tab.themeColor,
       backgroundColor: tab.backgroundColor,
       scrollPosition: tab.scrollPosition || 0,
-      selected: tab.selected || false
+      selected: tab.selected || false,
+      muted: tab.muted || false,
+      hasAudio: tab.hasAudio || false
     }
 
     if (options.atEnd) {

--- a/js/util/keyMap.js
+++ b/js/util/keyMap.js
@@ -23,7 +23,8 @@ var defaultKeyMap = {
   'reload': 'mod+r',
   'showMenu': 'ctrl+m',
   'followLink': 'mod+enter',
-  'fillPassword': 'mod+\\'
+  'fillPassword': 'mod+\\',
+  'toggleTabAudio': 'shift+mod+m'
 }
 /* Utility function to override default mapping with user settings */
 function userKeyMap (settings) {


### PR DESCRIPTION
In response to Can't Mute Tab Issue #1221
This enables the user to mute a tab with a shortcut. By default it is `shift+mod+m`.

Whenever a tab has muted setting enabled it will show the muted icon next to the tab, even if the tab has no audio playing. The playing speaker icon will only show if a tab is playing audible audio. Otherwise, no icon is shown.

I did run into an issue with the icon being taller than the tab title. Not sure if we want to shrink the icon or keep at the same size as the other icons in the nav bar.


![Screen Shot 2020-09-05 at 6 29 35 PM](https://user-images.githubusercontent.com/27718632/92316225-d62ae880-efa5-11ea-9ac8-b05d468f2778.png)
