### PR TITLE
Added escaped quotes to concurrently script

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "test": "node_modules/.bin/standard --verbose js/**/*.js main/*.js",
     "watch": "node ./scripts/watch.js",
     "startElectron": "./node_modules/.bin/electron . --development-mode",
-    "start": "npm run build && ./node_modules/.bin/concurrently \"npm run watch\" \"npm run startElectron\"",
+    "start": "npm run build && \"./node_modules/.bin/concurrently\" \"npm run watch\" \"npm run startElectron\"",
     "buildMain": "node ./scripts/buildMain.js",
     "buildBrowser": "node ./scripts/buildBrowser.js",
     "buildPreload": "node ./scripts/buildPreload.js",


### PR DESCRIPTION
For some reason, when I run `npm run start`, I get an error that '.' is not defined. It seemed that npm had trouble running `./node_modules/.bin/concurrently` for whatever reason. I ran this command through PowerShell on Windows 10. Enclosing the command in escaped quotes fixed the issue. It is very likely that I am doing something wrong as I would think a Windows developer would have encountered this immediately.