### PR TITLE
Improve error handling for invalid JSON

### DIFF
--- a/scripts/buildLocalization.js
+++ b/scripts/buildLocalization.js
@@ -22,13 +22,25 @@ function buildLocalization () {
     const data = fs.readFileSync(path.join(languageFileDir, file), 'utf-8')
 
     let obj
+    let decommented = null
+
     try {
-      obj = JSON.parse(decomment(data))
+      decommented = decomment(data)
+      obj = JSON.parse(decommented)
     } catch (e) {
       console.error('parsing language file "' + file + '" failed.')
       console.error(e.toString())
-      const loc = parseInt(/at position (\d+)/g.exec(e)[1])
-      console.info('"' + decomment(data).substring(loc - 40, loc + 40) + '"')
+
+      if (decommented !== null) {
+        const msg = e.message
+        const match = msg.match(/at position (\d+)/)
+
+        if (match !== null) {
+          const loc = parseInt(match[1])
+          console.info('"' + decommented.substring(loc - 40, loc + 40) + '"')
+        }
+      }
+
       process.exit()
     }
 


### PR DESCRIPTION
This PR fixes several issues:

* `decomment(data)` used to be called twice in case of an error. Since it is called at least once, we assign the result to a variable
* `String.prototype.match` is ~15 times faster than `RegExp.prototype.exec` (and is generally recommended to use `match` if only one match is needed, like in this case)
* There is no need for the `g` flag on the regex
* In case of missing closed brace (like it was the case with `tr.json`), the entire build would fail, because `exec(e)[1]` was not checking for `null` and the actual error message was `Unexpected end of JSON input`
* `exec(e)` was converting the entire error (including the stack trace) to a string. It might happen that somehow `at position` appears somewhere in the stack trace, while the error message is unrelated, leading to misleading error display info. Now we match only on the error message