### PR TITLE
Send maximize/minimize/unmaximize events to work around electron issue

### DIFF
--- a/main/remoteActions.js
+++ b/main/remoteActions.js
@@ -65,14 +65,20 @@ ipc.handle('clearStorageData', function () {
 
 ipc.handle('minimize', function (e) {
   mainWindow.minimize()
+  // workaround for https://github.com/minbrowser/min/issues/1662
+  mainWindow.webContents.send('minimize')
 })
 
 ipc.handle('maximize', function (e) {
   mainWindow.maximize()
+  // workaround for https://github.com/minbrowser/min/issues/1662
+  mainWindow.webContents.send('maximize')
 })
 
 ipc.handle('unmaximize', function (e) {
   mainWindow.unmaximize()
+  // workaround for https://github.com/minbrowser/min/issues/1662
+  mainWindow.webContents.send('unmaximize')
 })
 
 ipc.handle('close', function (e) {


### PR DESCRIPTION
Mostly fixes #1662 (which also has an explanation of why this is necessary).

This is still broken if you maximize/unmaximize the window by dragging on the title bar, rather than clicking the buttons. We could possibly solve that by watching for `resize` events and sending maximize/unmaximize based on that, but I doubt it would work reliably.