### PR TITLE
Add usage statistics collection

### DIFF
--- a/docs/statistics.md
+++ b/docs/statistics.md
@@ -1,0 +1,17 @@
+## Usage statistics collection in Min
+
+By default, Min sends some statistics about how it's used. Currently, these include:
+
+* Your operating system and computer language
+* When you installed Min
+* The version of Min that you're using
+* How often you use certain features in Min
+* An anonymous ID representing your installation of Min
+
+Collecting this data allows us to prioritize which devices and operating systems we test and which features we work on.
+
+Min does not send:
+* Anything that can be used to personally identify you
+* Any browsing history, passwords, or other data stored locally in Min
+
+If you want to opt-out of statistics collection, you can do so by going to the preferences page within Min and de-selecting "send usage statistics".

--- a/js/default.js
+++ b/js/default.js
@@ -149,6 +149,7 @@ require('passwordManager/passwordCapture.js').initialize()
 require('passwordManager/passwordViewer.js').initialize()
 require('util/theme.js').initialize()
 require('userscripts.js').initialize()
+require('statistics.js').initialize()
 
 // default searchbar plugins
 

--- a/js/statistics.js
+++ b/js/statistics.js
@@ -15,7 +15,8 @@ const statistics = {
         clientID: settings.get('clientID'),
         installTime: settings.get('installTime'),
         os: process.platform,
-        lang: navigator.language
+        lang: navigator.language,
+        appVersion: window.globalArgs['app-version']
       })
     })
       .catch(e => console.warn('failed to send usage statistics', e))

--- a/js/statistics.js
+++ b/js/statistics.js
@@ -25,11 +25,19 @@ const statistics = {
     setTimeout(statistics.upload, 10000)
     setInterval(statistics.upload, 24 * 60 * 60 * 1000)
 
-    if (!settings.get('clientID')) {
-      settings.set('clientID', Math.random().toString().slice(2))
-    }
+    settings.listen('collectUsageStats', function (value) {
+      if (value === false) {
+        // disabling stats collection should reset client ID
+        settings.set('clientID', undefined)
+      } else if (!settings.get('clientID')) {
+        settings.set('clientID', Math.random().toString().slice(2))
+      }
+    })
+
     if (!settings.get('installTime')) {
-      settings.set('installTime', Date.now())
+      // round install time to nearest hour to reduce uniqueness
+      const roundingFactor = 60 * 60 * 1000
+      settings.set('installTime', Math.floor(Date.now() / roundingFactor) * roundingFactor)
     }
   }
 }

--- a/js/statistics.js
+++ b/js/statistics.js
@@ -1,0 +1,36 @@
+const settings = require('util/settings/settings.js')
+
+const statistics = {
+  upload: function () {
+    if (settings.get('collectUsageStats') === false) {
+      return
+    }
+
+    fetch('https://services.minbrowser.org/stats/v1/collect', {
+      method: 'post',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        clientID: settings.get('clientID'),
+        installTime: settings.get('installTime'),
+        os: process.platform,
+        lang: navigator.language
+      })
+    })
+      .catch(e => console.warn('failed to send usage statistics', e))
+  },
+  initialize: function () {
+    setTimeout(statistics.upload, 10000)
+    setInterval(statistics.upload, 24 * 60 * 60 * 1000)
+
+    if (!settings.get('clientID')) {
+      settings.set('clientID', Math.random().toString().slice(2))
+    }
+    if (!settings.get('installTime')) {
+      settings.set('installTime', Date.now())
+    }
+  }
+}
+
+module.exports = statistics

--- a/localization/languages/ar.json
+++ b/localization/languages/ar.json
@@ -154,6 +154,7 @@
     },
     "settingsUserAgentToggle": null, //missing translation
     "settingsUpdateNotificationsToggle": null, //missing translation
+    "settingsUsageStatisticsToggle": null, //missing translation
     "settingsSearchEngineHeading": "محرك بحث",
     "settingsDefaultSearchEngine": "اختر محرك بحث اساسي",
     "settingsDDGExplanation": "كمحرك بحث اساسي لرؤية النتائج الآنية في مربع البحث DuckDuckGo ",

--- a/localization/languages/bg.json
+++ b/localization/languages/bg.json
@@ -153,6 +153,7 @@
     },
     "settingsUserAgentToggle": "Използване на персонализиран потребителски агент",
     "settingsUpdateNotificationsToggle": "Автоматично проверяване за актуализации",
+    "settingsUsageStatisticsToggle": null, //missing translation
     "settingsSearchEngineHeading": "Търсачки",
     "settingsDefaultSearchEngine": "Изберете търсачка по подразбиране:",
     "settingsDDGExplanation": "Поставете DuckDuckGo като търсачка по подразбиране, за да получавате моментални отговори в лентата за търсене.",

--- a/localization/languages/bn.json
+++ b/localization/languages/bn.json
@@ -154,6 +154,7 @@
     },
     "settingsUserAgentToggle": "একটি কাস্টম ব্যবহারকারী এজেন্ট ব্যবহার করুন",
     "settingsUpdateNotificationsToggle": "স্বয়ংক্রিয়ভাবে আপডেটগুলির জন্য পরীক্ষা করুন",
+    "settingsUsageStatisticsToggle": null, //missing translation
     "settingsSearchEngineHeading": "খোঁজ যন্ত্র",
     "settingsDefaultSearchEngine": "একটি ডিফল্ট অনুসন্ধান ইঞ্জিন চয়ন করুন:",
     "settingsDDGExplanation": "Searchbar এ তাত্ক্ষণিক উত্তর দেখতে ডিফল্ট অনুসন্ধান ইঞ্জিন হিসাবে DuckDuckGo সেট করুন।",

--- a/localization/languages/cs.json
+++ b/localization/languages/cs.json
@@ -154,6 +154,7 @@
     },
     "settingsUserAgentToggle": "Použít vlastní user agent",
     "settingsUpdateNotificationsToggle": "Automaticky kontrolovat aktualizace",
+    "settingsUsageStatisticsToggle": null, //missing translation
     "settingsSearchEngineHeading": "Vyhledávač",
     "settingsDefaultSearchEngine": "Zvolte si výchozí vyhledávač:",
     "settingsDDGExplanation": "Nastavte DuckDuckGo jako výchozí vyhledávač pro zobrazování okamžitých odpovědí ve vyhledávacím panelu.",

--- a/localization/languages/de.json
+++ b/localization/languages/de.json
@@ -154,6 +154,7 @@
     },
     "settingsUserAgentToggle": "Benutzerdefiniertes Benutzer-Agent nutzen",
     "settingsUpdateNotificationsToggle": "Automatisch nach Aktualisierungen überprüfen",
+    "settingsUsageStatisticsToggle": null, //missing translation
     "settingsSearchEngineHeading": "Suchmaschine",
     "settingsDefaultSearchEngine": "Standardsuchmaschine auswählen:",
     "settingsDDGExplanation": "DuckDuckGo als Standardsuchmaschine einstellen, um sofort Vorschläge in der Suchleiste zu erhalten.",

--- a/localization/languages/en-US.json
+++ b/localization/languages/en-US.json
@@ -154,6 +154,9 @@
     },
     "settingsUserAgentToggle": "Use a custom user agent",
     "settingsUpdateNotificationsToggle": "Automatically check for updates",
+    "settingsUsageStatisticsToggle": {
+      "unsafeHTML": "Send usage statistics (<a href=\"https://github.com/minbrowser/min/blob/master/docs/statistics.md\">More info</a>)"
+     },
     "settingsSearchEngineHeading": "Search Engine",
     "settingsDefaultSearchEngine": "Choose a default search engine:",
     "settingsDDGExplanation": "Set DuckDuckGo as the default search engine to see instant answers in the searchbar.",

--- a/localization/languages/es.json
+++ b/localization/languages/es.json
@@ -152,6 +152,7 @@
     "settingsUserscriptsExplanation": null, //missing translation
     "settingsUserAgentToggle": null, //missing translation
     "settingsUpdateNotificationsToggle": null, //missing translation
+    "settingsUsageStatisticsToggle": null, //missing translation
     "settingsSearchEngineHeading": "Motor de búsqueda",
     "settingsDefaultSearchEngine": "Elija un motor de búsqueda predeterminado:",
     "settingsDDGExplanation": "Establezca DuckDuckGo como motor de búsqueda predeterminado para ver respuestas instantáneas en la barra de búsqueda.",

--- a/localization/languages/fa.json
+++ b/localization/languages/fa.json
@@ -154,6 +154,7 @@
     },
     "settingsUserAgentToggle": null, //missing translation
     "settingsUpdateNotificationsToggle": null, //missing translation
+    "settingsUsageStatisticsToggle": null, //missing translation
     "settingsSearchEngineHeading": "موتور جستجو",
     "settingsDefaultSearchEngine": "انتخاب موتور جستجوی پیش فرض:",
     "settingsDDGExplanation": "DuckDuckGo را به عنوان موتور جستجوی پیش فرض تنظیم کنید تا در نوار جستجو نتایج آنی ببینید.",

--- a/localization/languages/fr.json
+++ b/localization/languages/fr.json
@@ -154,6 +154,7 @@
     },
     "settingsUserAgentToggle": "Utiliser un user-agent particulier",
     "settingsUpdateNotificationsToggle": "Vérifier automatiquement pour des mises à jour",
+    "settingsUsageStatisticsToggle": null, //missing translation
     "settingsSearchEngineHeading": "Moteur de recherche",
     "settingsDefaultSearchEngine": "Choisir un moteur de recherche par défaut :",
     "settingsDDGExplanation": "Définir DuckDuckGo comme moteur de recherche par défaut pour voir instantanément des résulats dans la barre de recherche.",

--- a/localization/languages/hu.json
+++ b/localization/languages/hu.json
@@ -152,6 +152,7 @@
     "settingsUserscriptsExplanation": "Felhasználói szkript magyarázat",
     "settingsUserAgentToggle": null, //missing translation
     "settingsUpdateNotificationsToggle": null, //missing translation
+    "settingsUsageStatisticsToggle": null, //missing translation
     "settingsSearchEngineHeading": "Keresőmotor",
     "settingsDefaultSearchEngine": "Válasza ki az alap keresőmotort:",
     "settingsDDGExplanation": "Állitsa be a DuckDuckGo keresőmotort, hogy lássa a válaszokat a keresősorban.",

--- a/localization/languages/it.json
+++ b/localization/languages/it.json
@@ -154,6 +154,7 @@
     },
     "settingsUserAgentToggle": null, //missing translation
     "settingsUpdateNotificationsToggle": "Controlla automaticamente la presenza di aggiornamenti",
+    "settingsUsageStatisticsToggle": null, //missing translation
     "settingsSearchEngineHeading": "Motore di ricerca",
     "settingsDefaultSearchEngine": "Scegli un motore di ricerca predefinito:",
     "settingsDDGExplanation": "Imposta DuckDuckGo come motore di ricerca predefinito per vedere risposte istantanee nella barra di ricerca.",

--- a/localization/languages/ja.json
+++ b/localization/languages/ja.json
@@ -154,6 +154,7 @@
     },
     "settingsUserAgentToggle": "カスタムユーザーエージェントを使用する",
     "settingsUpdateNotificationsToggle": "アップデートを自動的に確認する",
+    "settingsUsageStatisticsToggle": null, //missing translation
     "settingsSearchEngineHeading": "検索エンジン",
     "settingsDefaultSearchEngine": "デフォルトの検索エンジン:",
     "settingsDDGExplanation": "検索バーにインスタントアンサーを表示するには、DuckDuckGoをデフォルトの検索エンジンに設定してください。",

--- a/localization/languages/ko.json
+++ b/localization/languages/ko.json
@@ -154,6 +154,7 @@
     },
     "settingsUserAgentToggle": "사용자 정의 에이전트(UserAgent) 사용",
     "settingsUpdateNotificationsToggle": "판올림 자동 확인",
+    "settingsUsageStatisticsToggle": null, //missing translation
     "settingsSearchEngineHeading": "검색 도구",
     "settingsDefaultSearchEngine": "기본 검색 도구:",
     "settingsDDGExplanation": "덕덕고(DuckDuckGo)를 기본 검색 도구로 설정하여 검색 창에서 바로 검색해 보세요.",

--- a/localization/languages/lt.json
+++ b/localization/languages/lt.json
@@ -154,6 +154,7 @@
     },
     "settingsUserAgentToggle": null, //missing translation
     "settingsUpdateNotificationsToggle": "Automatiškai tikrinti ar yra atnaujinimų",
+    "settingsUsageStatisticsToggle": null, //missing translation
     "settingsSearchEngineHeading": "Paieškos sistema",
     "settingsDefaultSearchEngine": "Pasirinkite numatytąją paieškos sistemą:",
     "settingsDDGExplanation": "Nustatykite DuckDuckGo kaip numatytąją paieškos sistemą, norėdami paieškos juostoje matyti greitus atsakymus.",

--- a/localization/languages/pl.json
+++ b/localization/languages/pl.json
@@ -154,6 +154,7 @@
     },
     "settingsUserAgentToggle": "Użyj niestandardowego klienta użytkownika",
     "settingsUpdateNotificationsToggle": "Automatycznie sprawdź dostępność aktualizacji",
+    "settingsUsageStatisticsToggle": null, //missing translation
     "settingsSearchEngineHeading": "Wyszukiwarka",
     "settingsDefaultSearchEngine": "Wybierz domyślną wyszukiwarkę:",
     "settingsDDGExplanation": "Ustaw DuckDuckGo jako domyślną wyszukiwarkę, aby zobaczyć błyskawiczne odpowiedzi na pasku wyszukiwania.",

--- a/localization/languages/pt-BR.json
+++ b/localization/languages/pt-BR.json
@@ -154,6 +154,7 @@
     },
     "settingsUserAgentToggle": "Usar agente de usuário personalizado",
     "settingsUpdateNotificationsToggle": "Verificar atualizações automaticamente",
+    "settingsUsageStatisticsToggle": null, //missing translation
     "settingsSearchEngineHeading": "Serviço de busca",
     "settingsDefaultSearchEngine": "Escolha o serviço de busca padrão:",
     "settingsDDGExplanation": "Defina DuckDuckGo como o serviço padrão de buscas para ver respostas instantâneas na barra de busca.",

--- a/localization/languages/pt-PT.json
+++ b/localization/languages/pt-PT.json
@@ -154,6 +154,7 @@
     },
     "settingsUserAgentToggle": "Utilizar agente de utilizador personalizado",
     "settingsUpdateNotificationsToggle": "Procurar atualizações automaticamente",
+    "settingsUsageStatisticsToggle": null, //missing translation
     "settingsSearchEngineHeading": "Motor de pesquisa",
     "settingsDefaultSearchEngine": "Escolha o motor de pesquisa padrão:",
     "settingsDDGExplanation": "Defina DuckDuckGo como motor de pesquisa padrão para poder obter sugestões imediatas na barra de pesquisa.",

--- a/localization/languages/ru.json
+++ b/localization/languages/ru.json
@@ -154,6 +154,7 @@
     },
     "settingsUserAgentToggle": "Использовать пользовательский user agent",
     "settingsUpdateNotificationsToggle": "Автоматически проверять наличие обновлений",
+    "settingsUsageStatisticsToggle": null, //missing translation
     "settingsSearchEngineHeading": "Поиск",
     "settingsDefaultSearchEngine": "Выберите поисковую систему по умолчанию:",
     "settingsDDGExplanation": "Чтобы видеть мгновенные ответы в строке поиска, установите DuckDuckGo поисковиком по умолчанию.",

--- a/localization/languages/tr.json
+++ b/localization/languages/tr.json
@@ -154,6 +154,7 @@
     },
     "settingsUserAgentToggle": "Özel kullanıcı aracısı kullan",
     "settingsUpdateNotificationsToggle": "Güncelleştirmeleri otomatik olarak denetle",
+    "settingsUsageStatisticsToggle": null, //missing translation
     "settingsSearchEngineHeading": "Arama Motoru",
     "settingsDefaultSearchEngine": "Bir varsayılan arama motoru seçin:",
     "settingsDDGExplanation": "Arama çubuğundaki anlık yanıtları görmek için DuckDuckGo’yu varsayılan arama motoru olarak ayarlayın.",

--- a/localization/languages/uk.json
+++ b/localization/languages/uk.json
@@ -155,6 +155,7 @@
     },
     "settingsUserAgentToggle": "Використовувати власний агент користувача",
     "settingsUpdateNotificationsToggle": "Автоматично перевіряти наявність оновлень",
+    "settingsUsageStatisticsToggle": null, //missing translation
     "settingsSearchEngineHeading": "Пошукова система",
     "settingsDefaultSearchEngine": "Виберіть типову пошукову систему:",
     "settingsDDGExplanation": "Встановіть DuckDuckGo як типову пошукову систему, щоб побачити миттєві відповіді на панелі пошуку.",

--- a/localization/languages/uz.json
+++ b/localization/languages/uz.json
@@ -154,6 +154,7 @@
     },
     "settingsUserAgentToggle": "Maxsus foydalanvuchi agentidan foydalanish",
     "settingsUpdateNotificationsToggle": " Yangilanishlarni avtomatik ravishda tekshirish",
+    "settingsUsageStatisticsToggle": null, //missing translation
     "settingsSearchEngineHeading": "Qidiruv Tizimi",
     "settingsDefaultSearchEngine": "Standart qidiruv tizimini tanlang:",
     "settingsDDGExplanation": "Qidiruv panelida tezkor javoblarni ko'rish uchun DuckDuckGo ni standart qidiruv tizimi sifatida o'rnating.",

--- a/localization/languages/vi.json
+++ b/localization/languages/vi.json
@@ -148,6 +148,7 @@
     },
     "settingsUserAgentToggle": null, //missing translation
     "settingsUpdateNotificationsToggle": "Tự động kiểm tra cập nhật",
+    "settingsUsageStatisticsToggle": null, //missing translation
     "settingsSearchEngineHeading": "Công cụ tìm kiếm",
     "settingsDefaultSearchEngine": "Chọn công cụ tìm kiếm mặc định:",
     "settingsDDGExplanation": "Đặt DuckDuckGo thành công cụ tìm kiếm mặc định để xem câu trả lời ngay trong thanh tìm kiếm.",

--- a/localization/languages/zh-CN.json
+++ b/localization/languages/zh-CN.json
@@ -154,6 +154,7 @@
     },
     "settingsUserAgentToggle": null, //missing translation
     "settingsUpdateNotificationsToggle": "自动检查更新",
+    "settingsUsageStatisticsToggle": null, //missing translation
     "settingsSearchEngineHeading": "搜索引擎",
     "settingsDefaultSearchEngine": "选择默认的搜索引擎:",
     "settingsDDGExplanation": "将 DuckDuckGo 设为默认的搜索引擎可以直接在搜索栏查看搜索结果。",

--- a/localization/languages/zh-TW.json
+++ b/localization/languages/zh-TW.json
@@ -154,6 +154,7 @@
     },
     "settingsUserAgentToggle": "使用自訂使用者代理",
     "settingsUpdateNotificationsToggle": "自動檢查更新",
+    "settingsUsageStatisticsToggle": null, //missing translation
     "settingsSearchEngineHeading": "搜索引擎",
     "settingsDefaultSearchEngine": "選擇預設的搜索引擎：",
     "settingsDDGExplanation": "將 DuckDuckGo 設為預設的搜索引擎可以直接在網址欄查看搜尋結果",

--- a/pages/settings/index.html
+++ b/pages/settings/index.html
@@ -182,6 +182,14 @@
           data-string="settingsUpdateNotificationsToggle"
         ></label>
       </div>
+      <div class="setting-section">
+        <input type="checkbox" id="checkbox-usage-statistics" />
+        <label
+          for="checkbox-usage-statistics"
+          data-string="settingsUsageStatisticsToggle"
+          data-allowHTML
+        ></label>
+      </div>
     </div>
 
     <div class="settings-container" id="search-engine-settings-container">

--- a/pages/settings/settings.js
+++ b/pages/settings/settings.js
@@ -306,6 +306,22 @@ updateNotificationsCheckbox.addEventListener('change', function (e) {
   settings.set('updateNotificationsEnabled', this.checked)
 })
 
+/* usage statistics setting */
+
+var usageStatisticsCheckbox = document.getElementById('checkbox-usage-statistics')
+
+settings.get('collectUsageStats', function (value) {
+  if (value === false) {
+    usageStatisticsCheckbox.checked = false
+  } else {
+    usageStatisticsCheckbox.checked = true
+  }
+})
+
+usageStatisticsCheckbox.addEventListener('change', function (e) {
+  settings.set('collectUsageStats', this.checked)
+})
+
 /* default search engine setting */
 
 var searchEngineDropdown = document.getElementById('default-search-engine')


### PR DESCRIPTION
This PR adds a way to collect usage statistics, which allows us to answer questions like "How many users does Min have?", and "which operating systems are most frequently used?". Eventually, this can also be expanded to include things like "How often is feature X used?", which should make it easier to prioritize what to work on.

I'm going to start writing a document soon that describes what's collected in more detail (which will be linked to from the settings page), but in summary:

* We won't collect anything that can be used to identify individual users.
* We won't collect any browsing history, passwords, or other data stored in Min.
* There's an option to opt-out on the settings page.

Todo:

 - [x] Add app version to collected data