### PR TITLE
Use Firefox UA for google accounts

### DIFF
--- a/main/UASwitcher.js
+++ b/main/UASwitcher.js
@@ -13,6 +13,35 @@ if (settings.get('customUserAgent')) {
 }
 app.userAgentFallback = newUserAgent
 
+function getFirefoxUA () {
+  const rootUAs = {
+    mac: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:FXVERSION.0) Gecko/20100101 Firefox/FXVERSION.0',
+    windows: 'Mozilla/5.0 (Windows NT 10.0; WOW64; rv:FXVERSION.0) Gecko/20100101 Firefox/FXVERSION.0',
+    linux: 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:FXVERSION.0) Gecko/20100101 Firefox/FXVERSION.0'
+  }
+
+  let rootUA
+  if (process.platform === 'win32') {
+    rootUA = rootUAs.windows
+  } else if (process.platform === 'darwin') {
+    rootUA = rootUAs.mac
+  } else {
+    // 'aix', 'freebsd', 'linux', 'openbsd', 'sunos'
+    rootUA = rootUAs.linux
+  }
+
+  /*
+  Guess at an appropriate Firefox version to use in the UA.
+  We want a recent version (ideally the latest), but not a version that hasn't been released yet.
+  New releases are every ~4 weeks, with some delays for holidays. So assume 4.1 weeks, and estimate
+  starting from v91 on 2021-08-10
+  */
+
+  const fxVersion = 91 + Math.floor((Date.now() - 1628553600000) / (4.1 * 7 * 24 * 60 * 60 * 1000))
+
+  return rootUA.replace(/FXVERSION/g, fxVersion)
+}
+
 /*
 Google blocks signin in some cases unless a custom UA is used
 see https://github.com/minbrowser/min/issues/868
@@ -23,7 +52,7 @@ function enableGoogleUASwitcher (ses) {
       const url = new URL(details.url)
 
       if (url.hostname === 'accounts.google.com') {
-        details.requestHeaders['User-Agent'] = newUserAgent + ' Edg/' + process.versions.chrome
+        details.requestHeaders['User-Agent'] = getFirefoxUA()
       }
     }
     callback({ cancel: false, requestHeaders: details.requestHeaders })


### PR DESCRIPTION
This PR switches Google sign in to use a Firefox UA rather than an edge one. To avoid having to update the UA on every Firefox release, it uses the current date to guess what the latest Firefox version is.

#868