### PR TITLE
[WIP] Add experimental popup window support

### DIFF
--- a/js/browserUI.js
+++ b/js/browserUI.js
@@ -186,7 +186,9 @@ webviews.bindEvent('new-window', function (tabId, url, frameName, disposition) {
 */
 
 webviews.bindEvent('did-create-popup', function (tabId, popupId) {
-  var popupTab = tabs.add()
+  var popupTab = tabs.add({
+    private: tabs.get(tabId).private
+  })
   tabBar.addTab(popupTab)
   webviews.add(popupTab, popupId)
   switchToTab(popupTab)

--- a/js/browserUI.js
+++ b/js/browserUI.js
@@ -167,8 +167,8 @@ function switchToTab (id, options) {
   })
 }
 
+/*
 webviews.bindEvent('new-window', function (tabId, url, frameName, disposition) {
-  /* disabled in focus mode */
   if (focusMode.enabled()) {
     focusMode.warn()
     return
@@ -182,6 +182,14 @@ webviews.bindEvent('new-window', function (tabId, url, frameName, disposition) {
     enterEditMode: false,
     openInBackground: disposition === 'background-tab' && !settings.get('openTabsInForeground')
   })
+})
+*/
+
+webviews.bindEvent('did-create-popup', function (tabId, popupId) {
+  var popupTab = tabs.add()
+  tabBar.addTab(popupTab)
+  webviews.add(popupTab, popupId)
+  switchToTab(popupTab)
 })
 
 webviews.bindIPC('close-window', function (tabId, args) {

--- a/js/preload/default.js
+++ b/js/preload/default.js
@@ -18,6 +18,7 @@ function cloneEvent (e) {
 setTimeout(function () {
   /* Used for swipe gestures */
   window.addEventListener('wheel', function (e) {
+    console.log(e)
     ipc.send('wheel-event', cloneEvent(e))
   })
 

--- a/js/webviews.js
+++ b/js/webviews.js
@@ -169,7 +169,7 @@ const webviews = {
       }
     }
   },
-  add: function (tabId) {
+  add: function (tabId, existingViewId) {
     var tabData = tabs.get(tabId)
 
     // needs to be called before the view is created to that its listeners can be registered
@@ -188,23 +188,10 @@ const webviews = {
     }
 
     ipc.send('createView', {
+      existingViewId,
       id: tabId,
       webPreferencesString: JSON.stringify({
-        webPreferences: {
-          nodeIntegration: false,
-          nodeIntegrationInSubFrames: true,
-          scrollBounce: true,
-          safeDialogs: true,
-          safeDialogsMessage: 'Prevent this page from creating additional dialogs',
-          preload: __dirname + '/dist/preload.js',
-          contextIsolation: true,
-          sandbox: true,
-          enableRemoteModule: false,
-          allowPopups: false,
-          partition: partition || 'persist:webcontent',
-          enableWebSQL: false,
-          autoplayPolicy: (settings.get('enableAutoplay') ? 'no-user-gesture-required' : 'user-gesture-required')
-        }
+        partition: partition || 'persist:webcontent'
       }),
       boundsString: JSON.stringify(webviews.getViewBounds()),
       events: webviews.events.map(e => e.event).filter((i, idx, arr) => arr.indexOf(i) === idx)


### PR DESCRIPTION
This adds support for opening popup windows from webpages, using [this](https://github.com/electron/electron/pull/26802) new feature of Electron. Implementing this would fix most of the compatibility issues mentioned in #140

Known issues:
* ctrl+clicking on links to open them in a new tab no longer works. To fix that, we need https://github.com/electron/electron/pull/28518, which requires upgrading to Electron 14 (or maybe 13?)
* Occasionally the browser crashes when closing the popup window.
  * It would be really helpful to find a consistent way to reproduce this - if anyone finds one while testing, please let me know.