### PR TITLE
Add basic touchbar support

### DIFF
--- a/js/menuRenderer.js
+++ b/js/menuRenderer.js
@@ -48,6 +48,10 @@ module.exports = {
       webviews.callAsync(tabs.getSelected(), 'toggleDevTools')
     })
 
+    ipc.on('openEditor', function () {
+      tabEditor.show(tabs.getSelected())
+    })
+
     ipc.on('showBookmarks', function () {
       tabEditor.show(tabs.getSelected(), '!bookmarks ')
     })
@@ -132,6 +136,10 @@ module.exports = {
       browserUI.addTab(tabs.add({
         private: true
       }))
+    })
+
+    ipc.on('toggleTaskOverlay', function () {
+      taskOverlay.toggle()
     })
 
     ipc.on('goBack', function () {

--- a/main/main.js
+++ b/main/main.js
@@ -282,6 +282,8 @@ function createWindowWithBounds (bounds) {
     }
   })
 
+  mainWindow.setTouchBar(buildTouchBar())
+
   return mainWindow
 }
 

--- a/main/touchbar.js
+++ b/main/touchbar.js
@@ -3,6 +3,10 @@ const nativeImage = require('electron').nativeImage
 const { TouchBarLabel, TouchBarButton, TouchBarSpacer } = TouchBar
 
 function buildTouchBar () {
+  if (process.platform !== 'darwin') {
+    return null
+  }
+
   return new TouchBar({
     items: [
       new TouchBarButton({

--- a/main/touchbar.js
+++ b/main/touchbar.js
@@ -1,0 +1,42 @@
+const TouchBar = require('electron').TouchBar
+const nativeImage = require('electron').nativeImage
+const { TouchBarLabel, TouchBarButton, TouchBarSpacer } = TouchBar
+
+function buildTouchBar () {
+  return new TouchBar({
+    items: [
+      new TouchBarButton({
+        accessibilityLabel: l('goBack'),
+        icon: nativeImage.createFromNamedImage('NSImageNameTouchBarGoBackTemplate', [-1, 0, 1]),
+        click: function () {
+          sendIPCToWindow(mainWindow, 'goBack')
+        }
+      }),
+      new TouchBarSpacer({ size: 'flexible' }),
+      new TouchBarButton({
+        icon: nativeImage.createFromNamedImage('NSImageNameTouchBarSearchTemplate', [-1, 0, 1]),
+        iconPosition: 'left',
+        // TODO this is really hacky, find a better way to set the size
+        label: '    ' + l('searchbarPlaceholder') + '                                ',
+        click: function () {
+          sendIPCToWindow(mainWindow, 'openEditor')
+        }
+      }),
+      new TouchBarSpacer({ size: 'flexible' }),
+      new TouchBarButton({
+        icon: nativeImage.createFromNamedImage('NSImageNameTouchBarAdd', [-1, 0, 1]),
+        accessibilityLabel: l('newTabAction'),
+        click: function () {
+          sendIPCToWindow(mainWindow, 'addTab')
+        }
+      }),
+      new TouchBarButton({
+        accessibilityLabel: l('viewTasks'),
+        icon: nativeImage.createFromNamedImage('NSImageNameTouchBarListViewTemplate', [-1, 0, 1]),
+        click: function () {
+          sendIPCToWindow(mainWindow, 'toggleTaskOverlay')
+        }
+      })
+    ]
+  })
+}

--- a/scripts/buildMain.js
+++ b/scripts/buildMain.js
@@ -6,6 +6,7 @@ const outFile = path.resolve(__dirname, '../main.build.js')
 const modules = [
   'dist/localization.build.js',
   'main/menu.js',
+  'main/touchbar.js',
   'main/registryConfig.js',
   'main/main.js',
   'js/util/settings/settings.js',


### PR DESCRIPTION
Fixes #335.

I kept the available actions pretty simple now, basically just the same actions as what's in the tab bar:

<img width="1004" alt="Touch Bar Shot 2020-11-19 at 9 52 26 PM" src="https://user-images.githubusercontent.com/10314059/99756655-43352100-2ab3-11eb-93eb-585cdb8048e1.png">

I don't actually have a touchbar to test this on (just the simulator), so I don't have a good sense of what would be useful, but if anyone has more ideas, let me know.

(The biggest one is probably showing a list of open tabs, but it's reasonably complicated to send the tab list to the parent process to do that, so I want to skip doing that for now).