### PR TITLE
Fix data corruption when modifying multiple settings simultaneously

### DIFF
--- a/js/util/settings/settings.js
+++ b/js/util/settings/settings.js
@@ -20,21 +20,22 @@ var settings = {
 
     if (process.type === 'browser') {
       /* eslint-disable no-inner-declarations */
-      function writeFileInner () {
-        settings.fileWritePromise = fs.promises.writeFile(settings.filePath, JSON.stringify(settings.list)).then(function (e) {
-          settings.fileWritePromise = null
+      /* eslint-disable no-inner-declarations */
+      function newFileWrite () {
+        return fs.promises.writeFile(settings.filePath, JSON.stringify(settings.list)).then(function (e) {
           if (cb) {
             cb()
           }
         })
       }
+
+      function ongoingFileWrite () {
+        return settings.fileWritePromise || Promise.resolve()
+      }
       /* eslint-enable no-inner-declarations */
 
-      if (settings.fileWritePromise) {
-        settings.fileWritePromise.then(writeFileInner)
-      } else {
-        writeFileInner()
-      }
+      // eslint-disable-next-line no-return-assign
+      settings.fileWritePromise = ongoingFileWrite().then(newFileWrite).then(() => settings.fileWritePromise = null)
 
       if (mainWindow) {
         mainWindow.webContents.send('receiveSettingsData', settings.list)

--- a/js/util/settings/settings.js
+++ b/js/util/settings/settings.js
@@ -3,7 +3,7 @@ var settings = {
   fileWritePromise: null,
   list: {},
   onChangeCallbacks: [],
-  save: function (cb) {
+  save: function () {
     /*
     Writing to the settings file from multiple places simultaneously causes data corruption, so to avoid that:
     * We forward data from the renderer process to the main process, and only write from there
@@ -13,9 +13,6 @@ var settings = {
 
     if (process.type === 'renderer') {
       ipc.send('receiveSettingsData', settings.list)
-      if (cb) {
-        cb()
-      }
     }
 
     if (process.type === 'browser') {
@@ -63,9 +60,9 @@ var settings = {
       settings.onChangeCallbacks.push({ cb: key })
     }
   },
-  set: function (key, value, cb) {
+  set: function (key, value) {
     settings.list[key] = value
-    settings.save(cb)
+    settings.save()
     settings.runChangeCallacks()
   },
   initialize: function () {

--- a/js/util/settings/settingsContent.js
+++ b/js/util/settings/settingsContent.js
@@ -34,12 +34,9 @@ var settings = {
       settings.onChangeCallbacks.push({ cb: key })
     }
   },
-  set: function (key, value, cb) {
+  set: function (key, value) {
     settings.list[key] = value
     postMessage({ message: 'setSetting', key, value })
-    if (cb) {
-      cb()
-    }
     settings.runChangeCallacks()
   },
   load: function () {

--- a/pages/settings/settings.js
+++ b/pages/settings/settings.js
@@ -15,9 +15,9 @@ function showRestartRequiredBanner () {
   settings.set('restartNow', true)
 }
 settings.get('restartNow', (value) => {
-    if(value === true) {
-        showRestartRequiredBanner()
-    }
+  if (value === true) {
+    showRestartRequiredBanner()
+  }
 })
 
 /* content blocking settings */
@@ -462,9 +462,8 @@ function onKeyMapChange (e) {
     }
 
     keyMapSettings[action] = parseKeyInput(newValue)
-    settings.set('keyMap', keyMapSettings, function () {
-      showRestartRequiredBanner()
-    })
+    settings.set('keyMap', keyMapSettings)
+    showRestartRequiredBanner()
   })
 }
 

--- a/reader/readerThemeSelector.js
+++ b/reader/readerThemeSelector.js
@@ -56,9 +56,10 @@ themeSelectors.forEach(function (el) {
   el.addEventListener('click', function () {
     var theme = this.getAttribute('data-theme')
     if (isNight()) {
-      settings.set('readerNightTheme', theme, setReaderTheme)
+      settings.set('readerNightTheme', theme)
     } else {
-      settings.set('readerDayTheme', theme, setReaderTheme)
+      settings.set('readerDayTheme', theme)
     }
+    setReaderTheme()
   })
 })


### PR DESCRIPTION
Fixes #1520 

`settings.set` can be called from either the main process or the UI process. Previously, calling this would just write to the settings file immediately from whichever process it was called in. The problem with this is that if `settings.set` is called multiple times in a sequence, multiple `fs.writeFile` calls can happen at the same time, which corrupts the settings file.

This PR makes two changes to avoid that:
* Save requests are forwarded from the UI process to the main process, so that `writeFile` is only called from the main process.
* Within the main process, `writeFile` calls are queued so that they can't occur simultaneously.