### PR TITLE
Improve Bitwarden integration

### DIFF
--- a/js/passwordManager/bitwarden.js
+++ b/js/passwordManager/bitwarden.js
@@ -140,6 +140,12 @@ class Bitwarden {
       return true
     } catch (ex) {
       const { error, data } = ex
+
+      if (error.includes('not logged in')) {
+        await this.signInAndSave()
+        return await this.unlockStore(password)
+      }
+
       console.error('Error accessing Bitwarden CLI. STDOUT: ' + data + '. STDERR: ' + error)
       throw ex
     }

--- a/js/passwordManager/bitwarden.js
+++ b/js/passwordManager/bitwarden.js
@@ -145,7 +145,11 @@ class Bitwarden {
   }
 
   getSignInRequirements () {
-    return ['email', 'password']
+    return ['clientID', 'clientSecret']
+  }
+
+  getSignInInstructions () {
+    return l('passwordManagerBitwardenSignIn')
   }
 
   async signInAndSave (credentials, path = this.path) {
@@ -156,7 +160,10 @@ class Bitwarden {
     } catch (e) {
       console.warn(e)
     }
-    const process = new ProcessSpawner(path, ['login', '--raw', credentials.email, credentials.password])
+    const process = new ProcessSpawner(path, ['login', '--apikey'], {
+      BW_CLIENTID: credentials.clientID.trim(),
+      BW_CLIENTSECRET: credentials.clientSecret.trim()
+    })
 
     await process.execute()
 

--- a/js/passwordManager/keychain.js
+++ b/js/passwordManager/keychain.js
@@ -40,10 +40,6 @@ class Keychain {
     })
   }
 
-  getSignInRequirements () {
-    return []
-  }
-
   saveCredential (domain, username, password) {
     ipcRenderer.invoke('credentialStoreSetPassword', { domain, username, password })
   }

--- a/js/passwordManager/managerSetup.js
+++ b/js/passwordManager/managerSetup.js
@@ -26,6 +26,8 @@ const setupDialog = {
     document.getElementById('password-manager-setup-link').textContent = l('passwordManagerSetupLink').replace('%p', manager.name)
     document.getElementById('password-manager-setup-link-installer').textContent = l('passwordManagerSetupLinkInstaller').replace('%p', manager.name)
 
+    dragBox.textContent = l('passwordManagerSetupDragBox')
+
     if (setupDialog.setupMode === 'installer') {
       primaryInstructions.hidden = true
       secondaryInstructions.hidden = false
@@ -165,17 +167,19 @@ function afterInstall (toolPath) {
   var signInFields = [
     { placeholder: l('email'), id: 'email', type: 'text' },
     { placeholder: l('password'), id: 'password', type: 'password' },
-    { placeholder: l('secretKey'), id: 'secretKey', type: 'password' }
+    { placeholder: l('secretKey'), id: 'secretKey', type: 'password' },
+    { placeholder: 'Client ID', id: 'clientID', type: 'password' },
+    { placeholder: 'Client Secret', id: 'clientSecret', type: 'password' }
   ].filter(f => setupDialog.manager.getSignInRequirements().includes(f.id))
 
   // Verify the tool by trying to use it to unlock the password store.
   const data = ipcRenderer.sendSync('prompt', {
-    text: l('passwordManagerSetupSignIn'),
+    text: setupDialog.manager.getSignInInstructions ? setupDialog.manager.getSignInInstructions() : l('passwordManagerSetupSignIn'),
     values: signInFields,
     ok: l('dialogConfirmButton'),
     cancel: l('dialogSkipButton'),
     width: 500,
-    height: 220
+    height: 240
   })
 
   for (const key in data) {

--- a/js/passwordManager/managerSetup.js
+++ b/js/passwordManager/managerSetup.js
@@ -164,31 +164,7 @@ function launchInstaller (filePath, platform) {
 }
 
 function afterInstall (toolPath) {
-  var signInFields = [
-    { placeholder: l('email'), id: 'email', type: 'text' },
-    { placeholder: l('password'), id: 'password', type: 'password' },
-    { placeholder: l('secretKey'), id: 'secretKey', type: 'password' },
-    { placeholder: 'Client ID', id: 'clientID', type: 'password' },
-    { placeholder: 'Client Secret', id: 'clientSecret', type: 'password' }
-  ].filter(f => setupDialog.manager.getSignInRequirements().includes(f.id))
-
-  // Verify the tool by trying to use it to unlock the password store.
-  const data = ipcRenderer.sendSync('prompt', {
-    text: setupDialog.manager.getSignInInstructions ? setupDialog.manager.getSignInInstructions() : l('passwordManagerSetupSignIn'),
-    values: signInFields,
-    ok: l('dialogConfirmButton'),
-    cancel: l('dialogSkipButton'),
-    width: 500,
-    height: 240
-  })
-
-  for (const key in data) {
-    if (data[key] === '') {
-      throw new Error('no credentials entered')
-    }
-  }
-
-  setupDialog.manager.signInAndSave(data, toolPath)
+  setupDialog.manager.signInAndSave(toolPath)
     .then(() => {
       setupDialog.hide()
     })

--- a/js/util/process.js
+++ b/js/util/process.js
@@ -22,16 +22,17 @@ const customEnv = Object.assign({}, process.env, { PATH: processPath })
 const maxBufferSize = 25 * 1024 * 1024
 
 class ProcessSpawner {
-  constructor (command, args) {
+  constructor (command, args, env = {}) {
     this.command = command
     this.args = args
     this.data = ''
     this.error = ''
+    this.env = Object.assign({}, customEnv, env)
   }
 
   async execute () {
     return new Promise((resolve, reject) => {
-      const process = spawn(this.command, this.args, { env: customEnv, maxBuffer: maxBufferSize })
+      const process = spawn(this.command, this.args, { env: this.env, maxBuffer: maxBufferSize })
 
       process.stdout.on('data', (data) => {
         this.data += data
@@ -56,7 +57,7 @@ class ProcessSpawner {
   }
 
   executeSync (input) {
-    const process = spawnSync(this.command, this.args, { input: input, encoding: 'utf8', env: customEnv, maxBuffer: maxBufferSize })
+    const process = spawnSync(this.command, this.args, { input: input, encoding: 'utf8', env: this.env, maxBuffer: maxBufferSize })
     return process.output[1].slice(0, -1)
   }
 
@@ -76,7 +77,7 @@ class ProcessSpawner {
         command: this.command,
         args: this.args,
         input: input,
-        customEnv: customEnv,
+        customEnv: this.env,
         maxBuffer: maxBufferSize,
         taskId: taskId
       })
@@ -86,7 +87,7 @@ class ProcessSpawner {
   checkCommandExists () {
     return new Promise((resolve, reject) => {
       const checkCommand = (platformType === 'windows') ? 'where' : 'which'
-      const process = spawn(checkCommand, [this.command], { env: customEnv })
+      const process = spawn(checkCommand, [this.command], { env: this.env })
 
       process.stdout.on('data', (data) => {
         if (data.length > 0) {

--- a/localization/languages/ar.json
+++ b/localization/languages/ar.json
@@ -256,6 +256,7 @@
     "passwordManagerSetupStep2": null, //missing translation
     "passwordManagerSetupDragBox": null, //missing translation
     "passwordManagerSetupInstalling": null, //missing translation
+    "passwordManagerBitwardenSignIn": null, //missing translation
     "passwordManagerSetupSignIn": null, //missing translation
     "disableAutofill": null, //missing translation
     "passwordManagerSetupUnlockError": null, //missing translation

--- a/localization/languages/bg.json
+++ b/localization/languages/bg.json
@@ -257,6 +257,7 @@
     "passwordManagerSetupStep2": "След това плъзнете уреда в полето отдолу:",
     "passwordManagerSetupDragBox": "Плъзнете уреда тук",
     "passwordManagerSetupInstalling": "Инсталиране...",
+    "passwordManagerBitwardenSignIn": null, //missing translation
     "passwordManagerSetupSignIn": "Впишете се във Вашия мениджър на пароли, за да започнете употребата на автоматично попълване. Вашите пълномощия няма да се съхраняват никъде в Min.",
     "disableAutofill": "Деактивиране на автоматично попълване на пароли",
     "passwordManagerSetupUnlockError": "Неуспешно отключване на хранилището за пароли: ",

--- a/localization/languages/bn.json
+++ b/localization/languages/bn.json
@@ -254,6 +254,7 @@
     "passwordManagerSetupStep2": null, //missing translation
     "passwordManagerSetupDragBox": null, //missing translation
     "passwordManagerSetupInstalling": null, //missing translation
+    "passwordManagerBitwardenSignIn": null, //missing translation
     "passwordManagerSetupSignIn": null, //missing translation
     "disableAutofill": null, //missing translation
     "passwordManagerSetupUnlockError": null, //missing translation

--- a/localization/languages/cs.json
+++ b/localization/languages/cs.json
@@ -258,6 +258,7 @@
     "passwordManagerSetupStep2": "Pak přetáhněte nástroj do pole níže:",
     "passwordManagerSetupDragBox": "Přetáhněte nástroj sem",
     "passwordManagerSetupInstalling": "Probíhá instalace...",
+    "passwordManagerBitwardenSignIn": null, //missing translation
     "passwordManagerSetupSignIn": "Přihlaste se do vašeho správce hesel, abyste mohli začít používat automatické vkládání. Vaše přihlašovací údaje nebudou v prohlížeči Min nikde uchovány.",
     "disableAutofill": "Vypnout automatické vkládání",
     "passwordManagerSetupUnlockError": "Selhalo odemčení úložiště hesel: ",

--- a/localization/languages/de.json
+++ b/localization/languages/de.json
@@ -260,6 +260,7 @@
     "passwordManagerSetupStep2": "Ziehe danach das Programm in die untere Box:",
     "passwordManagerSetupDragBox": "Ziehe das Programm hierher",
     "passwordManagerSetupInstalling": "Installiere...",
+    "passwordManagerBitwardenSignIn": null, //missing translation
     "passwordManagerSetupSignIn": "Melde dich in deinem Passwortmanager an, um die automatische Ausfüll Funktion zu nutzen. Deine Zugangsdaten werden nirgendwo in Min gespeichert.",
     "disableAutofill": "Automatische Ausfüll Funktion deaktivieren",
     "passwordManagerSetupUnlockError": "Beim Entsperren des Passwortmanagers ist ein Fehler aufgetreten:",

--- a/localization/languages/en-US.json
+++ b/localization/languages/en-US.json
@@ -260,6 +260,7 @@
     "passwordManagerSetupStep2": "Then drag the tool into the box below:",
     "passwordManagerSetupDragBox": "Drag the tool here",
     "passwordManagerSetupInstalling": "Installing...",
+    "passwordManagerBitwardenSignIn": "To connect your Bitwarden account, go to vault.bitwarden.com/#/settings/account, scroll to the bottom, and choose \"View API Key\". Then paste the values into the fields below.",
     "passwordManagerSetupSignIn": "Sign in to your password manager to start using autofill. Your credentials won't be stored anywhere inside Min.",
     "disableAutofill": "Disable Autofill",
     "passwordManagerSetupUnlockError": "Failed to unlock the password store: ",

--- a/localization/languages/es.json
+++ b/localization/languages/es.json
@@ -259,6 +259,7 @@
     "passwordManagerSetupStep2": "Luego arrastra la herramienta hasta el cuadro de abajo:",
     "passwordManagerSetupDragBox": "Arrastra la herramienta hasta aquí",
     "passwordManagerSetupInstalling": "Instalando...",
+    "passwordManagerBitwardenSignIn": null, //missing translation
     "passwordManagerSetupSignIn": "Inicia sesión en tu gestor de contraseñas para empezar a usar el Auto-llenado. Tus credenciales no serán almacenadas en ningún lugar dentro de Min.",
     "disableAutofill": "Desactivar Auto-llenado",
     "passwordManagerSetupUnlockError": "No se pudo desbloquear el almacén de contraseñas:",

--- a/localization/languages/fa.json
+++ b/localization/languages/fa.json
@@ -255,6 +255,7 @@
     "passwordManagerSetupStep2": null, //missing translation
     "passwordManagerSetupDragBox": null, //missing translation
     "passwordManagerSetupInstalling": null, //missing translation
+    "passwordManagerBitwardenSignIn": null, //missing translation
     "passwordManagerSetupSignIn": null, //missing translation
     "disableAutofill": null, //missing translation
     "passwordManagerSetupUnlockError": null, //missing translation

--- a/localization/languages/fr.json
+++ b/localization/languages/fr.json
@@ -260,6 +260,7 @@
     "passwordManagerSetupStep2": "Puis cliquer-glisser l'outil dans le cadre ci-dessous :",
     "passwordManagerSetupDragBox": "Déposer l'outil ici",
     "passwordManagerSetupInstalling": "En cours d'installation...",
+    "passwordManagerBitwardenSignIn": null, //missing translation
     "passwordManagerSetupSignIn": "Connectez-vous à votre gestionnaire de mots de pass pour commencer à utiliser le remplissage automatique. Vos informations de connexion ne seront jamais stockées par Min.",
     "disableAutofill": "Désactiver le remplissage automatique",
     "passwordManagerSetupUnlockError": "Échec d'ouverture de la bibliothèque de mots passe : ",

--- a/localization/languages/hr.json
+++ b/localization/languages/hr.json
@@ -260,6 +260,7 @@
     "passwordManagerSetupStep2": "Zatim povucite alat u donji okvir:",
     "passwordManagerSetupDragBox": "Povucite alat ovdje",
     "passwordManagerSetupInstalling": "Instaliranje...",
+    "passwordManagerBitwardenSignIn": null, //missing translation
     "passwordManagerSetupSignIn": "Prijavite se na upravitelj lozinki da biste počeli koristiti automatsko popunjavanje. Vjerodajnice se neće pohraniti nigdje u Min.",
     "disableAutofill": "Onemogući automatsko popunjavanje",
     "passwordManagerSetupUnlockError": "Otključavanje spremišta lozinki nije uspjelo: ",

--- a/localization/languages/hu.json
+++ b/localization/languages/hu.json
@@ -252,6 +252,7 @@
     "passwordManagerSetupStep2": null, //missing translation
     "passwordManagerSetupDragBox": null, //missing translation
     "passwordManagerSetupInstalling": null, //missing translation
+    "passwordManagerBitwardenSignIn": null, //missing translation
     "passwordManagerSetupSignIn": null, //missing translation
     "disableAutofill": null, //missing translation
     "passwordManagerSetupUnlockError": null, //missing translation

--- a/localization/languages/it.json
+++ b/localization/languages/it.json
@@ -260,6 +260,7 @@
     "passwordManagerSetupStep2": "Quindi trascina il tool nel box qui sotto:",
     "passwordManagerSetupDragBox": "Trascina il tool qui",
     "passwordManagerSetupInstalling": "Installazione...",
+    "passwordManagerBitwardenSignIn": null, //missing translation
     "passwordManagerSetupSignIn": "Entra nel tuo gestore di password per iniziare ad usare l'autocompletamento. Le tue credenziali non saranno salvate da nessuna parte in Min.",
     "disableAutofill": "Disabilita autocompletamento",
     "passwordManagerSetupUnlockError": "Impossibile sbloccare le password: ",

--- a/localization/languages/ja.json
+++ b/localization/languages/ja.json
@@ -260,6 +260,7 @@
     "passwordManagerSetupStep2": "次に、ツールを下のボックスにドラッグします。",
     "passwordManagerSetupDragBox": "ここにツールをドラッグ",
     "passwordManagerSetupInstalling": "インストールしています...",
+    "passwordManagerBitwardenSignIn": null, //missing translation
     "passwordManagerSetupSignIn": "パスワードマネージャーにログインして、自動入力の使用を開始します。 資格情報はMin内のどこにも保存されません。",
     "disableAutofill": "自動入力を無効にする",
     "passwordManagerSetupUnlockError": "パスワードストアのロック解除に失敗しました： ",

--- a/localization/languages/ko.json
+++ b/localization/languages/ko.json
@@ -260,6 +260,7 @@
     "passwordManagerSetupStep2": "그 다음 도구를 아래 박스 안에 끌어다 놓습니다:",
     "passwordManagerSetupDragBox": "도구를 여기에 끌어다 놓으세요.",
     "passwordManagerSetupInstalling": "설치하는 중...",
+    "passwordManagerBitwardenSignIn": null, //missing translation
     "passwordManagerSetupSignIn": "자동완성을 사용하려면 비밀번호 관리자에 로그인하세요. 귀하의 자격증명은 민(Min)의 그 어디에도 저장되지 않습니다.",
     "disableAutofill": "자동완성 비활성화",
     "passwordManagerSetupUnlockError": "비밀번호 저장소를 여는데 실패했습니다: ",

--- a/localization/languages/lt.json
+++ b/localization/languages/lt.json
@@ -254,6 +254,7 @@
     "passwordManagerSetupStep2": null, //missing translation
     "passwordManagerSetupDragBox": null, //missing translation
     "passwordManagerSetupInstalling": null, //missing translation
+    "passwordManagerBitwardenSignIn": null, //missing translation
     "passwordManagerSetupSignIn": null, //missing translation
     "disableAutofill": null, //missing translation
     "passwordManagerSetupUnlockError": null, //missing translation

--- a/localization/languages/pl.json
+++ b/localization/languages/pl.json
@@ -260,6 +260,7 @@
     "passwordManagerSetupStep2": "Następnie przeciągnij narzędzie do pola poniżej:",
     "passwordManagerSetupDragBox": "Przeciągnij narzędzie tutaj",
     "passwordManagerSetupInstalling": "Instalowanie...",
+    "passwordManagerBitwardenSignIn": null, //missing translation
     "passwordManagerSetupSignIn": "Zaloguj się do menedżera haseł, aby rozpocząć korzystanie z autouzupełniania. Twoje dane uwierzytelniające nie będą przechowywane nigdzie w Min.",
     "disableAutofill": "Wyłącz autouzupełnianie",
     "passwordManagerSetupUnlockError": "nie udało się odblokować przechowalni haseł: ",

--- a/localization/languages/pt-BR.json
+++ b/localization/languages/pt-BR.json
@@ -260,6 +260,7 @@
     "passwordManagerSetupStep2": "Em seguida, arraste a ferramenta para a caixa abaixo:",
     "passwordManagerSetupDragBox": "Arraste a ferramenta aqui",
     "passwordManagerSetupInstalling": "Instalando ...",
+    "passwordManagerBitwardenSignIn": null, //missing translation
     "passwordManagerSetupSignIn": "Entre no seu gerenciador de senhas para começar a usar o preenchimento automático. Suas credenciais não serão armazenadas em nenhum lugar do Min.",
     "disableAutofill": "Desativar preenchimento automático",
     "passwordManagerSetupUnlockError": "Falha ao desbloquear o armazenamento de senhas:",

--- a/localization/languages/pt-PT.json
+++ b/localization/languages/pt-PT.json
@@ -260,6 +260,7 @@
     "passwordManagerSetupStep2": "Depois, arraste a ferramenta para a caixa abaixo:",
     "passwordManagerSetupDragBox": "Arraste a ferramenta para aqui",
     "passwordManagerSetupInstalling": "A instalar...",
+    "passwordManagerBitwardenSignIn": null, //missing translation
     "passwordManagerSetupSignIn": "Inicie sessão no gestor de palavras-passe para utilizar o preenchimento automático. As suas credenciais não serão guardadas no Min.",
     "disableAutofill": "Desativar preenchimento automático",
     "passwordManagerSetupUnlockError": "Falha ao desbloquear: ",

--- a/localization/languages/ru.json
+++ b/localization/languages/ru.json
@@ -260,6 +260,7 @@
     "passwordManagerSetupStep2": "Затем перетащите инструмент в поле ниже:",
     "passwordManagerSetupDragBox": "Перетащите инструмент сюда",
     "passwordManagerSetupInstalling": "Установка...",
+    "passwordManagerBitwardenSignIn": null, //missing translation
     "passwordManagerSetupSignIn": "Войдите в свой менеджер паролей, чтобы начать использовать автозаполнение. Ваши учетные данные не будут храниться где-либо внутри Min.",
     "disableAutofill": "Отключить автозаполнение",
     "passwordManagerSetupUnlockError": "Не удалось разблокировать хранилище паролей: ",

--- a/localization/languages/tr.json
+++ b/localization/languages/tr.json
@@ -260,6 +260,7 @@
     "passwordManagerSetupStep2": "Ardından aracı aşağıdaki kutucuğa sürükleyip bırakın:",
     "passwordManagerSetupDragBox": "Aracı buraya sürükleyin",
     "passwordManagerSetupInstalling": "Yükleniyor...",
+    "passwordManagerBitwardenSignIn": null, //missing translation
     "passwordManagerSetupSignIn": "Otomatik dolduru kullanabilmek için parola yöneticinize giriş yapın. Kimlik bilgileriniz Min içerisinde bir yere kaydedilmeyecektir.",
     "disableAutofill": "Otomatik Dolduru Devre Dışı Bırak",
     "passwordManagerSetupUnlockError": "Parola kayıtlarının kilidi açılamadı: ",

--- a/localization/languages/uk.json
+++ b/localization/languages/uk.json
@@ -261,6 +261,7 @@
     "passwordManagerSetupStep2": "Потім перетягніть інструмент у поле нижче:",
     "passwordManagerSetupDragBox": "Перетягніть інструмент сюди",
     "passwordManagerSetupInstalling": "Встановлення...",
+    "passwordManagerBitwardenSignIn": null, //missing translation
     "passwordManagerSetupSignIn": "Увійдіть до менеджера паролів, щоб почати використовувати автозаповнення. Ваші облікові дані не зберігатимуться ніде в межах Min.",
     "disableAutofill": "Вимкнути автозаповнення",
     "passwordManagerSetupUnlockError": "Не вдалося розблокувати сховище паролів: ",

--- a/localization/languages/uz.json
+++ b/localization/languages/uz.json
@@ -254,6 +254,7 @@
     "passwordManagerSetupStep2": "Keyin vositani quyidagi maydonchaga torting:",
     "passwordManagerSetupDragBox": "Vositani bu yerga torting",
     "passwordManagerSetupInstalling": "O'rnatilmoqda...",
+    "passwordManagerBitwardenSignIn": null, //missing translation
     "passwordManagerSetupSignIn": "Avtomatik to'ldirishni ishlatish uchun parol menejeringiz tizimiga kiring. Sizning ma'lumotlaringiz Minni hech qanday joyida saqlanmaydi.",
     "disableAutofill": "Avtomatik to'ldirishni o'chirish",
     "passwordManagerSetupUnlockError": "Parollar do'konini ochish muvaffaqiyatsiz bo'ldi: ",

--- a/localization/languages/vi.json
+++ b/localization/languages/vi.json
@@ -247,6 +247,7 @@
     "passwordManagerSetupStep2": null, //missing translation
     "passwordManagerSetupDragBox": null, //missing translation
     "passwordManagerSetupInstalling": null, //missing translation
+    "passwordManagerBitwardenSignIn": null, //missing translation
     "passwordManagerSetupSignIn": null, //missing translation
     "disableAutofill": null, //missing translation
     "passwordManagerSetupUnlockError": null, //missing translation

--- a/localization/languages/zh-CN.json
+++ b/localization/languages/zh-CN.json
@@ -260,6 +260,7 @@
     "passwordManagerSetupStep2": "然后把工具拖动到下面的框中：",
     "passwordManagerSetupDragBox": "把工具拖动到这里",
     "passwordManagerSetupInstalling": "安装中...",
+    "passwordManagerBitwardenSignIn": null, //missing translation
     "passwordManagerSetupSignIn": "登录密码管理器以使用自动填充。你的凭证不会在Min内存储。",
     "disableAutofill": "关闭自动填充",
     "passwordManagerSetupUnlockError": "解锁密码存储区失败：",

--- a/localization/languages/zh-TW.json
+++ b/localization/languages/zh-TW.json
@@ -260,6 +260,7 @@
     "passwordManagerSetupStep2": "然後將檔案拖曳至下方：",
     "passwordManagerSetupDragBox": "將檔案拖至此處",
     "passwordManagerSetupInstalling": "正在安裝...",
+    "passwordManagerBitwardenSignIn": null, //missing translation
     "passwordManagerSetupSignIn": "登入你的密碼管理器並開始使用自動填入。您的資訊不會被存入 Min。",
     "disableAutofill": "取消",
     "passwordManagerSetupUnlockError": "無法登入密碼儲存庫。",


### PR DESCRIPTION
This PR attempts to fix a few of the most common issues with the Bitwarden integration:

* Bitwarden recently started requiring an API key instead of a password in some cases: https://bitwarden.com/help/article/cli-auth-challenges/, which I believe is the cause of the recent issues about Bitwarden setup failing. This PR updates the installation flow to ask for a client ID and key instead of a username and password. This also makes it possible to connect Bitwarden accounts that have 2FA enabled.

Fixes #1796, #1394, #929

* Added a re-prompt for authentication if the user is signed out and tries to autofill a password. Previously, the authentication prompt would never show after setup was complete, which meant it was possible to end up in a state where you weren't signed in and there was no way to sign in again in the UI. This should hopefully fix #1689.