### PR TITLE
Add search input to task overlay

### DIFF
--- a/css/taskOverlay.css
+++ b/css/taskOverlay.css
@@ -4,6 +4,45 @@
   background-color: inherit;
   z-index: 1;
   border-bottom: 1px rgba(0, 0, 0, 0.1) solid;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.task-search-input-container {
+  width: 400px;
+  max-width: 60vw;
+  position: relative;
+  padding: 0.25em 3em;
+}
+.task-search-input-container i {
+  position: absolute;
+  top: 0.55em;
+  left: 3.33em;
+}
+.task-search-input-container input {
+  width: 100%;
+  border: none;
+  background: rgba(0, 0, 0, 0.075);
+  padding: 0.25em 0.25em 0.25em 1.75em;
+  border-radius: 4px;
+}
+
+.dark-mode .task-search-input-container input {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+@media all and (max-width: 600px) {
+  .task-search-input-container {
+    max-width: 350px;
+    margin-left: var(--control-space-left);
+    margin-right: calc(var(--control-space-right) + 40px);
+    padding-left: 1em;
+    padding-right: 1em;
+  }
+  .task-search-input-container i {
+    left: 1.33em;
+  }
 }
 
 #switch-task-button {

--- a/css/taskOverlay.css
+++ b/css/taskOverlay.css
@@ -10,7 +10,7 @@
 }
 
 .task-search-input-container {
-  width: 400px;
+  width: 450px;
   max-width: 60vw;
   position: relative;
   padding: 0.25em 3em;
@@ -24,7 +24,7 @@
   width: 100%;
   border: none;
   background: rgba(0, 0, 0, 0.075);
-  padding: 0.25em 0.25em 0.25em 1.75em;
+  padding: 0.2em 0.25em 0.2em 1.75em;
   border-radius: 4px;
 }
 
@@ -104,7 +104,7 @@
 .task-container.collapsed input {
   cursor: pointer;
 }
-.task-container + .task-container {
+.task-container:not([hidden]) + .task-container {
   padding-top: 0.75em;
 }
 

--- a/index.html
+++ b/index.html
@@ -227,7 +227,12 @@
       <div
         class="simulated-navbar windowDragHandle"
         id="task-overlay-navbar"
-      ></div>
+      >
+      <div class="task-search-input-container">
+        <i class="i carbon:search"></i>
+        <input type="search" id="task-search-input" class="mousetrap"/>
+      </div>
+    </div>
       <div id="task-area"></div>
       <button id="add-task">
         <i class="i carbon:new-tab"></i>

--- a/index.html
+++ b/index.html
@@ -223,7 +223,7 @@
       </button>
     </div>
 
-    <div id="task-overlay" class="" hidden>
+    <div id="task-overlay" class="" hidden tabindex="-1">
       <div
         class="simulated-navbar windowDragHandle"
         id="task-overlay-navbar"

--- a/js/taskOverlay/taskOverlay.js
+++ b/js/taskOverlay/taskOverlay.js
@@ -119,6 +119,20 @@ var taskOverlay = {
     this.isShown = true
     taskSwitcherButton.classList.add('active')
 
+    taskOverlay.render()
+
+    // un-hide the overlay
+    this.overlayElement.hidden = false
+
+    // scroll to the selected element and focus it
+    var currentTabElement = document.querySelector('.task-tab-item[data-tab="{id}"]'.replace('{id}', tasks.getSelected().tabs.getSelected()))
+
+    if (currentTabElement) {
+      currentTabElement.classList.add('fakefocus')
+      currentTabElement.focus()
+    }
+  },
+  render: function () {
     this.tabDragula.containers = [addTaskButton]
     empty(taskContainer)
 
@@ -152,18 +166,6 @@ var taskOverlay = {
       taskContainer.appendChild(el)
       taskOverlay.tabDragula.containers.push(el.getElementsByClassName('task-tabs-container')[0])
     })
-
-    // scroll to the selected element and focus it
-
-    var currentTabElement = document.querySelector('.task-tab-item[data-tab="{id}"]'.replace('{id}', tasks.getSelected().tabs.getSelected()))
-
-    // un-hide the overlay
-    this.overlayElement.hidden = false
-
-    if (currentTabElement) {
-      currentTabElement.classList.add('fakefocus')
-      currentTabElement.focus()
-    }
   },
 
   hide: function () {
@@ -234,7 +236,7 @@ var taskOverlay = {
 
     input.addEventListener('blur', function () {
       input.value = ''
-      taskOverlay.show()
+      taskOverlay.render()
     })
 
     input.addEventListener('input', function (e) {
@@ -242,15 +244,17 @@ var taskOverlay = {
 
       if (!search) {
         // reset the overlay
-        taskOverlay.show()
+        taskOverlay.render()
         input.focus()
         return
       }
 
+      var totalTabMatches = 0
+
       tasks.forEach(function (task) {
         var taskContainer = document.querySelector(`.task-container[data-task="${task.id}"]`)
 
-        var tabMatches = 0
+        var taskTabMatches = 0
         task.tabs.forEach(function (tab) {
           var tabContainer = document.querySelector(`.task-tab-item[data-tab="${tab.id}"]`)
 
@@ -259,13 +263,21 @@ var taskOverlay = {
           const searchMatches = search.split(' ').every(word => searchText.includes(word))
           if (searchMatches) {
             tabContainer.hidden = false
-            tabMatches++
+            taskTabMatches++
+            totalTabMatches++
+
+            if (totalTabMatches === 1) {
+              // first match
+              tabContainer.classList.add('fakefocus')
+            } else {
+              tabContainer.classList.remove('fakefocus')
+            }
           } else {
             tabContainer.hidden = true
           }
         })
 
-        if (tabMatches === 0) {
+        if (taskTabMatches === 0) {
           taskContainer.hidden = true
         } else {
           taskContainer.hidden = false

--- a/js/taskOverlay/taskOverlay.js
+++ b/js/taskOverlay/taskOverlay.js
@@ -114,6 +114,8 @@ var taskOverlay = {
 
     tabEditor.hide()
 
+    document.getElementById('task-search-input').value = ''
+
     this.isShown = true
     taskSwitcherButton.classList.add('active')
 
@@ -216,7 +218,60 @@ var taskOverlay = {
     }
   },
 
+  initializeSearch: function () {
+    var container = document.querySelector('.task-search-input-container')
+    var input = document.getElementById('task-search-input')
+
+    container.addEventListener('click', e => { e.stopPropagation(); input.focus() })
+
+    input.addEventListener('input', function (e) {
+      var search = input.value.toLowerCase().trim()
+
+      if (!search) {
+        // reset the overlay
+        taskOverlay.show()
+        input.focus()
+        return
+      }
+
+      tasks.forEach(function (task) {
+        var taskContainer = document.querySelector(`.task-container[data-task="${task.id}"]`)
+
+        var tabMatches = 0
+        task.tabs.forEach(function (tab) {
+          var tabContainer = document.querySelector(`.task-tab-item[data-tab="${tab.id}"]`)
+
+          var searchText = (tab.title + ' ' + tab.url).toLowerCase()
+
+          if (searchText.includes(search)) {
+            tabContainer.hidden = false
+            tabMatches++
+          } else {
+            tabContainer.hidden = true
+          }
+        })
+
+        if (tabMatches === 0) {
+          taskContainer.hidden = true
+        } else {
+          taskContainer.hidden = false
+          taskContainer.classList.remove('collapsed')
+        }
+      })
+    })
+
+    input.addEventListener('keypress', function (e) {
+      if (e.keyCode === 13) {
+        var firstTab = taskOverlay.overlayElement.querySelector('.task-tab-item:not([hidden])')
+        if (firstTab) {
+          firstTab.click()
+        }
+      }
+    })
+  },
   initialize: function () {
+    this.initializeSearch()
+
     keyboardNavigationHelper.addToGroup('taskOverlay', taskOverlay.overlayElement)
 
     // swipe down on the tabstrip to show the task overlay

--- a/js/taskOverlay/taskOverlay.js
+++ b/js/taskOverlay/taskOverlay.js
@@ -222,7 +222,20 @@ var taskOverlay = {
     var container = document.querySelector('.task-search-input-container')
     var input = document.getElementById('task-search-input')
 
+    input.placeholder = l('tasksSearchTabs') + ' (T)'
+
     container.addEventListener('click', e => { e.stopPropagation(); input.focus() })
+
+    taskOverlay.overlayElement.addEventListener('keyup', function (e) {
+      if (e.key.toLowerCase() === 't' && document.activeElement.tagName !== 'INPUT') {
+        input.focus()
+      }
+    })
+
+    input.addEventListener('blur', function () {
+      input.value = ''
+      taskOverlay.show()
+    })
 
     input.addEventListener('input', function (e) {
       var search = input.value.toLowerCase().trim()

--- a/js/taskOverlay/taskOverlay.js
+++ b/js/taskOverlay/taskOverlay.js
@@ -254,9 +254,10 @@ var taskOverlay = {
         task.tabs.forEach(function (tab) {
           var tabContainer = document.querySelector(`.task-tab-item[data-tab="${tab.id}"]`)
 
-          var searchText = (tab.title + ' ' + tab.url).toLowerCase()
+          var searchText = (task.name + ' ' + tab.title + ' ' + tab.url).toLowerCase()
 
-          if (searchText.includes(search)) {
+          const searchMatches = search.split(' ').every(word => searchText.includes(word))
+          if (searchMatches) {
             tabContainer.hidden = false
             tabMatches++
           } else {

--- a/localization/languages/ar.json
+++ b/localization/languages/ar.json
@@ -71,6 +71,7 @@
     "taskDeleteWarning": {
       "unsafeHTML": "<a>تراجع؟</a> .تم حذف المهمة"
     },
+    "tasksSearchTabs": null, //missing translation
     "returnToTask": "عد إلى المهمة السابقة",
     "taskDescriptionTwo": "%t و %t",
     "taskDescriptionThree": "أخرى %n و %t ,%t",

--- a/localization/languages/bg.json
+++ b/localization/languages/bg.json
@@ -71,6 +71,7 @@
     "taskDeleteWarning": {
       "unsafeHTML": "Задачата е изтрита. <a>Върни обратно?</a>"
     },
+    "tasksSearchTabs": null, //missing translation
     "returnToTask": "Връщане към предишната задача",
     "taskDescriptionTwo": "%t и %t", //used to describe a task that has two tabs, %t is replaced with the tab titles
     "taskDescriptionThree": "%t, %t, и още %n", //used to describe a task that has three or more tabs

--- a/localization/languages/bn.json
+++ b/localization/languages/bn.json
@@ -71,6 +71,7 @@
     "taskDeleteWarning": {
       "unsafeHTML": "কার্য মোছা হয়েছে <a>Undo?</a>"
     },
+    "tasksSearchTabs": null, //missing translation
     "returnToTask": "আপনার আগের কাজে ফিরে যান",
     "taskDescriptionTwo": "%t এবং %t",
     "taskDescriptionThree": "%t, %t, and %n আরও",

--- a/localization/languages/cs.json
+++ b/localization/languages/cs.json
@@ -71,6 +71,7 @@
     "taskDeleteWarning": {
       "unsafeHTML": "Dimenze uzavřena. <a>Zpět?</a>"
     },
+    "tasksSearchTabs": null, //missing translation
     "returnToTask": "Vrátit se do předchozí dimenze",
     "taskDescriptionTwo": "%t a %t", //used to describe a task that has two tabs, %t is replaced with the tab titles
     "taskDescriptionThree": "%t, %t, a více (%n)", //used to describe a task that has three or more tabs

--- a/localization/languages/de.json
+++ b/localization/languages/de.json
@@ -71,6 +71,7 @@
     "taskDeleteWarning": {
       "unsafeHTML": "Aufgabe gelöscht. <a>Rückgängig machen?</a>"
     },
+    "tasksSearchTabs": null, //missing translation
     "returnToTask": "Zur vorherigen Aufgabe zurückkehren",
     "taskDescriptionTwo": "%t und %t",
     "taskDescriptionThree": "%t, %t, und %n mehr",

--- a/localization/languages/en-US.json
+++ b/localization/languages/en-US.json
@@ -71,6 +71,7 @@
     "taskDeleteWarning": {
       "unsafeHTML": "Task deleted. <a>Undo?</a>"
     },
+    "tasksSearchTabs": "Search tabs",
     "returnToTask": "Return to your previous task",
     "taskDescriptionTwo": "%t and %t", //used to describe a task that has two tabs, %t is replaced with the tab titles
     "taskDescriptionThree": "%t, %t, and %n more", //used to describe a task that has three or more tabs

--- a/localization/languages/es.json
+++ b/localization/languages/es.json
@@ -71,6 +71,7 @@
     "taskDeleteWarning": {
       "unsafeHTML": "Tarea eliminada. <a>¿Deshacer?</a>"
     },
+    "tasksSearchTabs": null, //missing translation
     "returnToTask": "Volver a su tarea anterior",
     "taskDescriptionTwo": "%t y %t", //used to describe a task that has two tabs, %t is replaced with the tab titles
     "taskDescriptionThree": "%t, %t, y %n más", //used to describe a task that has three or more tabs

--- a/localization/languages/fa.json
+++ b/localization/languages/fa.json
@@ -72,6 +72,7 @@
     "taskDeleteWarning": {
       "unsafeHTML": null //missing translation
     },
+    "tasksSearchTabs": null, //missing translation
     "returnToTask": null, //missing translation
     "taskDescriptionTwo": null, //missing translation
     "taskDescriptionThree": null, //missing translation

--- a/localization/languages/fr.json
+++ b/localization/languages/fr.json
@@ -71,6 +71,7 @@
     "taskDeleteWarning": {
       "unsafeHTML": "Tâche supprimée. <a>Annuler ?</a>"
     },
+    "tasksSearchTabs": null, //missing translation
     "returnToTask": "Revenir à la tâche précédente",
     "taskDescriptionTwo": "%t et %t",
     "taskDescriptionThree": "%t, %t, et %n",

--- a/localization/languages/hu.json
+++ b/localization/languages/hu.json
@@ -71,6 +71,7 @@
     "taskDeleteWarning": {
       "unsafeHTML": null //missing translation
     },
+    "tasksSearchTabs": null, //missing translation
     "returnToTask": null, //missing translation
     "taskDescriptionTwo": null, //missing translation
     "taskDescriptionThree": null, //missing translation

--- a/localization/languages/it.json
+++ b/localization/languages/it.json
@@ -71,6 +71,7 @@
     "taskDeleteWarning": {
       "unsafeHTML": "Task eliminato. <a>Annullare?</a>"
     },
+    "tasksSearchTabs": null, //missing translation
     "returnToTask": "Torna al task precedente",
     "taskDescriptionTwo": "%t , %t",
     "taskDescriptionThree": "%t, %t, e altri %n",

--- a/localization/languages/ja.json
+++ b/localization/languages/ja.json
@@ -71,6 +71,7 @@
     "taskDeleteWarning": {
       "unsafeHTML": "タスクは削除されます。 <a>キャンセル?</a>"
     },
+    "tasksSearchTabs": null, //missing translation
     "returnToTask": "前のタスクに戻る",
     "taskDescriptionTwo": "％tと％t",
     "taskDescriptionThree": "％t, ％t, ％n以上",

--- a/localization/languages/ko.json
+++ b/localization/languages/ko.json
@@ -71,6 +71,7 @@
     "taskDeleteWarning": {
       "unsafeHTML": "작업장을 제거했습니다. <a>되돌릴까요?</a>"
     },
+    "tasksSearchTabs": null, //missing translation
     "returnToTask": "이전 작업장으로 돌아가기",
     "taskDescriptionTwo": "%t 그리고 %t", //used to describe a task that has two tabs, %t is replaced with the tab title
     "taskDescriptionThree": "%t, %t, 그리고 %n개의 작업", //used to describe a task that has three or more tabs

--- a/localization/languages/lt.json
+++ b/localization/languages/lt.json
@@ -71,6 +71,7 @@
     "taskDeleteWarning": {
       "unsafeHTML": null //missing translation
     },
+    "tasksSearchTabs": null, //missing translation
     "returnToTask": null, //missing translation
     "taskDescriptionTwo": null, //missing translation
     "taskDescriptionThree": null, //missing translation

--- a/localization/languages/pl.json
+++ b/localization/languages/pl.json
@@ -71,6 +71,7 @@
     "taskDeleteWarning": {
       "unsafeHTML": "Zadanie usunięte. <a>Cofnąć?</a>"
     },
+    "tasksSearchTabs": null, //missing translation
     "returnToTask": "Wróć do poprzedniego zadania",
     "taskDescriptionTwo": "%t i %t",
     "taskDescriptionThree": "%t, %t i %n więcej",

--- a/localization/languages/pt-BR.json
+++ b/localization/languages/pt-BR.json
@@ -71,6 +71,7 @@
     "taskDeleteWarning": {
       "unsafeHTML": "Tarefa deletada! <a> desfazer?</a>"
     },
+    "tasksSearchTabs": null, //missing translation
     "returnToTask": "Retornar a sua tarefa anterior",
     "taskDescriptionTwo": "%t e %t",
     "taskDescriptionThree": "%t e %t, mais %n",

--- a/localization/languages/pt-PT.json
+++ b/localization/languages/pt-PT.json
@@ -71,6 +71,7 @@
     "taskDeleteWarning": {
       "unsafeHTML": "Tarefa eliminada. <a>Desfazer</a>?"
     },
+    "tasksSearchTabs": null, //missing translation
     "returnToTask": "Retornar à tarefa anterior",
     "taskDescriptionTwo": "%t e %t", //used to describe a task that has two tabs, %t is replaced with the tab titles
     "taskDescriptionThree": "%t, %t e %n mais", //used to describe a task that has three or more tabs

--- a/localization/languages/ru.json
+++ b/localization/languages/ru.json
@@ -71,6 +71,7 @@
     "taskDeleteWarning": {
       "unsafeHTML": "Задача удалена. <a>Отменить?</a>"
     },
+    "tasksSearchTabs": null, //missing translation
     "returnToTask": "Вернуться к предыдущей задаче",
     "taskDescriptionTwo": "%t и %t",
     "taskDescriptionThree": "%t, %t, и %n больше",

--- a/localization/languages/tr.json
+++ b/localization/languages/tr.json
@@ -71,6 +71,7 @@
     "taskDeleteWarning": {
       "unsafeHTML": "Görev silindi. <a>Geri?</a>"
     },
+    "tasksSearchTabs": null, //missing translation
     "returnToTask": "Önceki göreve geri dön",
     "taskDescriptionTwo": "%t ve %t",
     "taskDescriptionThree": "%t, %t ve %n fazlası",

--- a/localization/languages/uk.json
+++ b/localization/languages/uk.json
@@ -71,6 +71,7 @@
     "taskDeleteWarning": {
       "unsafeHTML": "Завдання видалено. <a>Скасувати?</a>"
     },
+    "tasksSearchTabs": null, //missing translation
     "returnToTask": "Повернутися до попереднього завдання",
     "taskDescriptionTwo": "%t і %t",
     "taskDescriptionThree": "%t, %t, і ще %n",

--- a/localization/languages/uz.json
+++ b/localization/languages/uz.json
@@ -71,6 +71,7 @@
     "taskDeleteWarning": {
       "unsafeHTML": "Vazifa o'chirildi. <a>Bekor qilasizmi?</a>"
     },
+    "tasksSearchTabs": null, //missing translation
     "returnToTask": "Oldingi vazifaga qaytish",
     "taskDescriptionTwo": "%t va %t", //used to describe a task that has two tabs, %t is replaced with the tab titles
     "taskDescriptionThree": "%t, %t, va yana %n", //used to describe a task that has three or more tabs

--- a/localization/languages/zh-CN.json
+++ b/localization/languages/zh-CN.json
@@ -71,6 +71,7 @@
     "taskDeleteWarning": {
       "unsafeHTML": "标签组已删除 <a>恢复？</a>"
     },
+    "tasksSearchTabs": null, //missing translation
     "returnToTask": "返回上一个标签组",
     "taskDescriptionTwo": "%t 和 %t", //used to describe a task that has two tabs, %t is replaced with the tab titles
     "taskDescriptionThree": "%t, %t, 和其他%n个标签", //used to describe a task that has three or more tabs

--- a/localization/languages/zh-TW.json
+++ b/localization/languages/zh-TW.json
@@ -71,6 +71,7 @@
     "taskDeleteWarning": {
       "unsafeHTML": "工作已刪除 <a>復原</a>"
     },
+    "tasksSearchTabs": null, //missing translation
     "returnToTask": "還原上次的工作",
     "taskDescriptionTwo": "%t 和 %t",
     "taskDescriptionThree": "%t，%t，和其他%n個分頁",


### PR DESCRIPTION
This PR adds a search box to the top of the task overlay to search through open tabs. Pressing enter from within the search switches to the first result.

I'm not totally happy with the way the search input looks; if anyone has ideas for how to make it better, let me know. The first search result should also probably be highlighted so that it's clear you can select it with enter.