### PR TITLE
update package json scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
   },
   "license": "Apache-2.0",
   "scripts": {
-    "test": "node_modules/.bin/standard --verbose js/**/*.js main/*.js",
+    "test": "standard --verbose js/**/*.js main/*.js",
     "watch": "node ./scripts/watch.js",
-    "startElectron": "./node_modules/.bin/electron . --development-mode",
-    "start": "npm run build && \"./node_modules/.bin/concurrently\" \"npm run watch\" \"npm run startElectron\"",
+    "startElectron": "electron . --development-mode",
+    "start": "npm run build && \"concurrently\" \"npm run watch\" \"npm run startElectron\"",
     "buildMain": "node ./scripts/buildMain.js",
     "buildBrowser": "node ./scripts/buildBrowser.js",
     "buildPreload": "node ./scripts/buildPreload.js",


### PR DESCRIPTION
Hello! I know this was previously "fixed" - but it wasn't. 
This changes using `node_modules/.bin/concurrently` *just an example* to using `concurrently` *still an example*

This allows all scripts to be ran on windows now but requires that you have to have the NodeJS path variable configured correctly.

Thanks! 🎉