### PR TITLE
Add settings section for clearing browser history

### DIFF
--- a/localization/languages/en-US.json
+++ b/localization/languages/en-US.json
@@ -176,6 +176,9 @@
     "settingsProxyRules": "Proxy rules:",
     "settingsProxyBypassRules": "No proxy for:",
     "settingsProxyConfigurationURL": "Configuration URL",
+    "settingsHistoryEraseNow": "Clear browsing history now",
+    "settingsHistoryHeading": "Privacy and history",
+    "settingsDeleteHistory": "Are you sure you want to delete all browsing history?",
     /* app menu */
     "appMenuFile": "File",
     "appMenuNewTab": "New Tab",

--- a/pages/settings/index.html
+++ b/pages/settings/index.html
@@ -77,6 +77,18 @@
       <div id="content-type-blocking"></div>
     </div>
 
+    <div class="settings-container" id="history-settings-container">
+      <h3 data-string="settingsHistoryHeading"></h3>
+      <div class="setting-section">
+        <button
+        style="border-radius: 4px; padding: 8px; background: black; color: white;"
+          data-string="settingsHistoryEraseNow"
+          id="clear-history-now">
+        </button>  
+      </div>
+      
+    </div>
+
     <div class="settings-container" id="appearance-settings-container">
       <h3 data-string="settingsAppearanceHeading"></h3>
 

--- a/pages/settings/settings.js
+++ b/pages/settings/settings.js
@@ -181,6 +181,24 @@ for (var contentType in contentTypes) {
   })(contentType)
 }
 
+/* Privacy and history */
+
+var clearHistoryButton = document.getElementById("clear-history-now")
+clearHistoryButton.addEventListener("click", () => {
+  const confirmedDeletion = confirm(l('settingsDeleteHistory'))
+  if (confirmedDeletion) {
+    try {
+      // Nuke history here with places.deleteAllHistory() ??
+      // postMessage({ message: { action: 'deleteAllHistory' } })
+      window.alert("Your browsing history has been erased.")
+    } catch (e) {
+      window.alert("There was an error clearing your history.")
+    }
+  } else {
+    return
+  }
+})
+
 /* dark mode setting */
 var darkModeNever = document.getElementById('dark-mode-never')
 var darkModeNight = document.getElementById('dark-mode-night')


### PR DESCRIPTION
Minimal version of the settings pane to clear browsing history.

Sadly, the functionality is not there:

1. First attempt was to use `places.deleteAllHistory()` but it's not available in this scope and I can't use require/import to fetch it

2. Tried using directly postMessage as places internally does but that postMessage within places is directed to the particular worker so this didn't work either

Also, I used inline styles which should be migrated to some stylesheet, but just wanted to put a quick PoC together to ask for pointers when it comes to actually clearing the DB of its stored URLs.