### PR TITLE
Popup filtering and block of third-party cookies

### DIFF
--- a/main/filtering.js
+++ b/main/filtering.js
@@ -171,7 +171,7 @@ function setFilteringSettings (settings) {
 
   enabledFilteringOptions.contentTypes = settings.contentTypes
   enabledFilteringOptions.blockingLevel = settings.blockingLevel
-  enabledFilteringOptions.exceptionDomains = settings.exceptionDomains.map(d => d.replace(/^www\./g, ''))
+  enabledFilteringOptions.exceptionDomains = settings.exceptionDomains.map(d => removeWWW(d))
 }
 
 function registerFiltering (ses) {

--- a/main/viewManager.js
+++ b/main/viewManager.js
@@ -68,6 +68,10 @@ function createView (existingViewId, id, webPreferencesString, boundsString, eve
   view.webContents.removeAllListeners('-add-new-contents')
 
   view.webContents.on('-add-new-contents', function (e, webContents, disposition, _userGesture, _left, _top, _width, _height, url, frameName, referrer, rawFeatures, postData) {
+    if (!filterPopups(url)) {
+      return
+    }
+
     var view = new BrowserView({ webPreferences: defaultViewWebPreferences, webContents: webContents })
 
     var popupId = Math.random().toString()


### PR DESCRIPTION
Simple popup filtering by using the current filters via easylist/easyprivacy/customFilters and adblock's 'popup' option.
Discussion: #1660 

Filter that will block popups (via `window.open`, for example) that open google.com:
```
||google.com^$popup
```