### PR TITLE
fix concurrently scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "test": "standard --verbose js/**/*.js main/*.js",
     "watch": "node ./scripts/watch.js",
     "startElectron": "electron . --development-mode",
-    "start": "npm run build && \"concurrently\" \"npm run watch\" \"npm run startElectron\"",
+    "start": "npm run build && concurrently \"npm run watch\" \"npm run startElectron\"",
     "buildMain": "node ./scripts/buildMain.js",
     "buildBrowser": "node ./scripts/buildBrowser.js",
     "buildPreload": "node ./scripts/buildPreload.js",


### PR DESCRIPTION
fix start script

this was a bug on windows where it couldn't find the parents directory /concurrently, for example:

Min: GitHub/Min
Cannot find GitHub/concurrently/bin/concurrently.js

Well this fixes it, just by removing some quotes, out of every thing I've tested - everything on linux and macOs still work