### PR TITLE
:lipstick: | removed unusable `else` keyword :v:

### DIFF
--- a/main/menu.js
+++ b/main/menu.js
@@ -6,9 +6,8 @@ function buildAppMenu (options = {}) {
       if (Array.isArray(value)) {
         // value is array if multiple entries are set
         return value[0].replace('mod', 'CmdOrCtrl')
-      } else {
-        return value.replace('mod', 'CmdOrCtrl')
       }
+      return value.replace('mod', 'CmdOrCtrl')
     }
 
     return null


### PR DESCRIPTION
# :lipstick: | removed unusable `else` keyword :v:

## with return keyword, else is useless

when we use `return` in if statement, that meant, when condition is true, return value and close function, , and if not, then, go on outside of if statement, and run next line, and then return other value and break function