### PR TITLE
Support links in PDF viewer

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "keytar": "7.6.0",
     "mousetrap": "^1.5.3",
     "node-abi": "^3.2.0",
-    "pdfjs-dist": "2.4.456",
+    "pdfjs-dist": "^2.12.313",
     "regedit": "^3.0.3",
     "string_score": "^0.1.22"
   },

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "keytar": "7.6.0",
     "mousetrap": "^1.5.3",
     "node-abi": "^3.2.0",
-    "pdfjs-dist": "^2.12.313",
+    "pdfjs-dist": "2.12.313",
     "regedit": "^3.0.3",
     "string_score": "^0.1.22"
   },

--- a/pages/pdfViewer/viewer.css
+++ b/pages/pdfViewer/viewer.css
@@ -150,7 +150,8 @@
   }
 
   .annotationLayer img,
-  .annotationLayer .popupAnnotation {
+  .annotationLayer .popupAnnotation,
+  .annotationLayer .popupWrapper {
     display: none;
   }
 

--- a/pages/pdfViewer/viewer.css
+++ b/pages/pdfViewer/viewer.css
@@ -149,6 +149,35 @@
     transform-origin: top left;
   }
 
+  .annotationLayer img,
+  .annotationLayer .popupAnnotation {
+    display: none;
+  }
+
+  .annotationLayer span[data-l10n-id] {
+    display: none;
+  }
+
+  .annotationLayer section {
+    position: absolute;
+    text-align: initial;
+  }
+  
+  .annotationLayer .linkAnnotation > a,a {
+    position: absolute;
+    font-size: 1em;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
+  
+  .annotationLayer .linkAnnotation > a:hover {
+    opacity: 0.2;
+    background: rgba(255, 255, 0, 1);
+    box-shadow: 0 2px 10px rgba(255, 255, 0, 1);
+  }
+
   .page-container {
     position: relative;
   }

--- a/pages/pdfViewer/viewer.js
+++ b/pages/pdfViewer/viewer.js
@@ -224,7 +224,7 @@ function setUpPageAnnotationLayer (pageView) {
     // Adapted from https://github.com/mozilla/pdf.js/blob/8ac0ccc2277a7c0c85d6fec41c0f3fc3d1a2d232/web/pdf_link_service.js#L238
     let explicitDest
     if (typeof dest === 'string') {
-      explicitDest = pdf.getDestination(dest)
+      explicitDest = await pdf.getDestination(dest)
     } else {
       explicitDest = await dest
     }


### PR DESCRIPTION
This PR adds the necessary code (mostly adapted from the default pdfjs viewer) to support internal / external links.

Test page: https://www.antennahouse.com/hubfs/xsl-fo-sample/pdf/basic-link-1.pdf?hsLang=en

The PDF viewer code is pretty messy; I didn't change any of it in this PR, but might come back to it later.

Fixes #1422, https://github.com/minbrowser/min/issues/909#issuecomment-1007962847