### PR TITLE
Enable "use separate title bar" setting for all platforms (not just Linux)

### DIFF
--- a/css/windowControls.css
+++ b/css/windowControls.css
@@ -9,13 +9,13 @@ body {
   display: none;
 }
 
-body.windows:not(.maximized):not(.fullscreen),
+body.windows:not(.maximized):not(.fullscreen):not(.separate-titlebar),
 body.linux:not(.maximized):not(.fullscreen):not(.separate-titlebar) {
   --control-space-top: 12px;
 }
 
 /* On Windows, draggable regions aren't clickable, so the drag region is a separate area above the tabstrip */
-body.windows:not(.maximized):not(.fullscreen) .window-drag-area,
+body.windows:not(.maximized):not(.fullscreen):not(.separate-titlebar) .window-drag-area,
 body.linux:not(.maximized):not(.fullscreen):not(.separate-titlebar)
   .window-drag-area {
   display: block;
@@ -41,13 +41,13 @@ body.mac .window-drag-area {
 
 /* mac window buttons */
 
-body.mac:not(.fullscreen) {
+body.mac:not(.fullscreen):not(.separate-titlebar) {
   --control-space-left: 75px;
 }
 
 /* Windows caption buttions */
 
-body.windows {
+body.windows:not(.separate-titlebar) {
   --control-space-right: 138px;
 }
 
@@ -55,7 +55,7 @@ body.windows {
   display: none;
 }
 
-body.windows .windows-caption-buttons {
+body.windows:not(.separate-titlebar) .windows-caption-buttons {
   display: flex;
   position: absolute;
   top: var(--control-space-top);

--- a/css/windowControls.css
+++ b/css/windowControls.css
@@ -16,8 +16,7 @@ body.linux:not(.maximized):not(.fullscreen):not(.separate-titlebar) {
 
 /* On Windows, draggable regions aren't clickable, so the drag region is a separate area above the tabstrip */
 body.windows:not(.maximized):not(.fullscreen):not(.separate-titlebar) .window-drag-area,
-body.linux:not(.maximized):not(.fullscreen):not(.separate-titlebar)
-  .window-drag-area {
+body.linux:not(.maximized):not(.fullscreen):not(.separate-titlebar) .window-drag-area {
   display: block;
   position: fixed;
   /* leave an empty space around the edges of the drag area so that the window can be resized */
@@ -29,7 +28,7 @@ body.linux:not(.maximized):not(.fullscreen):not(.separate-titlebar)
 }
 
 /* On mac, the entire navbar is draggable, so the drag area is placed behind the navbar */
-body.mac .window-drag-area {
+body.mac:not(.separate-titlebar) .window-drag-area {
   display: block;
   position: fixed;
   top: 0;

--- a/main/main.js
+++ b/main/main.js
@@ -173,10 +173,10 @@ function createWindowWithBounds (bounds) {
     y: bounds.y,
     minWidth: (process.platform === 'win32' ? 400 : 320), // controls take up more horizontal space on Windows
     minHeight: 350,
-    titleBarStyle: 'hidden',
+    titleBarStyle: settings.get('useSeparateTitlebar') ? 'default' : 'hidden',
     trafficLightPosition: { x: 12, y: 19 },
     icon: __dirname + '/icons/icon256.png',
-    frame: process.platform === 'darwin' || settings.get('useSeparateTitlebar') === true,
+    frame: settings.get('useSeparateTitlebar'),
     alwaysOnTop: settings.get('windowAlwaysOnTop'),
     backgroundColor: '#fff', // the value of this is ignored, but setting it seems to work around https://github.com/electron/electron/issues/10559
     webPreferences: {

--- a/pages/settings/index.html
+++ b/pages/settings/index.html
@@ -141,7 +141,7 @@
         ></div>
       </div>
 
-      <div class="setting-section" hidden id="section-separate-titlebar">
+      <div class="setting-section" id="section-separate-titlebar">
         <input type="checkbox" id="checkbox-separate-titlebar" />
         <label
           for="checkbox-separate-titlebar"

--- a/pages/settings/settings.js
+++ b/pages/settings/settings.js
@@ -248,10 +248,6 @@ showDividerCheckbox.addEventListener('change', function (e) {
 
 /* separate titlebar setting */
 
-if (navigator.platform.includes('Linux')) {
-  document.getElementById('section-separate-titlebar').hidden = false
-}
-
 settings.get('useSeparateTitlebar', function (value) {
   if (value === true) {
     separateTitlebarCheckbox.checked = true


### PR DESCRIPTION
### Purpose of this commit
As a Mac user, the only way to "maximize" a window is to double click on the title bar of the application. **However, it's not possible to do it with Min browser since title bar is hidden on Mac.** 

Although @PalmerAL [kindly point out](https://discord.com/channels/764269005195968512/764544014259060797/814756935316013066) that I can hold "cmd" + clicking on the "green traffic light", it's not as intuitive as double clicking title bar, as most users should be familiar with. 

Also, if we are giving Linux users that have special desktops the option to show title bar, why wouldn't we make it consistent for all platforms and give users flexibility of having a separate title bar? 

I therefore propose to enable "Use separate title bar" option for all platforms.

This commit also adjust the size/position of the "navbar" on both Windows and Mac OS when title bar is shown. Please find below the result of this change when the option is enabled:

**Mac OS**
![Screenshot 2021-02-28 at 21 40 55](https://user-images.githubusercontent.com/952785/109435033-298b6a00-7a10-11eb-8dc6-d9e08816b67c.png)
![Screenshot 2021-02-28 at 21 40 46](https://user-images.githubusercontent.com/952785/109435036-2db78780-7a10-11eb-82fe-3834102daf3a.png)
 
**Windows 10**
![minbrowser_win_settings_titlebar](https://user-images.githubusercontent.com/952785/109435048-4031c100-7a10-11eb-8b3a-6a258d77cd11.PNG)
![minbrowser_win_titlebar](https://user-images.githubusercontent.com/952785/109435051-42941b00-7a10-11eb-851a-4b38d051f4b4.PNG)
