### PR TITLE
Implement macOS handoff support

### DIFF
--- a/js/default.js
+++ b/js/default.js
@@ -153,6 +153,7 @@ require('pageTranslations.js').initialize()
 require('sessionRestore.js').initialize()
 require('bookmarkConverter.js').initialize()
 require('newTabPage.js').initialize()
+require('macHandoff.js').initialize()
 
 // default searchbar plugins
 

--- a/js/macHandoff.js
+++ b/js/macHandoff.js
@@ -1,0 +1,22 @@
+/* Handoff support for macOS */
+
+module.exports = {
+  initialize: function () {
+    tasks.on('tab-selected', function (id) {
+      if (tabs.get(id).private) {
+        ipc.send('handoffUpdate', { url: '' })
+      } else {
+        ipc.send('handoffUpdate', { url: tabs.get(id).url })
+      }
+    })
+    tasks.on('tab-updated', function (id, key) {
+      if (key === 'url' && tabs.getSelected() === id) {
+        if (tabs.get(id).private) {
+          ipc.send('handoffUpdate', { url: '' })
+        } else {
+          ipc.send('handoffUpdate', { url: tabs.get(id).url })
+        }
+      }
+    })
+  }
+}

--- a/main/main.js
+++ b/main/main.js
@@ -86,13 +86,17 @@ var saveWindowBounds = function () {
 }
 
 function sendIPCToWindow (window, action, data) {
-  // if there are no windows, create a new one
-  if (!mainWindow) {
-    createWindow(function () {
-      mainWindow.webContents.send(action, data || {})
+  if (window && window.webContents && window.webContents.isLoading()) {
+    window.webContents.once('did-finish-load', function () {
+      window.webContents.send(action, data || {})
     })
+  } else if (window) {
+    window.webContents.send(action, data || {})
   } else {
-    mainWindow.webContents.send(action, data || {})
+    var window = createWindow()
+    window.webContents.once('did-finish-load', function () {
+      window.webContents.send(action, data || {})
+    })
   }
 }
 
@@ -128,47 +132,39 @@ function handleCommandLineArguments (argv) {
   }
 }
 
-function createWindow (cb) {
-  fs.readFile(path.join(userDataPath, 'windowBounds.json'), 'utf-8', function (e, data) {
-    var bounds
+function createWindow () {
+  var bounds;
 
-    if (data) {
-      try {
-        bounds = JSON.parse(data)
-      } catch (e) {
-        console.warn('error parsing window bounds file: ', e)
-      }
-    }
-    if (e || !data || !bounds) { // there was an error, probably because the file doesn't exist
-      var size = electron.screen.getPrimaryDisplay().workAreaSize
-      bounds = {
-        x: 0,
-        y: 0,
-        width: size.width,
-        height: size.height,
-        maximized: true
-      }
-    }
+  try {
+    var data = fs.readFileSync(path.join(userDataPath, 'windowBounds.json'), 'utf-8')
+    bounds = JSON.parse(data)
+  } catch (e) {}
 
-    // make the bounds fit inside a currently-active screen
-    // (since the screen Min was previously open on could have been removed)
-    // see: https://github.com/minbrowser/min/issues/904
-    var containingRect = electron.screen.getDisplayMatching(bounds).workArea
-
+  if (!bounds) { // there was an error, probably because the file doesn't exist
+    var size = electron.screen.getPrimaryDisplay().workAreaSize
     bounds = {
-      x: clamp(bounds.x, containingRect.x, (containingRect.x + containingRect.width) - bounds.width),
-      y: clamp(bounds.y, containingRect.y, (containingRect.y + containingRect.height) - bounds.height),
-      width: clamp(bounds.width, 0, containingRect.width),
-      height: clamp(bounds.height, 0, containingRect.height),
-      maximized: bounds.maximized
+      x: 0,
+      y: 0,
+      width: size.width,
+      height: size.height,
+      maximized: true
     }
+  }
 
-    createWindowWithBounds(bounds)
+  // make the bounds fit inside a currently-active screen
+  // (since the screen Min was previously open on could have been removed)
+  // see: https://github.com/minbrowser/min/issues/904
+  var containingRect = electron.screen.getDisplayMatching(bounds).workArea
 
-    if (cb) {
-      cb()
-    }
-  })
+  bounds = {
+    x: clamp(bounds.x, containingRect.x, (containingRect.x + containingRect.width) - bounds.width),
+    y: clamp(bounds.y, containingRect.y, (containingRect.y + containingRect.height) - bounds.height),
+    width: clamp(bounds.width, 0, containingRect.width),
+    height: clamp(bounds.height, 0, containingRect.height),
+    maximized: bounds.maximized
+  }
+
+  return createWindowWithBounds(bounds)
 }
 
 function createWindowWithBounds (bounds) {
@@ -322,20 +318,20 @@ app.on('ready', function () {
     return
   }
 
-  createWindow(function () {
-    mainWindow.webContents.on('did-finish-load', function () {
-      // if a URL was passed as a command line argument (probably because Min is set as the default browser on Linux), open it.
-      handleCommandLineArguments(process.argv)
+  createWindow()
 
-      // there is a URL from an "open-url" event (on Mac)
-      if (global.URLToOpen) {
-        // if there is a previously set URL to open (probably from opening a link on macOS), open it
-        sendIPCToWindow(mainWindow, 'addTab', {
-          url: global.URLToOpen
-        })
-        global.URLToOpen = null
-      }
-    })
+  mainWindow.webContents.on('did-finish-load', function () {
+    // if a URL was passed as a command line argument (probably because Min is set as the default browser on Linux), open it.
+    handleCommandLineArguments(process.argv)
+
+    // there is a URL from an "open-url" event (on Mac)
+    if (global.URLToOpen) {
+      // if there is a previously set URL to open (probably from opening a link on macOS), open it
+      sendIPCToWindow(mainWindow, 'addTab', {
+        url: global.URLToOpen
+      })
+      global.URLToOpen = null
+    }
   })
 
   mainMenu = buildAppMenu()
@@ -350,6 +346,16 @@ app.on('open-url', function (e, url) {
     })
   } else {
     global.URLToOpen = url // this will be handled later in the createWindow callback
+  }
+})
+
+// handoff support for macOS
+app.on('continue-activity', function(e, type, userInfo, details) {
+  if (type === 'NSUserActivityTypeBrowsingWeb' && details.webpageURL) {
+    e.preventDefault()
+    sendIPCToWindow(mainWindow, 'addTab', {
+      url: details.webpageURL
+    })
   }
 })
 
@@ -388,6 +394,14 @@ ipc.on('showSecondaryMenu', function (event, data) {
     x: data.x,
     y: data.y
   })
+})
+
+ipc.on('handoffUpdate', function(e, data) {
+  if (data.url && data.url.startsWith('http')) {
+    app.setUserActivity('NSUserActivityTypeBrowsingWeb', {}, data.url)
+  } else {
+    app.invalidateCurrentActivity()
+  }
 })
 
 ipc.on('quit', function () {

--- a/scripts/createPackage.js
+++ b/scripts/createPackage.js
@@ -94,7 +94,8 @@ module.exports = function (platform, extraOptions) {
             CFBundleTypeRole: 'Viewer',
             LSItemContentTypes: ['public.xhtml']
           }
-        ]
+        ],
+        NSUserActivityTypes: ['NSUserActivityTypeBrowsingWeb'] // macOS handoff support
       }
     },
     directories: {


### PR DESCRIPTION
@flightmansam I implemented support for macOS handoff based on your suggestion in https://github.com/minbrowser/min/discussions/1988#discussioncomment-2741427 . The actual handoff implementation is really simple, since Electron has built-in APIs for it. I ran into some issues with the timing of receiving the handoff request while Min was being launched (if you tried to use handoff while Min wasn't already running), so I had to restructure some of the window-creation code to make it work.

If you have time, would you be willing to review this?