### PR TITLE
Fix several problems with clearing history

### DIFF
--- a/main/remoteActions.js
+++ b/main/remoteActions.js
@@ -54,10 +54,31 @@ ipc.handle('downloadURL', function (e, url) {
 })
 
 ipc.handle('clearStorageData', function () {
-  /* It's important not to delete data from file:// here, since that would also remove internal browser data (such as bookmarks) */
-  return session.fromPartition('persist:webcontent').clearStorageData({ origin: 'http://' })
+  return session.fromPartition('persist:webcontent').clearStorageData()
+  /* It's important not to delete data from file:// from the default partition, since that would also remove internal browser data (such as bookmarks). However, HTTP data does need to be cleared, as there can be leftover data from loading external resources in the browser UI */
     .then(function () {
-      session.fromPartition('persist:webcontent').clearStorageData({ origin: 'https://' })
+      return session.defaultSession.clearStorageData({ origin: 'http://' })
+    })
+    .then(function () {
+      return session.defaultSession.clearStorageData({ origin: 'https://' })
+    })
+    .then(function () {
+      return session.fromPartition('persist:webcontent').clearCache()
+    })
+    .then(function () {
+      return session.fromPartition('persist:webcontent').clearHostResolverCache()
+    })
+    .then(function () {
+      return session.fromPartition('persist:webcontent').clearAuthCache()
+    })
+    .then(function () {
+      return session.defaultSession.clearCache()
+    })
+    .then(function () {
+      return session.defaultSession.clearHostResolverCache()
+    })
+    .then(function () {
+      return session.defaultSession.clearAuthCache()
     })
 })
 


### PR DESCRIPTION
I was reading [an article](https://popzazzle.blogspot.com/2021/10/min-browser-can-you-resist-irresistible.html) on Min that mentioned that some cookies remained after using the "clear history" command. I spent some time investigating this, and found a few issues:

* Loading favicons can store cache and cookie data, but we were never clearing this data, since it's stored in a different partition than regular web content.
* We weren't calling `clearCache` in addition to `clearStorageData`, which is needed to empty the cache directory.
* Using `origin: 'http://'` results in IndexedDB databases not being cleared (I'm not sure why); switching to just `clearStorageData()` with no origin parameter set fixes this.
  * We can't do this in the default session, since that would delete Min's history IndexedDB database, but there shouldn't be any other databases there anyway.

To test this:
* Run `!clearhistory` with this branch.
* Verify that bookmarks are still visible, but history entries are removed.
* On mac, run `sqlite3 ~/Library/Application Support/Min-development/Cookies` and then `select * from cookies;`. Verify that no results appear.
  * Even after erasing the cookies, the file size of the cookies database appears to remain the same, but it should all be blank space and contain no actual cookies.
* Verify that `~/Library/Application Support/Min-development/Partitions/webcontent/Cache` is empty except for the index file (which should itself be empty).

The process should be pretty similar on other operating systems, although you may need to install an sqlite viewer.

Even with these changes, Chromium still keeps a "Network Persistent State" file that contains a partial list of domains visited; I don't see any method in Electron to clear that. I suppose we could just delete it ourselves if we need to.

This is probably worthy of making a bug fix release once this gets merged.
