### PR TITLE
Replace keytar with the built-in safeStorage module

### DIFF
--- a/js/passwordManager/keychain.js
+++ b/js/passwordManager/keychain.js
@@ -1,16 +1,8 @@
-/*
-A note about the keychain storage format:
-keytar saves entries as (service, account, password), but only supports listing all entries given a particular service
-We need a way to find all passwords created by Min, so we use "min saved password" as the service name,
-and then store both the account domain and username in the "account" field as a JS object
-*/
-
 const { ipcRenderer } = require('electron')
 
 class Keychain {
   constructor () {
     this.name = 'Built-in password manager'
-    this.keychainServiceName = 'Min saved password'
   }
 
   getDownloadLink () {
@@ -34,19 +26,14 @@ class Keychain {
   }
 
   async getSuggestions (domain) {
-    return ipcRenderer.invoke('keychainFindCredentials', this.keychainServiceName).then(function (results) {
+    return ipcRenderer.invoke('credentialStoreGetCredentials').then(function (results) {
       return results
         .filter(function (result) {
-          try {
-            return JSON.parse(result.account).domain === domain
-          } catch (e) {
-            return false
-          }
+          return result.domain === domain
         })
         .map(function (result) {
           return {
-            username: JSON.parse(result.account).username,
-            password: result.password,
+            ...result,
             manager: 'Keychain'
           }
         })
@@ -58,20 +45,18 @@ class Keychain {
   }
 
   saveCredential (domain, username, password) {
-    ipcRenderer.invoke('keychainSetPassword', this.keychainServiceName, JSON.stringify({ domain: domain, username: username }), password)
+    ipcRenderer.invoke('credentialStoreSetPassword', { domain, username, password })
   }
 
   deleteCredential (domain, username) {
-    ipcRenderer.invoke('keychainDeletePassword', this.keychainServiceName, JSON.stringify({ domain: domain, username: username }))
+    ipcRenderer.invoke('credentialStoreDeletePassword', { domain, username })
   }
 
   getAllCredentials () {
-    return ipcRenderer.invoke('keychainFindCredentials', this.keychainServiceName).then(function (results) {
+    return ipcRenderer.invoke('credentialStoreGetCredentials').then(function (results) {
       return results.map(function (result) {
         return {
-          domain: JSON.parse(result.account).domain,
-          username: JSON.parse(result.account).username,
-          password: result.password,
+          ...result,
           manager: 'Keychain'
         }
       })

--- a/main/keychainService.js
+++ b/main/keychainService.js
@@ -25,6 +25,7 @@ function readSavedPasswordFile () {
   } catch (e) {
     if (e.code !== 'ENOENT') {
       console.warn(e)
+      throw new Error(e)
     }
   }
   if (file) {

--- a/main/keychainService.js
+++ b/main/keychainService.js
@@ -1,26 +1,96 @@
-/*
-Wrapper for node-keytar
-Runs in the main process because of https://github.com/atom/node-keytar/issues/250
-*/
+/* Uses Electron's safeStorage to encrypt a password file - encryption key gets stored in the system keychain */
 
 const keytar = require('keytar')
+const safeStorage = require('electron').safeStorage
+const passwordFilePath = path.join(userDataPath, 'passwordStore')
 
-ipc.handle('keychainGetPassword', function (event, service, account) {
-  return keytar.getPassword(service, account)
+/*
+file format:
+{
+  version: 1,
+  credentials: [
+    {
+      domain:,
+      username:,
+      password:
+    }
+  ]
+}
+*/
+
+function readSavedPasswordFile () {
+  let file
+  try {
+    file = fs.readFileSync(passwordFilePath)
+  } catch (e) {
+    if (e.code !== 'ENOENT') {
+      console.warn(e)
+    }
+  }
+  if (file) {
+    return JSON.parse(safeStorage.decryptString(file))
+  } else {
+    return {
+      version: 1,
+      credentials: []
+    }
+  }
+}
+
+function writeSavedPasswordFile (content) {
+  fs.writeFileSync(passwordFilePath, safeStorage.encryptString(JSON.stringify(content)))
+}
+
+function credentialStoreSetPassword (account) {
+  const fileContent = readSavedPasswordFile()
+
+  // delete duplicate credentials
+  for (let i = 0; i < fileContent.credentials.length; i++) {
+    if (fileContent.credentials[i].domain === account.domain && fileContent.credentials[i].username === account.username) {
+      fileContent.credentials.splice(i, 1)
+      i--
+    }
+  }
+
+  fileContent.credentials.push(account)
+  writeSavedPasswordFile(fileContent)
+}
+
+ipc.handle('credentialStoreSetPassword', async function (event, account) {
+  return credentialStoreSetPassword(account)
 })
 
-ipc.handle('keychainSetPassword', function (event, service, account, password) {
-  return keytar.setPassword(service, account, password)
+ipc.handle('credentialStoreDeletePassword', async function (event, account) {
+  const fileContent = readSavedPasswordFile()
+
+  // delete matching credentials
+  for (let i = 0; i < fileContent.credentials.length; i++) {
+    if (fileContent.credentials[i].domain === account.domain && fileContent.credentials[i].username === account.username) {
+      fileContent.credentials.splice(i, 1)
+      i--
+    }
+  }
+
+  return writeSavedPasswordFile(fileContent)
 })
 
-ipc.handle('keychainDeletePassword', function (event, service, account) {
-  return keytar.deletePassword(service, account)
+ipc.handle('credentialStoreGetCredentials', async function () {
+  return readSavedPasswordFile().credentials
 })
 
-ipc.handle('keychainFindCredentials', function (event, service) {
-  return keytar.findCredentials(service)
-})
+/* On startup, migrate everything from keychain */
 
-ipc.handle('keychainFindPassword', function (event, service) {
-  return keytar.setPassword(service)
-})
+setTimeout(function () {
+  if (!settings.get('v1_23_keychainMigrationComplete')) {
+    keytar.findCredentials('Min saved password').then(function (results) {
+      results.forEach(function (result) {
+        credentialStoreSetPassword({
+          domain: JSON.parse(result.account).domain,
+          username: JSON.parse(result.account).username,
+          password: result.password
+        })
+      })
+      settings.set('v1_23_keychainMigrationComplete', true)
+    })
+  }
+}, 5000)


### PR DESCRIPTION
This PR changes the way passwords are stored with the built-in password manager. Previously, the `keytar` module was used to add individual passwords as keychain entries; however, as described in #1761, the keytar module is no longer being updated and will stop working in future versions of node/electron, so we need an alternative solution.

With this PR, passwords are instead stored in a file inside the app data directory, which is encrypted using a randomly-generated key that's stored in the keychain. The encryption and decryption is all handled by the recently-added safeStorage module in Electron: https://www.electronjs.org/docs/latest/api/safe-storage

The behavior of the password manager should be identical with these changes - previously-saved passwords should get automatically migrated to the new format, and adding/deleting/viewing passwords should all work as expected. If you test this and see something unexpected happening, please let me know.