### PR TITLE
Add option to follow system darkmode

### DIFF
--- a/js/util/theme.js
+++ b/js/util/theme.js
@@ -2,6 +2,10 @@ if (typeof require !== 'undefined') {
   var settings = require('util/settings/settings.js')
 }
 
+function systemShouldEnableDarkMode () {
+  return settings.list.systemShouldUseDarkColors
+}
+
 function shouldEnableDarkMode () {
   var hours = new Date().getHours()
   return (hours > 21 || hours < 6)
@@ -36,16 +40,18 @@ function initialize () {
     }
 
     // 0 or undefined: automatic dark mode
-    if (value === undefined || value === 0 || value === false) {
+    if (value === undefined || value === 0 || value === 2 || value === false) {
       // If it is night and darkMode is set to auto/default
-      if (shouldEnableDarkMode()) {
+      if (value === 2 && systemShouldEnableDarkMode()) {
+        enableDarkMode()
+      } else if (value === 0 && shouldEnableDarkMode()) {
         enableDarkMode()
       } else {
         disableDarkMode()
       }
 
       themeInterval = setInterval(function () {
-        if (shouldEnableDarkMode()) {
+        if (systemShouldEnableDarkMode() || shouldEnableDarkMode()) {
           if (!window.isDarkMode) {
             enableDarkMode()
           }

--- a/js/util/theme.js
+++ b/js/util/theme.js
@@ -6,7 +6,7 @@ function systemShouldEnableDarkMode () {
   return settings.list.systemShouldUseDarkColors
 }
 
-function shouldEnableDarkMode () {
+function isNightTime () {
   var hours = new Date().getHours()
   return (hours > 21 || hours < 6)
 }
@@ -30,7 +30,16 @@ function disableDarkMode () {
 var themeInterval = null
 
 function initialize () {
-  settings.listen('darkMode', function (value) {
+  function themeSettingsChanged (value) {
+    /*
+    value is the value of the darkMode pref
+    0 - automatic dark mode
+    -1: never
+    0: at night
+    1: always
+    2: follow system (default)
+    true / false: legacy pref values, translate to always/system
+    */
     clearInterval(themeInterval)
 
     // 1 or true: dark mode is always enabled
@@ -39,19 +48,16 @@ function initialize () {
       return
     }
 
-    // 0 or undefined: automatic dark mode
-    if (value === undefined || value === 0 || value === 2 || value === false) {
-      // If it is night and darkMode is set to auto/default
-      if (value === 2 && systemShouldEnableDarkMode()) {
-        enableDarkMode()
-      } else if (value === 0 && shouldEnableDarkMode()) {
+    // 2, undefined, or false: automatic dark mode following system
+    if (value === undefined || value === 2 || value === false) {
+      if (systemShouldEnableDarkMode()) {
         enableDarkMode()
       } else {
         disableDarkMode()
       }
 
       themeInterval = setInterval(function () {
-        if (systemShouldEnableDarkMode() || shouldEnableDarkMode()) {
+        if (systemShouldEnableDarkMode()) {
           if (!window.isDarkMode) {
             enableDarkMode()
           }
@@ -59,12 +65,35 @@ function initialize () {
           disableDarkMode()
         }
       }, 10000)
-    }
+    } else if (value === 0) {
+      // 0: automatic dark mode at night
+      if (isNightTime()) {
+        enableDarkMode()
+      } else {
+        disableDarkMode()
+      }
 
-    // -1: never enable
-
-    if (value === -1) {
+      themeInterval = setInterval(function () {
+        if (isNightTime()) {
+          if (!window.isDarkMode) {
+            enableDarkMode()
+          }
+        } else if (window.isDarkMode) {
+          disableDarkMode()
+        }
+      }, 10000)
+    } else if (value === -1) {
+      // -1: never enable
       disableDarkMode()
+    }
+  }
+  settings.listen('darkMode', themeSettingsChanged)
+  settings.listen('systemShouldUseDarkColors', function () {
+    // the settings API differs between the UI process and tabs
+    if (typeof process === 'undefined') {
+      settings.get('darkMode', themeSettingsChanged)
+    } else {
+      themeSettingsChanged(settings.get('darkMode'))
     }
   })
 }

--- a/localization/languages/ar.json
+++ b/localization/languages/ar.json
@@ -149,6 +149,7 @@
     "settingsDarkModeNever": "لا",
     "settingsDarkModeNight": "في الليل",
     "settingsDarkModeAlways": "دائما",
+    "settingsDarkModeSystem": null,
     "settingsSiteThemeToggle": "تفعيل سمة الموقع",
     "settingsShowDividerToggle": "عرض الفاصل بين علامات التبويب",
     "settingsAdditionalFeaturesHeading": "مميزات اضافية",

--- a/localization/languages/bg.json
+++ b/localization/languages/bg.json
@@ -149,6 +149,7 @@
     "settingsDarkModeNever": "Никога",
     "settingsDarkModeNight": "През нощта",
     "settingsDarkModeAlways": "Винаги",
+    "settingsDarkModeSystem": null,
     "settingsSiteThemeToggle": "Активиране на теми на сайтове",
     "settingsAdditionalFeaturesHeading": "Допълнителни функции",
     "settingsUserscriptsToggle": "Активиране на потребителски скриптове",

--- a/localization/languages/bn.json
+++ b/localization/languages/bn.json
@@ -149,6 +149,7 @@
     "settingsDarkModeNever": "কখনই",
     "settingsDarkModeNight": "রাতে",
     "settingsDarkModeAlways": "সর্বদা",
+    "settingsDarkModeSystem": null,
     "settingsSiteThemeToggle": "সাইটের থিম সক্ষম করুন",
     "settingsAdditionalFeaturesHeading": "অতিরিক্ত বৈশিষ্ট্য",
     "settingsUserscriptsToggle": "ব্যবহারকারী স্ক্রিপ্ট সক্রিয় করুন",

--- a/localization/languages/cs.json
+++ b/localization/languages/cs.json
@@ -149,6 +149,7 @@
     "settingsDarkModeNever": "Nikdy",
     "settingsDarkModeNight": "Pouze v noci",
     "settingsDarkModeAlways": "Vždy",
+    "settingsDarkModeSystem": null,
     "settingsSiteThemeToggle": "Povolit motiv webu",
     "settingsAdditionalFeaturesHeading": "Další funkce",
     "settingsUserscriptsToggle": "Povolit uživatelské skripty",

--- a/localization/languages/de.json
+++ b/localization/languages/de.json
@@ -149,6 +149,7 @@
     "settingsDarkModeNever": "Nie",
     "settingsDarkModeNight": "In der Nacht",
     "settingsDarkModeAlways": "Immer",
+    "settingsDarkModeSystem": null,
     "settingsSiteThemeToggle": "Seitenabhängiges Aussehen aktivieren",
     "settingsAdditionalFeaturesHeading": "Zusätzliche Funktionen",
     "settingsUserscriptsToggle": "Benutzerdefinierte Skripte aktivieren",

--- a/localization/languages/en-US.json
+++ b/localization/languages/en-US.json
@@ -149,6 +149,7 @@
     "settingsDarkModeNever": "Never",
     "settingsDarkModeNight": "At night",
     "settingsDarkModeAlways": "Always",
+    "settingsDarkModeSystem": "Follow system theme",
     "settingsSiteThemeToggle": "Enable site theme",
     "settingsAdditionalFeaturesHeading": "Additional Features",
     "settingsUserscriptsToggle": "Enable user scripts",

--- a/localization/languages/es.json
+++ b/localization/languages/es.json
@@ -149,6 +149,7 @@
     "settingsDarkModeNever": "Nunca", // googled
     "settingsDarkModeNight": "Por la noche", // googled
     "settingsDarkModeAlways": "Siempre", // googled
+    "settingsDarkModeSystem": null,
     "settingsSiteThemeToggle": "Habilitar tema del sitio",
     "settingsAdditionalFeaturesHeading": "Características adicionales",
     "settingsUserscriptsToggle": "Habilitar userscripts", //userscript doesn't have a Spanish translation, afaik maybe "script de usuario"

--- a/localization/languages/fa.json
+++ b/localization/languages/fa.json
@@ -150,6 +150,7 @@
     "settingsDarkModeNever": "پوسته تاریک خاموش",
     "settingsDarkModeNight": null, //"At night" missing translation
     "settingsDarkModeAlways": "پوسته تاریک برای همیشه",
+    "settingsDarkModeSystem": null,
     "settingsSiteThemeToggle": "تغییر پوسته",
     "settingsAdditionalFeaturesHeading": "امکانات افزوده",
     "settingsUserscriptsToggle": "فعال کردن اسکریپت های کاربر",

--- a/localization/languages/fr.json
+++ b/localization/languages/fr.json
@@ -149,6 +149,7 @@
     "settingsDarkModeNever": "Jamais",
     "settingsDarkModeNight": "La nuit",
     "settingsDarkModeAlways": "Toujours",
+    "settingsDarkModeSystem": null,
     "settingsSiteThemeToggle": "Activer le thème du site",
     "settingsAdditionalFeaturesHeading": "Fonctionnalités supplémentaires",
     "settingsUserscriptsToggle": "Activer les scripts personnalisés",

--- a/localization/languages/hu.json
+++ b/localization/languages/hu.json
@@ -149,6 +149,7 @@
     "settingsDarkModeNever": null, //"Never" missing translation
     "settingsDarkModeNight": null, //"At night" missing translation
     "settingsDarkModeAlways": null, //"Always" missing translation
+    "settingsDarkModeSystem": null,
     "settingsSiteThemeToggle": null, //missing translation
     "settingsAdditionalFeaturesHeading": "További beállítások",
     "settingsUserscriptsToggle": "Felhasználói szkriptek",

--- a/localization/languages/it.json
+++ b/localization/languages/it.json
@@ -149,6 +149,7 @@
     "settingsDarkModeNever": "Mai",
     "settingsDarkModeNight": "Di notte",
     "settingsDarkModeAlways": "Sempre",
+    "settingsDarkModeSystem": null,
     "settingsSiteThemeToggle": "Abilita tema adattivo (si adatta al sito)",
     "settingsAdditionalFeaturesHeading": "Funzionalità aggiuntive",
     "settingsUserscriptsToggle": "Abilita script definiti dall'utente",

--- a/localization/languages/ja.json
+++ b/localization/languages/ja.json
@@ -149,6 +149,7 @@
     "settingsDarkModeNever": "決して",
     "settingsDarkModeNight": "夜に",
     "settingsDarkModeAlways": "常に",
+    "settingsDarkModeSystem": null,
     "settingsSiteThemeToggle": "サイトテーマを有効にする",
     "settingsAdditionalFeaturesHeading": "追加機能",
     "settingsUserscriptsToggle": "ユーザースクリプトを有効にする",

--- a/localization/languages/ko.json
+++ b/localization/languages/ko.json
@@ -149,6 +149,7 @@
     "settingsDarkModeNever": "사용하지 않음",
     "settingsDarkModeNight": "밤에만 사용",
     "settingsDarkModeAlways": "항상 사용",
+    "settingsDarkModeSystem": null,
     "settingsSiteThemeToggle": "누리집 색상 주제 사용",
     "settingsAdditionalFeaturesHeading": "추가 기능",
     "settingsUserscriptsToggle": "사용자 명령(스크립트) 사용",

--- a/localization/languages/lt.json
+++ b/localization/languages/lt.json
@@ -149,6 +149,7 @@
     "settingsDarkModeNever": null, //"Never" missing translation
     "settingsDarkModeNight": null, //"At night" missing translation
     "settingsDarkModeAlways": null, //"Always" missing translation
+    "settingsDarkModeSystem": null,
     "settingsSiteThemeToggle": null, //missing translation
     "settingsAdditionalFeaturesHeading": "Papildomos ypatybės",
     "settingsUserscriptsToggle": "Įjungti naudotojo scenarijus",

--- a/localization/languages/pl.json
+++ b/localization/languages/pl.json
@@ -149,6 +149,7 @@
     "settingsDarkModeNever": "Nigdy",
     "settingsDarkModeNight": "W nocy",
     "settingsDarkModeAlways": "Zawsze",
+    "settingsDarkModeSystem": null,
     "settingsSiteThemeToggle": "Włącz motyw witryny",
     "settingsAdditionalFeaturesHeading": "Dodatkowe funkcje",
     "settingsUserscriptsToggle": "Włącz skrypty użytkownika",

--- a/localization/languages/pt-BR.json
+++ b/localization/languages/pt-BR.json
@@ -149,6 +149,7 @@
     "settingsDarkModeNever": "Nunca",
     "settingsDarkModeNight": "À noite",
     "settingsDarkModeAlways": "Sempre",
+    "settingsDarkModeSystem": null,
     "settingsSiteThemeToggle": "Habilitar mudanças de cores na barra de endereços",
     "settingsAdditionalFeaturesHeading": "Recursos adicionais",
     "settingsUserscriptsToggle": "Habilitar scripts do usuário",

--- a/localization/languages/pt-PT.json
+++ b/localization/languages/pt-PT.json
@@ -149,6 +149,7 @@
     "settingsDarkModeNever": "Nunca",
     "settingsDarkModeNight": "De noite",
     "settingsDarkModeAlways": "Sempre",
+    "settingsDarkModeSystem": null,
     "settingsSiteThemeToggle": "Ativar tema do site",
     "settingsAdditionalFeaturesHeading": "Outras funcionalidades",
     "settingsUserscriptsToggle": "Ativar scripts de utilizador",

--- a/localization/languages/ru.json
+++ b/localization/languages/ru.json
@@ -149,6 +149,7 @@
     "settingsDarkModeNever": "Нет",
     "settingsDarkModeNight": "Только ночью",
     "settingsDarkModeAlways": "Всегда",
+    "settingsDarkModeSystem": null,
     "settingsSiteThemeToggle": "Использовать тему сайта",
     "settingsAdditionalFeaturesHeading": "Дополнительные возможности",
     "settingsUserscriptsToggle": "Пользовательские скрипты",

--- a/localization/languages/tr.json
+++ b/localization/languages/tr.json
@@ -149,6 +149,7 @@
     "settingsDarkModeNever": "Asla",
     "settingsDarkModeNight": "Geceleyin",
     "settingsDarkModeAlways": "Her zaman",
+    "settingsDarkModeSystem": null,
     "settingsSiteThemeToggle": "Site temasını etkinleştir",
     "settingsAdditionalFeaturesHeading": "Ek Özellikler",
     "settingsUserscriptsToggle": "Kullanıcı betiklerini etkinleştir",

--- a/localization/languages/uk.json
+++ b/localization/languages/uk.json
@@ -150,6 +150,7 @@
     "settingsDarkModeNever": "Ніколи",
     "settingsDarkModeNight": "Вночі",
     "settingsDarkModeAlways": "Завжди",
+    "settingsDarkModeSystem": null,
     "settingsSiteThemeToggle": "Увімкнути тему сайту",
     "settingsAdditionalFeaturesHeading": "Додаткові можливості",
     "settingsUserscriptsToggle": "Увімкнути скрипти користувача",

--- a/localization/languages/uz.json
+++ b/localization/languages/uz.json
@@ -148,6 +148,7 @@
     "settingsDarkModeNever": null, //"Never" missing translation
     "settingsDarkModeNight": null, //"At night" missing translation
     "settingsDarkModeAlways": null, //"Always" missing translation
+    "settingsDarkModeSystem": null,
     "settingsDarkModeToggle": "Qorong'u rejimini yoqish",
     "settingsSiteThemeToggle": "Sahifa mavzusini yoqish",
     "settingsAdditionalFeaturesHeading": "Qo'shimcha xususiyatlar",

--- a/localization/languages/vi.json
+++ b/localization/languages/vi.json
@@ -142,6 +142,7 @@
     "settingsDarkModeNever": null, //"Never" missing translation
     "settingsDarkModeNight": null, //"At night" missing translation
     "settingsDarkModeAlways": null, //"Always" missing translation
+    "settingsDarkModeSystem": null,
     "settingsSiteThemeToggle": "Bật chủ đề trang",
     "settingsAdditionalFeaturesHeading": "Đặc tính hơn",
     "settingsUserscriptsToggle": "Bật mã script người dùng",

--- a/localization/languages/zh-CN.json
+++ b/localization/languages/zh-CN.json
@@ -149,6 +149,7 @@
     "settingsDarkModeNever": "禁用",
     "settingsDarkModeNight": "只在夜晚开启",
     "settingsDarkModeAlways": "一直开启",
+    "settingsDarkModeSystem": null,
     "settingsSiteThemeToggle": "启用网站主题",
     "settingsAdditionalFeaturesHeading": "其他功能",
     "settingsUserscriptsToggle": "允许自定义脚本",

--- a/localization/languages/zh-TW.json
+++ b/localization/languages/zh-TW.json
@@ -149,6 +149,7 @@
     "settingsDarkModeNever": "永不",
     "settingsDarkModeNight": "於晚上開啟",
     "settingsDarkModeAlways": "永遠",
+    "settingsDarkModeSystem": null,
     "settingsSiteThemeToggle": "啟用網站主題",
     "settingsAdditionalFeaturesHeading": "其他功能",
     "settingsUserscriptsToggle": "允許使用者指令",

--- a/main/main.js
+++ b/main/main.js
@@ -11,7 +11,8 @@ const {
   ipcMain: ipc,
   Menu, MenuItem,
   crashReporter,
-  dialog
+  dialog,
+  nativeTheme
 } = electron
 
 crashReporter.start({
@@ -391,4 +392,8 @@ ipc.on('showSecondaryMenu', function (event, data) {
 
 ipc.on('quit', function () {
   app.quit()
+})
+
+nativeTheme.on('updated', function () {
+  settings.set('systemShouldUseDarkColors', electron.nativeTheme.shouldUseDarkColors)
 })

--- a/main/main.js
+++ b/main/main.js
@@ -394,6 +394,12 @@ ipc.on('quit', function () {
   app.quit()
 })
 
-nativeTheme.on('updated', function () {
-  settings.set('systemShouldUseDarkColors', electron.nativeTheme.shouldUseDarkColors)
+app.on('ready', function() {
+  nativeTheme.on('updated', function () {
+    settings.set('systemShouldUseDarkColors', electron.nativeTheme.shouldUseDarkColors)
+  })
+
+  if (electron.nativeTheme.shouldUseDarkColors !== settings.get('systemShouldUseDarkColors')) {
+    settings.set('systemShouldUseDarkColors', electron.nativeTheme.shouldUseDarkColors)
+  }
 })

--- a/pages/settings/index.html
+++ b/pages/settings/index.html
@@ -106,6 +106,13 @@
             data-string="settingsDarkModeAlways"
           ></label>
         </div>
+        <div class="setting-option">
+          <input type="radio" name="darkMode" id="dark-mode-system" />
+          <label
+            for="dark-mode-system"
+            data-string="settingsDarkModeSystem"
+          ></label>
+        </div>
       </div>
 
       <div class="setting-section">

--- a/pages/settings/settings.js
+++ b/pages/settings/settings.js
@@ -185,12 +185,14 @@ for (var contentType in contentTypes) {
 var darkModeNever = document.getElementById('dark-mode-never')
 var darkModeNight = document.getElementById('dark-mode-night')
 var darkModeAlways = document.getElementById('dark-mode-always')
+var darkModeSystem = document.getElementById('dark-mode-system')
 
 // -1 - off ; 0 - auto ; 1 - on
 settings.get('darkMode', function (value) {
   darkModeNever.checked = (value === -1)
   darkModeNight.checked = (value === 0 || value === undefined || value === false)
   darkModeAlways.checked = (value === 1 || value === true)
+  darkModeSystem.checked = (value === 2 || value === undefined || value === false)
 })
 
 darkModeNever.addEventListener('change', function (e) {
@@ -206,6 +208,11 @@ darkModeNight.addEventListener('change', function (e) {
 darkModeAlways.addEventListener('change', function (e) {
   if (this.checked) {
     settings.set('darkMode', 1)
+  }
+})
+darkModeSystem.addEventListener('change', function (e) {
+  if (this.checked) {
+    settings.set('darkMode', 2)
   }
 })
 

--- a/pages/settings/settings.js
+++ b/pages/settings/settings.js
@@ -190,7 +190,7 @@ var darkModeSystem = document.getElementById('dark-mode-system')
 // -1 - off ; 0 - auto ; 1 - on
 settings.get('darkMode', function (value) {
   darkModeNever.checked = (value === -1)
-  darkModeNight.checked = (value === 0 || value === undefined || value === false)
+  darkModeNight.checked = (value === 0)
   darkModeAlways.checked = (value === 1 || value === true)
   darkModeSystem.checked = (value === 2 || value === undefined || value === false)
 })


### PR DESCRIPTION
Adds the option to let the darkmode setting rely on the underlying OS darkmode.

Only tested on Mac.

---

I'm also not familiar with Electron and how these apps are usually structured. I read through the Min architecture document on the wiki but could only get this to work by grabbing the OS setting from the main thread.