### PR TITLE
Improve integration of browser theme settings with system theme

### DIFF
--- a/js/util/theme.js
+++ b/js/util/theme.js
@@ -2,15 +2,6 @@ if (typeof require !== 'undefined') {
   var settings = require('util/settings/settings.js')
 }
 
-function systemShouldEnableDarkMode () {
-  return settings.list.systemShouldUseDarkColors
-}
-
-function isNightTime () {
-  var hours = new Date().getHours()
-  return (hours > 21 || hours < 6)
-}
-
 function enableDarkMode () {
   document.body.classList.add('dark-mode')
   window.isDarkMode = true
@@ -27,75 +18,15 @@ function disableDarkMode () {
   })
 }
 
-var themeInterval = null
-
 function initialize () {
-  function themeSettingsChanged (value) {
-    /*
-    value is the value of the darkMode pref
-    0 - automatic dark mode
-    -1: never
-    0: at night
-    1: always
-    2: follow system (default)
-    true / false: legacy pref values, translate to always/system
-    */
-    clearInterval(themeInterval)
-
-    // 1 or true: dark mode is always enabled
-    if (value === 1 || value === true) {
+  function themeChanged (value) {
+    if (value === true) {
       enableDarkMode()
-      return
-    }
-
-    // 2, undefined, or false: automatic dark mode following system
-    if (value === undefined || value === 2 || value === false) {
-      if (systemShouldEnableDarkMode()) {
-        enableDarkMode()
-      } else {
-        disableDarkMode()
-      }
-
-      themeInterval = setInterval(function () {
-        if (systemShouldEnableDarkMode()) {
-          if (!window.isDarkMode) {
-            enableDarkMode()
-          }
-        } else if (window.isDarkMode) {
-          disableDarkMode()
-        }
-      }, 10000)
-    } else if (value === 0) {
-      // 0: automatic dark mode at night
-      if (isNightTime()) {
-        enableDarkMode()
-      } else {
-        disableDarkMode()
-      }
-
-      themeInterval = setInterval(function () {
-        if (isNightTime()) {
-          if (!window.isDarkMode) {
-            enableDarkMode()
-          }
-        } else if (window.isDarkMode) {
-          disableDarkMode()
-        }
-      }, 10000)
-    } else if (value === -1) {
-      // -1: never enable
+    } else {
       disableDarkMode()
     }
   }
-  settings.listen('darkMode', themeSettingsChanged)
-  settings.listen('systemShouldUseDarkColors', function () {
-    // the settings API differs between the UI process and tabs
-    if (typeof process === 'undefined') {
-      settings.get('darkMode', themeSettingsChanged)
-    } else {
-      themeSettingsChanged(settings.get('darkMode'))
-    }
-  })
+  settings.listen('darkThemeIsActive', themeChanged)
 }
 
 if (typeof module !== 'undefined') {

--- a/main/main.js
+++ b/main/main.js
@@ -393,13 +393,3 @@ ipc.on('showSecondaryMenu', function (event, data) {
 ipc.on('quit', function () {
   app.quit()
 })
-
-app.on('ready', function() {
-  nativeTheme.on('updated', function () {
-    settings.set('systemShouldUseDarkColors', electron.nativeTheme.shouldUseDarkColors)
-  })
-
-  if (electron.nativeTheme.shouldUseDarkColors !== settings.get('systemShouldUseDarkColors')) {
-    settings.set('systemShouldUseDarkColors', electron.nativeTheme.shouldUseDarkColors)
-  }
-})

--- a/main/themeMain.js
+++ b/main/themeMain.js
@@ -1,0 +1,57 @@
+function isNightTime () {
+  var hours = new Date().getHours()
+  return (hours > 21 || hours < 6)
+}
+
+var themeInterval = null
+
+function themeSettingsChanged (value) {
+  /*
+        value is the value of the darkMode pref
+        0 - automatic dark mode
+        -1: never
+        0: at night
+        1: always
+        2: follow system (default)
+        true / false: legacy pref values, translate to always/system
+        */
+  clearInterval(themeInterval)
+
+  // 1 or true: dark mode is always enabled
+  if (value === 1 || value === true) {
+    nativeTheme.themeSource = 'dark'
+    return
+  }
+
+  // 2, undefined, or false: automatic dark mode following system
+  if (value === undefined || value === 2 || value === false) {
+    nativeTheme.themeSource = 'system'
+  } else if (value === 0) {
+    // 0: automatic dark mode at night
+    if (isNightTime()) {
+      nativeTheme.themeSource = 'dark'
+    } else {
+      nativeTheme.themeSource = 'light'
+    }
+
+    themeInterval = setInterval(function () {
+      if (isNightTime()) {
+        nativeTheme.themeSource = 'dark'
+      } else {
+        nativeTheme.themeSource = 'light'
+      }
+    }, 10000)
+  } else if (value === -1) {
+    // -1: never enable
+    nativeTheme.themeSource = 'light'
+  }
+}
+
+app.on('ready', function () {
+  settings.listen('darkMode', themeSettingsChanged)
+
+  nativeTheme.on('updated', function () {
+    console.log('updated')
+    settings.set('darkThemeIsActive', nativeTheme.shouldUseDarkColors)
+  })
+})

--- a/scripts/buildMain.js
+++ b/scripts/buildMain.js
@@ -19,7 +19,8 @@ const modules = [
   'main/remoteMenu.js',
   'main/remoteActions.js',
   'main/keychainService.js',
-  'js/util/proxy.js'
+  'js/util/proxy.js',
+  'main/themeMain.js'
 ]
 
 function buildMain () {


### PR DESCRIPTION
This PR update the theme settings to use Electron's [nativeTheme](https://www.electronjs.org/docs/latest/api/native-theme) module. This means that the theme settings in Min's preferences will also control whether webpages and context menus use a dark mode - previously, this was always determined by the OS global theme setting.