### PR TITLE
Add a snippet to full-text search results

### DIFF
--- a/js/places/placesWorker.js
+++ b/js/places/placesWorker.js
@@ -51,7 +51,6 @@ function addToHistoryCache (item) {
     tagIndex.addPage(item)
   }
   delete item.pageHTML
-  delete item.extractedText
   delete item.searchIndex
 
   historyInMemoryCache.push(item)
@@ -59,7 +58,6 @@ function addToHistoryCache (item) {
 
 function addOrUpdateHistoryCache (item) {
   delete item.pageHTML
-  delete item.extractedText
   delete item.searchIndex
 
   let oldItem
@@ -139,7 +137,7 @@ onmessage = function (e) {
             visitCount: 0,
             lastVisit: Date.now(),
             pageHTML: '',
-            extractedText: '',
+            extractedText: pageData.extractedText,
             searchIndex: [],
             isBookmarked: false,
             tags: [],
@@ -149,6 +147,7 @@ onmessage = function (e) {
         for (const key in pageData) {
           if (key === 'extractedText') {
             item.searchIndex = tokenize(pageData.extractedText)
+            item.extractedText = pageData.extractedText
           } else if (key === 'tags') {
             // ensure tags are never saved with spaces in them
             item.tags = pageData.tags.map(t => t.replace(/\s/g, '-'))

--- a/js/searchbar/placesPlugin.js
+++ b/js/searchbar/placesPlugin.js
@@ -75,6 +75,7 @@ function showSearchbarPlaceResults (text, input, event, pluginName = 'places') {
       var data = {
         url: result.url,
         metadata: result.tags,
+        descriptionBlock: result.searchSnippet,
         delete: function () {
           places.deleteHistory(result.url)
         },

--- a/js/searchbar/placesPlugin.js
+++ b/js/searchbar/placesPlugin.js
@@ -75,7 +75,7 @@ function showSearchbarPlaceResults (text, input, event, pluginName = 'places') {
       var data = {
         url: result.url,
         metadata: result.tags,
-        descriptionBlock: result.searchSnippet,
+        descriptionBlock: (results.length < 4 ? result.searchSnippet : null),
         delete: function () {
           places.deleteHistory(result.url)
         },

--- a/js/util/database.js
+++ b/js/util/database.js
@@ -14,7 +14,7 @@ db.version(1).stores({
   /*
   color - the main color of the page, extracted from the page icon
   pageHTML - a saved copy of the page's HTML, when it was last visited. Removed in 1.6.0, so all pages visited after then will have an empty string in this field.
-  extractedText - the text content of the page, extracted from pageHTML. Unused as of 1.7.0, should be removed completely in a future version.
+  extractedText - the text content of the page, extracted from pageHTML.
   searchIndex - an array of words on the page (created from extractedText), used for full-text searchIndex
   isBookmarked - whether the page is a bookmark
   extraData - other metadata about the page


### PR DESCRIPTION
Often when searching using the full-text search feature, the page title alone isn't enough to tell whether the result is what I'm looking for. This PR shows a small snippet of the page text that matches the query below the result, which makes it easier to figure out. An example:
<img width="1239" alt="Screen Shot 2021-12-18 at 11 42 19 PM" src="https://user-images.githubusercontent.com/10314059/146665309-544e2a21-c2f5-4058-9246-7b672bccae18.png">

This also brings back storage of the full page text, instead of just the tokenized index. This was originally removed to save storage space; however, I believe the main problem that was originally causing the database to use excessive space is now fixed (#832), so this hopefully shouldn't be too much of a problem.
