### PR TITLE
Translation for the sending usage statistics

### DIFF
--- a/localization/languages/fr.json
+++ b/localization/languages/fr.json
@@ -159,7 +159,7 @@
     },
     "settingsUserAgentToggle": "Utiliser un user-agent particulier",
     "settingsUpdateNotificationsToggle": "Vérifier automatiquement pour des mises à jour",
-    "settingsUsageStatisticsToggle": "Envoyer des statistiques d'utilisation",
+    "settingsUsageStatisticsToggle": "Envoyer des statistiques d'utilisation (<a href=\"https://github.com/minbrowser/min/blob/master/docs/statistics.md\">Quelles statistiques ?</a>)",
     "settingsSearchEngineHeading": "Moteur de recherche",
     "settingsDefaultSearchEngine": "Choisir un moteur de recherche par défaut :",
     "settingsDDGExplanation": "Définir DuckDuckGo comme moteur de recherche par défaut pour voir instantanément des résulats dans la barre de recherche.",

--- a/localization/languages/fr.json
+++ b/localization/languages/fr.json
@@ -159,7 +159,9 @@
     },
     "settingsUserAgentToggle": "Utiliser un user-agent particulier",
     "settingsUpdateNotificationsToggle": "Vérifier automatiquement pour des mises à jour",
-    "settingsUsageStatisticsToggle": "Envoyer des statistiques d'utilisation (<a href=\"https://github.com/minbrowser/min/blob/master/docs/statistics.md\">Quelles statistiques ?</a>)",
+    "settingsUsageStatisticsToggle": {
+          "unsafeHTML": "Envoyer des statistiques d'utilisation (<a href=\"https://github.com/minbrowser/min/blob/master/docs/statistics.md\">Quelles statistiques ?</a>)"
+    },
     "settingsSearchEngineHeading": "Moteur de recherche",
     "settingsDefaultSearchEngine": "Choisir un moteur de recherche par défaut :",
     "settingsDDGExplanation": "Définir DuckDuckGo comme moteur de recherche par défaut pour voir instantanément des résulats dans la barre de recherche.",

--- a/localization/languages/fr.json
+++ b/localization/languages/fr.json
@@ -159,7 +159,7 @@
     },
     "settingsUserAgentToggle": "Utiliser un user-agent particulier",
     "settingsUpdateNotificationsToggle": "Vérifier automatiquement pour des mises à jour",
-    "settingsUsageStatisticsToggle": null, //missing translation
+    "settingsUsageStatisticsToggle": "Envoyer des statistiques d'utilisation",
     "settingsSearchEngineHeading": "Moteur de recherche",
     "settingsDefaultSearchEngine": "Choisir un moteur de recherche par défaut :",
     "settingsDDGExplanation": "Définir DuckDuckGo comme moteur de recherche par défaut pour voir instantanément des résulats dans la barre de recherche.",


### PR DESCRIPTION
I've noticed that the "Custom bangs", and same for the shortcut section at the end of the preferences is not in the translation file, I'll be happy to translate it if you add it there :)