### PR TITLE
Fix mac titlebar layout for RTL languages

### DIFF
--- a/css/windowControls.css
+++ b/css/windowControls.css
@@ -44,6 +44,11 @@ body.mac:not(.fullscreen):not(.separate-titlebar) {
   --control-space-left: 75px;
 }
 
+body.rtl.mac:not(.fullscreen):not(.separate-titlebar) {
+  --control-space-left: 0px;
+  --control-space-right: 75px;
+}
+
 /* Windows caption buttions */
 
 body.windows:not(.separate-titlebar) {

--- a/localization/languages/ar.json
+++ b/localization/languages/ar.json
@@ -1,6 +1,7 @@
 {
   "name": "Arabic",
   "identifier": "ar",
+  "rtl": true,
   "translations": {
     /* Context menu items
         these are the items displayed in the menu when you right-click on a page

--- a/localization/languages/fa.json
+++ b/localization/languages/fa.json
@@ -1,6 +1,7 @@
 {
   "name": "Persian",
   "identifier": "fa",
+  "rtl": true,
   "translations": {
     /* Context menu items
         these are the items displayed in the menu when you right-click on a page

--- a/localization/localizationHelpers.js
+++ b/localization/localizationHelpers.js
@@ -55,6 +55,10 @@ set the value attribute for all elements with a [data-value] attribute
  */
 
 if (typeof document !== 'undefined') {
+  if (languages[getCurrentLanguage()] && languages[getCurrentLanguage()].rtl) {
+    document.body.classList.add('rtl')
+  }
+
   document.querySelectorAll('[data-string]').forEach(function (el) {
     var str = l(el.getAttribute('data-string'))
     if (typeof str === 'string') {


### PR DESCRIPTION
Fixes #1688.

This still isn't perfect (and the layout isn't really RTL), but it's at least usable now.

<img width="832" src="https://user-images.githubusercontent.com/10314059/126887917-0d16f218-642c-40f7-bc12-68376b7bfee7.png">
