### PR TITLE
Support tab dragging on macOS

### DIFF
--- a/css/tabBar.css
+++ b/css/tabBar.css
@@ -111,7 +111,22 @@ body.linux #menu-button {
 }
 .tab-item.gu-mirror {
   top: var(--control-space-top) !important;
-  background: rgba(255, 255, 255, 0.8) !important;
+  background: rgba(255, 255, 255, 1) !important;
+  height: 32px !important;
+  line-height: 32px !important;
+  margin-top: 2px !important;
+  opacity: 0.9;
+  box-shadow: 0px 0px 5px rgba(0, 0, 0, 0.25);
+}
+.dark-mode .tab-item.gu-mirror {
+  background: rgb(84, 91, 100) !important;
+  color: white !important;
+}
+.tab-item.gu-transit {
+  opacity: 0 !important;
+}
+.tab-item.gu-mirror .tab-icon-area {
+  display: none;
 }
 
 #navbar.show-dividers .tab-item:not(:last-child) {

--- a/css/windowControls.css
+++ b/css/windowControls.css
@@ -15,8 +15,8 @@ body.linux:not(.maximized):not(.fullscreen):not(.separate-titlebar) {
 }
 
 /* On Windows, draggable regions aren't clickable, so the drag region is a separate area above the tabstrip */
-body.windows:not(.maximized):not(.fullscreen):not(.separate-titlebar) .window-drag-area,
-body.linux:not(.maximized):not(.fullscreen):not(.separate-titlebar) .window-drag-area {
+body.windows:not(.maximized):not(.fullscreen):not(.separate-titlebar):not(.disable-window-drag) .window-drag-area,
+body.linux:not(.maximized):not(.fullscreen):not(.separate-titlebar):not(.disable-window-drag) .window-drag-area {
   display: block;
   position: fixed;
   /* leave an empty space around the edges of the drag area so that the window can be resized */
@@ -28,7 +28,7 @@ body.linux:not(.maximized):not(.fullscreen):not(.separate-titlebar) .window-drag
 }
 
 /* On mac, the entire navbar is draggable, so the drag area is placed behind the navbar */
-body.mac:not(.separate-titlebar) .window-drag-area {
+body.mac:not(.separate-titlebar):not(.disable-window-drag) .window-drag-area {
   display: block;
   position: fixed;
   top: 0;

--- a/js/keybindings.js
+++ b/js/keybindings.js
@@ -90,19 +90,19 @@ function defineShortcut (keysOrKeyMapName, fn, options = {}) {
       combo: keys,
       keys: keys.split('+'),
       fn: shortcutCallback,
-      keyUp: options.keyUp
+      keyUp: options.keyUp || false
     })
-    if (!registeredMousetrapBindings[keys]) {
-      // mousetrap only allows one listener for each key combination
+    if (!registeredMousetrapBindings[keys + (options.keyUp ? '-keyup' : '')]) {
+      // mousetrap only allows one listener for each key combination (+keyup variant)
       // so register a single listener, and have it call all the other listeners that we have
       Mousetrap.bind(keys, function (e, combo) {
         shortcutsList.forEach(function (shortcut) {
-          if (shortcut.combo === combo) {
+          if (shortcut.combo === combo && (e.type === 'keyup') === shortcut.keyUp) {
             shortcut.fn(e, combo)
           }
         })
       }, (options.keyUp ? 'keyup' : null))
-      registeredMousetrapBindings[keys] = true
+      registeredMousetrapBindings[keys + (options.keyUp ? '-keyup' : '')] = true
     }
   })
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "dexie": "^3.0.3",
-    "dragula": "^3.7.3",
+    "dragula": "github:minbrowser/dragula",
     "electron-squirrel-startup": "^1.0.0",
     "expr-eval": "^2.0.2",
     "keytar": "7.6.0",


### PR DESCRIPTION
Implements the rest of https://github.com/minbrowser/min/issues/948#issuecomment-670179504. Normal dragging with the mouse moves the window (same as the current behavior). Dragging while holding the cmd key rearranges tabs.

The Dragula library has a hard-coded check that ignores drag events while cmd is pressed: https://github.com/bevacqua/dragula/blob/master/dragula.js#L98, so to make this work, I've forked the library and switched the dependency in Min to use the forked version instead.