### PR TITLE
npm run start path not recognized

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test": "node_modules/.bin/standard --verbose js/**/*.js main/*.js",
     "watch": "node ./scripts/watch.js",
     "startElectron": "./node_modules/.bin/electron . --development-mode",
-    "start": "npm run build && ./node_modules/.bin/concurrently \"npm run watch\" \"npm run startElectron\"",
+    "start": "npm run build && \"./node_modules/.bin/concurrently\" \"npm run watch\" \"npm run startElectron\"",
     "buildMain": "node ./scripts/buildMain.js",
     "buildBrowser": "node ./scripts/buildBrowser.js",
     "buildPreload": "node ./scripts/buildPreload.js",


### PR DESCRIPTION
'.' is not recognized as an internal or external command, operable program or batch file.
This seems to be fixed by adding escaped quotation marks.
This is the same fix as proposed in the PR https://github.com/minbrowser/min/pull/1236