### PR TITLE
Add in-browser translation

### DIFF
--- a/js/default.js
+++ b/js/default.js
@@ -150,6 +150,7 @@ require('util/theme.js').initialize()
 require('userscripts.js').initialize()
 require('statistics.js').initialize()
 require('taskOverlay/taskOverlay.js').initialize()
+require('pageTranslations.js').initialize()
 require('sessionRestore.js').initialize()
 
 // default searchbar plugins

--- a/js/pageTranslations.js
+++ b/js/pageTranslations.js
@@ -55,12 +55,12 @@ const pageTranslations = {
       code: 'es'
     }
   ],
-  translateInto(tabId, language) {
+  translateInto (tabId, language) {
     webviews.callAsync(tabId, 'send', ['translate-page', language])
   },
   makeTranslationRequest: async function (tab, data) {
     console.log(data)
-    const res = await fetch('https://libretranslate.de/translate', {
+    const res = await fetch('http://143.198.178.22:5000/translate', {
       method: 'POST',
       body: JSON.stringify({
         q: data[0].query,

--- a/js/pageTranslations.js
+++ b/js/pageTranslations.js
@@ -1,6 +1,7 @@
 const webviews = require('webviews.js')
 
 const pageTranslations = {
+  apiURL: 'https://translate-api.minbrowser.org/translate',
   languages: [
     {
       name: 'English',
@@ -55,12 +56,22 @@ const pageTranslations = {
       code: 'es'
     }
   ],
+  getLanguageList: function () {
+    const userPrefs = navigator.languages.map(lang => lang.split('-')[0])
+    const topLangs = pageTranslations.languages.filter(lang => userPrefs.includes(lang.code))
+
+    // Translations to/from English are the highest quality in Libretranslate, so always show that near the top
+    if (!topLangs.some(lang => lang.code === 'en')) {
+      topLangs.push(pageTranslations.languages.find(lang => lang.code === 'en'))
+    }
+    const otherLangs = pageTranslations.languages.filter(lang => !userPrefs.includes(lang.code) && lang.code !== 'en')
+    return [topLangs, otherLangs]
+  },
   translateInto (tabId, language) {
     webviews.callAsync(tabId, 'send', ['translate-page', language])
   },
   makeTranslationRequest: async function (tab, data) {
-    console.log(data)
-    const res = await fetch('https://translate-api.minbrowser.org/translate', {
+    const requestOptions = {
       method: 'POST',
       body: JSON.stringify({
         q: data[0].query,
@@ -68,15 +79,30 @@ const pageTranslations = {
         target: data[0].lang
       }),
       headers: { 'Content-Type': 'application/json' }
-    })
+    }
 
-    const result = await res.json()
-
-    console.log(result)
-
-    webviews.callAsync(tab, 'send', ['translation-response', {
-      response: result
-    }])
+    fetch(pageTranslations.apiURL, requestOptions)
+      .then(res => res.json())
+      .then(function (result) {
+        console.log(result)
+        webviews.callAsync(tab, 'send', ['translation-response-' + data[0].requestId, {
+          response: result
+        }])
+      })
+      .catch(function (e) {
+        // retry once
+        setTimeout(function () {
+          console.warn('retrying translation request')
+          fetch(pageTranslations.apiURL, requestOptions)
+            .then(res => res.json())
+            .then(function (result) {
+              console.log('after retry', result)
+              webviews.callAsync(tab, 'send', ['translation-response-' + data[0].requestId, {
+                response: result
+              }])
+            })
+        }, 5000)
+      })
   },
   initialize: function () {
     webviews.bindIPC('translation-request', this.makeTranslationRequest)

--- a/js/pageTranslations.js
+++ b/js/pageTranslations.js
@@ -1,7 +1,10 @@
 const webviews = require('webviews.js')
+const statistics = require('js/statistics.js')
+const settings = require('util/settings/settings.js')
 
 const pageTranslations = {
   apiURL: 'https://translate-api.minbrowser.org/translate',
+  translatePrivacyInfo: 'When you translate a page, the page contents are sent to Min\'s servers. We don\'t save your translations or use them to identify you.',
   languages: [
     {
       name: 'English',
@@ -68,6 +71,16 @@ const pageTranslations = {
     return [topLangs, otherLangs]
   },
   translateInto (tabId, language) {
+    statistics.incrementValue('translatePage.' + language)
+
+    if (!settings.get('translatePrivacyPrompt')) {
+      const accepted = confirm(pageTranslations.translatePrivacyInfo)
+      if (accepted) {
+        settings.set('translatePrivacyPrompt', true)
+      } else {
+        return
+      }
+    }
     webviews.callAsync(tabId, 'send', ['translate-page', language])
   },
   makeTranslationRequest: async function (tab, data) {

--- a/js/pageTranslations.js
+++ b/js/pageTranslations.js
@@ -1,0 +1,87 @@
+const webviews = require('webviews.js')
+
+const pageTranslations = {
+  languages: [
+    {
+      name: 'English',
+      code: 'en'
+    },
+    {
+      name: 'Arabic',
+      code: 'ar'
+    },
+    {
+      name: 'Chinese',
+      code: 'zh'
+    },
+    {
+      name: 'French',
+      code: 'fr'
+    },
+    {
+      name: 'German',
+      code: 'de'
+    },
+    {
+      name: 'Hindi',
+      code: 'hi'
+    },
+    {
+      name: 'Irish',
+      code: 'ga'
+    },
+    {
+      name: 'Italian',
+      code: 'it'
+    },
+    {
+      name: 'Japanese',
+      code: 'ja'
+    },
+    {
+      name: 'Korean',
+      code: 'ko'
+    },
+    {
+      name: 'Portuguese',
+      code: 'pt'
+    },
+    {
+      name: 'Russian',
+      code: 'ru'
+    },
+    {
+      name: 'Spanish',
+      code: 'es'
+    }
+  ],
+  translateInto(tabId, language) {
+    webviews.callAsync(tabId, 'send', ['translate-page', language])
+  },
+  makeTranslationRequest: async function (tab, data) {
+    console.log(data)
+    const res = await fetch('https://libretranslate.de/translate', {
+      method: 'POST',
+      body: JSON.stringify({
+        q: data[0].query,
+        source: 'auto',
+        target: data[0].lang
+      }),
+      headers: { 'Content-Type': 'application/json' }
+    })
+
+    const result = await res.json()
+
+    console.log(result)
+
+    webviews.callAsync(tab, 'send', ['translation-response', {
+      response: result,
+      range: data[0].range
+    }])
+  },
+  initialize: function () {
+    webviews.bindIPC('translation-request', this.makeTranslationRequest)
+  }
+}
+
+module.exports = pageTranslations

--- a/js/pageTranslations.js
+++ b/js/pageTranslations.js
@@ -75,8 +75,7 @@ const pageTranslations = {
     console.log(result)
 
     webviews.callAsync(tab, 'send', ['translation-response', {
-      response: result,
-      range: data[0].range
+      response: result
     }])
   },
   initialize: function () {

--- a/js/pageTranslations.js
+++ b/js/pageTranslations.js
@@ -60,7 +60,7 @@ const pageTranslations = {
   },
   makeTranslationRequest: async function (tab, data) {
     console.log(data)
-    const res = await fetch('http://143.198.178.22:5000/translate', {
+    const res = await fetch('https://translate-api.minbrowser.org/translate', {
       method: 'POST',
       body: JSON.stringify({
         q: data[0].query,

--- a/js/preload/translate.js
+++ b/js/preload/translate.js
@@ -1,0 +1,97 @@
+const maxNodesToTranslate = 192
+const chunkSize = 32
+
+function isVisible (el) {
+  // https://github.com/jquery/jquery/blob/305f193aa57014dc7d8fa0739a3fefd47166cd44/src/css/hiddenVisibleSelectors.js
+  return el.offsetWidth || el.offsetHeight || (el.getClientRects && el.getClientRects().length)
+}
+
+function getNodes (doc, win) {
+  var maybeNodes = [].slice.call(doc.body.childNodes)
+  var textNodes = []
+
+  var ignore = 'link, style, script, noscript, .hidden, [class*="-hidden"], .visually-hidden, .visuallyhidden, [role=presentation], [hidden], [style*="display:none"], [style*="display: none"], .ad, .dialog, .modal, select, svg, details:not([open])'
+
+  while (maybeNodes.length) {
+    var node = maybeNodes.shift()
+
+    // if the node should be ignored, skip it and all of it's child nodes
+    if (node.matches && node.matches(ignore)) {
+      continue
+    }
+
+    // if the node is a text node, add it to the list of text nodes
+
+    if (node.nodeType === 3) {
+      textNodes.push(node)
+      continue
+    }
+
+    if (!isVisible(node)) {
+      continue
+    }
+
+    // otherwise, add the node's text nodes to the list of text, and the other child nodes to the list of nodes to check
+    var childNodes = node.childNodes
+    var cnl = childNodes.length
+
+    for (var i = cnl - 1; i >= 0; i--) {
+      var childNode = childNodes[i]
+      maybeNodes.unshift(childNode)
+    }
+  }
+
+  return textNodes
+}
+
+async function translate (lang) {
+  var nodes = getNodes(document, window)
+
+  // try to also extract text for same-origin iframes (such as the reader mode frame)
+
+  var frames = document.querySelectorAll('iframe')
+
+  for (var x = 0; x < frames.length; x++) {
+    try {
+      nodes = nodes.concat(getNodes(frames[x].contentDocument, frames[x].contentWindow))
+    } catch (e) { }
+  }
+
+  nodes = nodes.filter(n => n.textContent.replace(/\s+/g, '').length > 2)
+
+  function handleChunk (start, end) {
+    console.log(start, end)
+    var query = nodes.slice(start, end).map(node => node.textContent)
+
+    ipc.send('translation-request', {
+      query,
+      range: [start, end],
+      lang
+    })
+
+    ipc.once('translation-response', function (e, data) {
+      data.response.translatedText.forEach(function (text, i) {
+        var idx = data.range[0] + i
+
+        if (query[i].startsWith(' ')) {
+          text = ' ' + text
+        }
+        if (query[i].endsWith(' ')) {
+          text += ' '
+        }
+
+        nodes[idx].textContent = text
+      })
+
+      if (data.range[1] < maxNodesToTranslate && data.range[1] < nodes.length) {
+        handleChunk(data.range[1] + 1, data.range[1] + 1 + chunkSize)
+      }
+    })
+  }
+
+  handleChunk(0, chunkSize)
+}
+
+ipc.on('translate-page', function (e, lang) {
+  translate(lang)
+})

--- a/js/preload/translate.js
+++ b/js/preload/translate.js
@@ -1,5 +1,5 @@
-const maxNodesToTranslate = 192
-const chunkSize = 32
+const maxNodesToTranslate = 240
+const chunkSize = 15
 
 function isVisible (el) {
   // https://github.com/jquery/jquery/blob/305f193aa57014dc7d8fa0739a3fefd47166cd44/src/css/hiddenVisibleSelectors.js
@@ -11,6 +11,8 @@ function getNodes (doc, win) {
   var textNodes = []
 
   var ignore = 'link, style, script, noscript, .hidden, [class*="-hidden"], .visually-hidden, .visuallyhidden, [role=presentation], [hidden], [style*="display:none"], [style*="display: none"], .ad, .dialog, .modal, select, svg, details:not([open])'
+
+  ignore += ', pre, code'
 
   while (maybeNodes.length) {
     var node = maybeNodes.shift()
@@ -84,7 +86,7 @@ async function translate (lang) {
       })
 
       if (data.range[1] < maxNodesToTranslate && data.range[1] < nodes.length) {
-        handleChunk(data.range[1] + 1, data.range[1] + 1 + chunkSize)
+        handleChunk(data.range[1], data.range[1] + chunkSize)
       }
     })
   }

--- a/js/remoteMenuRenderer.js
+++ b/js/remoteMenuRenderer.js
@@ -15,6 +15,9 @@ function open (menuTemplate, x, y) {
     if (menuPart instanceof Array) {
       return menuPart.map(item => prepareToSend(item))
     } else {
+      if (menuPart.submenu) {
+        menuPart.submenu = prepareToSend(menuPart.submenu)
+      }
       if (typeof menuPart.click === 'function') {
         menuCallbacks[nextMenuId][nextItemId] = menuPart.click
         menuPart.click = nextItemId

--- a/js/webviewMenu.js
+++ b/js/webviewMenu.js
@@ -287,13 +287,31 @@ const webviewMenu = {
 
     var translateMenu = {
       label: 'Translate Page (Beta)',
-      submenu: pageTranslations.languages.map(function (language) {
-        return {
+      submenu: []
+    }
+
+    const translateLangList = pageTranslations.getLanguageList()
+
+    translateLangList[0].forEach(function (language) {
+      translateMenu.submenu.push({
+        label: language.name,
+        click: function () {
+          pageTranslations.translateInto(tabs.getSelected(), language.code)
+        }
+      })
+    })
+
+    if (translateLangList[1].length > 0) {
+      translateMenu.submenu.push({
+        type: 'separator'
+      })
+      translateLangList[1].forEach(function (language) {
+        translateMenu.submenu.push({
           label: language.name,
           click: function () {
             pageTranslations.translateInto(tabs.getSelected(), language.code)
           }
-        }
+        })
       })
     }
 

--- a/js/webviewMenu.js
+++ b/js/webviewMenu.js
@@ -315,6 +315,17 @@ const webviewMenu = {
       })
     }
 
+    translateMenu.submenu.push({
+      type: 'separator'
+    })
+
+    translateMenu.submenu.push({
+      label: 'Send Feedback',
+      click: function () {
+        browserUI.addTab(tabs.add({ url: 'https://github.com/minbrowser/min/issues/new?title=Translation%20feedback%20for%20' + encodeURIComponent(tabs.get(tabs.getSelected()).url) }), { enterEditMode: false, openInBackground: false })
+      }
+    })
+
     menuSections.push([translateMenu])
 
     // Electron's default menu position is sometimes wrong on Windows with a touchscreen

--- a/js/webviewMenu.js
+++ b/js/webviewMenu.js
@@ -5,6 +5,7 @@ const browserUI = require('browserUI.js')
 const searchEngine = require('util/searchEngine.js')
 const userscripts = require('userscripts.js')
 const settings = require('util/settings/settings.js')
+const pageTranslations = require('pageTranslations.js')
 
 const remoteMenu = require('remoteMenuRenderer.js')
 
@@ -233,7 +234,7 @@ const webviewMenu = {
         click: function () {
           try {
             webviews.goBackIgnoringRedirects(tabs.getSelected())
-          } catch (e) {}
+          } catch (e) { }
         }
       },
       {
@@ -241,7 +242,7 @@ const webviewMenu = {
         click: function () {
           try {
             webviews.callAsync(tabs.getSelected(), 'goForward')
-          } catch (e) {}
+          } catch (e) { }
         }
       }
     ]
@@ -283,6 +284,20 @@ const webviewMenu = {
       })
       menuSections.push(scriptActions)
     }
+
+    var translateMenu = {
+      label: 'Translate Page (Beta)',
+      submenu: pageTranslations.languages.map(function (language) {
+        return {
+          label: language.name,
+          click: function () {
+            pageTranslations.translateInto(tabs.getSelected(), language.code)
+          }
+        }
+      })
+    }
+
+    menuSections.push([translateMenu])
 
     // Electron's default menu position is sometimes wrong on Windows with a touchscreen
     // https://github.com/minbrowser/min/issues/903

--- a/main/remoteMenu.js
+++ b/main/remoteMenu.js
@@ -7,6 +7,15 @@ ipc.on('open-context-menu', function (e, data) {
       item.click = function () {
         e.sender.send('context-menu-item-selected', { menuId: data.id, itemId: id })
       }
+      if (item.submenu) {
+        for (var i = 0; i < item.submenu.length; i++) {
+          (function (id) {
+            item.submenu[i].click = function () {
+              e.sender.send('context-menu-item-selected', { menuId: data.id, itemId: id })
+            }
+          })(item.submenu[i].click)
+        }
+      }
       menu.append(new MenuItem(item))
     })
     menu.append(new MenuItem({ type: 'separator' }))

--- a/scripts/buildPreload.js
+++ b/scripts/buildPreload.js
@@ -9,10 +9,11 @@ const modules = [
   'js/preload/readerDetector.js',
   'js/preload/siteUnbreak.js',
   'js/util/settings/settingsPreload.js',
-  'js/preload/passwordFill.js'
+  'js/preload/passwordFill.js',
+  'js/preload/translate.js',
 ]
 
-function buildPreload () {
+function buildPreload() {
   /* concatenate modules */
   let output = ''
   modules.forEach(function (script) {


### PR DESCRIPTION
This PR adds an in-browser page translation feature using [LibreTranslate](https://github.com/LibreTranslate/LibreTranslate), an open-source translation engine, available in the page context menu.

This is discussed more in #1180, but the intent is to include this as an experimental feature (with a "beta" label in the UI), and see how many people use it. If it gets significant usage, there's options for improving the translation quality, running LibreTranslate on better hosting to improve the translation speed, etc.