### PR TITLE
Added textarea for ads and trackers whitelist in settings

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -91,7 +91,8 @@ a {
   color: dodgerblue;
 }
 
-.dark-mode input {
+.dark-mode input,
+.dark-mode textarea {
   background-color: rgb(52, 58, 68);
   color: white;
   border-color: transparent;

--- a/pages/settings/index.html
+++ b/pages/settings/index.html
@@ -59,11 +59,11 @@
               for="content-blocking-exceptions"
               data-string="settingsContentBlockingExceptions"
             ></label>
-            <input
-              type="text"
+            <textarea
+              spellcheck="false"
               id="content-blocking-exceptions"
               style="width: 100%; max-width: 500px"
-            />
+            ></textarea>
           </div>
           <a
             id="customize-filters-link"

--- a/pages/settings/index.html
+++ b/pages/settings/index.html
@@ -63,6 +63,7 @@
               spellcheck="false"
               id="content-blocking-exceptions"
               style="width: 100%; max-width: 500px"
+              rows="1"
             ></textarea>
           </div>
           <a

--- a/pages/settings/settings.css
+++ b/pages/settings/settings.css
@@ -136,6 +136,10 @@ html {
   margin: 0.75em 0.5em 0 1.58em;
 }
 
+#content-blocking-information textarea {
+  resize: vertical;
+}
+
 #customize-filters-link {
   display: block;
   margin-top: 0.66em;

--- a/pages/settings/settings.css
+++ b/pages/settings/settings.css
@@ -62,6 +62,7 @@ html {
   padding-left: 0.33em;
 }
 .setting-section label + input,
+.setting-section label + textarea,
 .setting-section label + select {
   margin-left: 0.66em;
 }
@@ -137,6 +138,7 @@ html {
 }
 
 #content-blocking-information textarea {
+  vertical-align: text-bottom;
   resize: vertical;
 }
 

--- a/pages/settings/settings.js
+++ b/pages/settings/settings.js
@@ -61,6 +61,10 @@ function changeBlockingLevelSetting (level) {
   })
 }
 
+function setExceptionInputSize () {
+  blockingExceptionsInput.style.height = (blockingExceptionsInput.scrollHeight + 2) + 'px'
+}
+
 settings.get('filtering', function (value) {
   // migrate from old settings (<v1.9.0)
   if (value && typeof value.trackers === 'boolean') {
@@ -81,6 +85,7 @@ settings.get('filtering', function (value) {
 
   if (value && value.exceptionDomains && value.exceptionDomains.length > 0) {
     blockingExceptionsInput.value = value.exceptionDomains.join(', ') + ', '
+    setExceptionInputSize()
   }
 })
 
@@ -91,6 +96,8 @@ trackingLevelOptions.forEach(function (item, idx) {
 })
 
 blockingExceptionsInput.addEventListener('input', function () {
+  setExceptionInputSize()
+
   // remove protocols because of https://github.com/minbrowser/min/issues/1428
   var newValue = this.value.split(',').map(i => i.trim().replace('http://', '').replace('https://', '')).filter(i => !!i)
 


### PR DESCRIPTION
Note: Spellcheck **should** be disabled by default for textarea, but I think it's safer to include in case it ever changes.
Fixes #1427 