### PR TITLE
Change bookmark editor behavior

### DIFF
--- a/css/bookmarkManager.css
+++ b/css/bookmarkManager.css
@@ -17,9 +17,18 @@
   box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.2);
 }
 
+.bookmark-editor .tag-edit-area {
+  display: inline-block;
+}
+
 .bookmark-editor .bookmark-delete-button {
   top: auto;
   bottom: calc(0.16em + 1px);
+}
+.bookmark-editor.simplified .bookmark-delete-button {
+  position: static;
+  margin-left: 0.75em;
+  transform: translateY(0.1875em);
 }
 
 .bookmark-editor .bookmark-url {

--- a/css/listItem.css
+++ b/css/listItem.css
@@ -106,11 +106,13 @@ body.touch .searchbar-item .action-button {
 body.dark-mode.touch .searchbar-item .action-button {
   opacity: 0.8;
 }
-.searchbar-item .action-button:hover {
+.searchbar-item .action-button:hover,
+.searchbar-item .action-button:focus {
   opacity: 1;
   background: rgba(0, 0, 0, 0.05);
 }
-.dark-mode .searchbar-item .action-button:hover {
+.dark-mode .searchbar-item .action-button:hover,
+.dark-mode .searchbar-item .action-button:focus {
   opacity: 1;
   background: rgba(0, 0, 0, 0.15);
 }

--- a/js/navbar/bookmarkStar.js
+++ b/js/navbar/bookmarkStar.js
@@ -23,24 +23,26 @@ const bookmarkStar = {
 
     searchbarPlugins.clearAll()
 
-    star.classList.toggle('carbon:star')
-    star.classList.toggle('carbon:star-filled')
+    places.updateItem(tabs.get(tabId).url, {
+      isBookmarked: true,
+      title: tabs.get(tabId).title // if this page is open in a private tab, the title may not be saved already, so it needs to be included here
+    }, function () {
+      star.classList.remove('carbon:star')
+      star.classList.add('carbon:star-filled')
+      star.setAttribute('aria-pressed', true)
 
-    places.toggleBookmarked(tabId, function (isBookmarked) {
-      if (isBookmarked) {
-        star.classList.remove('carbon:star')
-        star.classList.add('carbon:star-filled')
-        // since the update happens asynchronously, and star.update() could be called after onClick but before the update, it's possible for the classes to get out of sync with the actual bookmark state. Updating them here fixes tis.
-        star.setAttribute('aria-pressed', true)
-        var editorInsertionPoint = document.createElement('div')
-        searchbarPlugins.getContainer('simpleBookmarkTagInput').appendChild(editorInsertionPoint)
-        bookmarkEditor.show(tabs.get(tabs.getSelected()).url, editorInsertionPoint, null, { simplified: true, autoFocus: true })
-      } else {
-        star.classList.add('carbon:star')
-        star.classList.remove('carbon:star-filled')
-        star.setAttribute('aria-pressed', false)
-        searchbar.showResults('')
-      }
+      var editorInsertionPoint = document.createElement('div')
+      searchbarPlugins.getContainer('simpleBookmarkTagInput').appendChild(editorInsertionPoint)
+      bookmarkEditor.show(tabs.get(tabs.getSelected()).url, editorInsertionPoint, function (newBookmark) {
+        if (!newBookmark) {
+          // bookmark was deleted
+          star.classList.add('carbon:star')
+          star.classList.remove('carbon:star-filled')
+          star.setAttribute('aria-pressed', false)
+          searchbar.showResults('')
+          searchbar.associatedInput.focus()
+        }
+      }, { simplified: true, autoFocus: true })
     })
   },
   update: function (tabId, star) {
@@ -55,7 +57,7 @@ const bookmarkStar = {
 
     // check if the page is bookmarked or not, and update the star to match
 
-    db.places.where('url').equals(currentURL).first(function (item) {
+    places.getItem(currentURL, function (item) {
       if (item && item.isBookmarked) {
         star.classList.remove('carbon:star')
         star.classList.add('carbon:star-filled')

--- a/js/places/places.js
+++ b/js/places/places.js
@@ -114,6 +114,16 @@ const places = {
   onMessage: function (e) { // assumes this is from a search operation
     places.runWorkerCallback(e.data.callbackId, e.data.result)
   },
+  getItem: function (url, callback) {
+    const callbackId = places.addWorkerCallback(callback)
+    places.worker.postMessage({
+      action: 'getPlace',
+      pageData: {
+        url: url
+      },
+      callbackId: callbackId
+    })
+  },
   updateItem: function (url, fields, callback) {
     const callbackId = places.addWorkerCallback(callback)
     places.worker.postMessage({
@@ -123,25 +133,6 @@ const places = {
         ...fields
       },
       callbackId: callbackId
-    })
-  },
-  toggleBookmarked: function (tabId, callback) { // Toggles whether a URL is bookmarked or not
-    const url = tabs.get(tabId).url
-
-    db.places.where('url').equals(url).first(function (item) {
-      if (item && item.isBookmarked) {
-        places.updateItem(url, { isBookmarked: false }, function () {
-          callback(false)
-        })
-      } else {
-        // if this page is open in a private tab, the title may not be saved already, so it needs to be included here
-        places.updateItem(url, {
-          isBookmarked: true,
-          title: tabs.get(tabId).title
-        }, function () {
-          callback(true)
-        })
-      }
     })
   },
   toggleTag: function (url, tag) {

--- a/js/places/placesWorker.js
+++ b/js/places/placesWorker.js
@@ -106,6 +106,26 @@ onmessage = function (e) {
   const callbackId = e.data.callbackId
   const options = e.data.options
 
+  if (action === 'getPlace') {
+    let found = false
+    for (let i = 0; i < historyInMemoryCache.length; i++) {
+      if (historyInMemoryCache[i].url === pageData.url) {
+        postMessage({
+          result: historyInMemoryCache[i],
+          callbackId: callbackId
+        })
+        found = true
+        break
+      }
+    }
+    if (!found) {
+      postMessage({
+        result: null,
+        callbackId: callbackId
+      })
+    }
+  }
+
   if (action === 'updatePlace') {
     db.transaction('rw', db.places, function () {
       db.places.where('url').equals(pageData.url).first(function (item) {

--- a/js/searchbar/bookmarkEditor.js
+++ b/js/searchbar/bookmarkEditor.js
@@ -49,7 +49,14 @@ const bookmarkEditor = {
       URLSpan.className = 'bookmark-url'
       URLSpan.textContent = bookmarkEditor.currentInstance.bookmark.url
       editor.appendChild(URLSpan)
+    }
 
+    // tag area
+    var tagArea = document.createElement('div')
+    tagArea.className = 'tag-edit-area'
+    editor.appendChild(tagArea)
+
+    if (!options.simplified) {
       // save button
       var saveButton = document.createElement('button')
       saveButton.className = 'action-button always-visible i carbon:checkmark'
@@ -60,23 +67,18 @@ const bookmarkEditor = {
         bookmarkEditor.currentInstance.onClose(bookmarkEditor.currentInstance.bookmark)
         bookmarkEditor.currentInstance = null
       })
-
-      // delete button
-      var delButton = document.createElement('button')
-      delButton.className = 'action-button always-visible bookmark-delete-button i carbon:delete'
-      delButton.tabIndex = -1
-      editor.appendChild(delButton)
-      delButton.addEventListener('click', function () {
-        editor.remove()
-        bookmarkEditor.currentInstance.onClose(null)
-        bookmarkEditor.currentInstance = null
-      })
     }
 
-    // tag area
-    var tagArea = document.createElement('div')
-    tagArea.className = 'tag-edit-area'
-    editor.appendChild(tagArea)
+    // delete button
+    var delButton = document.createElement('button')
+    delButton.className = 'action-button always-visible bookmark-delete-button i carbon:delete'
+    delButton.tabIndex = -1
+    editor.appendChild(delButton)
+    delButton.addEventListener('click', function () {
+      editor.remove()
+      bookmarkEditor.currentInstance.onClose(null)
+      bookmarkEditor.currentInstance = null
+    })
 
     var tags = {
       selected: [],


### PR DESCRIPTION
Previously, clicking on the bookmark star or pressing ctrl+d while on a page you already bookmarked would delete the bookmark. There were two problems with this:

* If you didn't remember whether you'd bookmarked the page, but wanted to bookmark it, pressing ctrl+d would sometimes do the opposite of what you wanted (by deleting the bookmark).
* Once you'd bookmarked a page, there wasn't an easy way to edit the bookmark's tags without going to the bookmark viewer.

This PR changes the behavior so that clicking the star or using the shortcut will always save the page and open the bookmark editor, regardless of whether it was previously bookmarked. The editor now has a separate button to delete the bookmark:
<img width="868" alt="Screen Shot 2021-06-13 at 3 03 29 PM" src="https://user-images.githubusercontent.com/10314059/121820493-a9a0ad00-cc58-11eb-868d-d553bf00c226.png">
