### PR TITLE
Implement partial UA client hints support for gmail

### DIFF
--- a/js/preload/siteUnbreak.js
+++ b/js/preload/siteUnbreak.js
@@ -96,6 +96,29 @@ if (window.location.hostname === 'calendar.google.com') {
   `)
 }
 
+/* Gmail - required for loading standard version (otherwise redirects to basic HTML) */
+
+if (window.location.hostname === 'mail.google.com') {
+  const chromiumVersion = process.versions.chrome.split('.')[0]
+  scriptsToRun.push(`
+    (function() {
+      const simulatedUAData = {
+        brands: [
+          {brand: "Chromium", version: "${chromiumVersion}"},
+          {brand: "Not A;Brand", version: "99"}
+        ],
+        mobile: false,
+        getHighEntropyValues: function() {
+          console.warn('getHighEntropyValues is unimplemented', arguments)
+          return null
+        }
+      }
+
+      Object.defineProperty(navigator, 'userAgentData', {get: () => simulatedUAData})
+    })()
+  `)
+}
+
 if (scriptsToRun.length > 0) {
   setTimeout(function () {
     electron.webFrame.executeJavaScript(scriptsToRun.join(';'))

--- a/main/UASwitcher.js
+++ b/main/UASwitcher.js
@@ -26,6 +26,11 @@ function enableGoogleUASwitcher (ses) {
         details.requestHeaders['User-Agent'] = newUserAgent + ' Edg/' + process.versions.chrome
       }
     }
+
+    const chromiumVersion = process.versions.chrome.split('.')[0]
+    details.requestHeaders['SEC-CH-UA'] = `"Chromium";v="${chromiumVersion}", " Not A;Brand";v="99"`
+    details.requestHeaders['SEC-CH-UA-MOBILE'] = '?0'
+
     callback({ cancel: false, requestHeaders: details.requestHeaders })
   })
 }


### PR DESCRIPTION
Starting a few days ago, Gmail now checks (for unknown reasons) for `navigator.userAgentData`. If it isn't found, it redirects to the basic HTML version.

Client hints currently doesn't work in Electron: https://github.com/electron/electron/issues/30201. So this PR adds a (somewhat ridiculous) workaround of creating a fake `userAgentData` object that mostly conforms to the one Chrome provides. With that, the standard version of Gmail seems to load again.

Separately, signing in to Gmail is broken, see https://github.com/minbrowser/min/issues/868. You can workaround that by setting your user-agent to Firefox in preferences, but then you'll have to switch back to the standard user-agent after signing in before trying this fix.

I wish Google would stop trying to block non-official Chromium browsers...