### PR TITLE
Updates to command-line arguments 

### DIFF
--- a/js/menuRenderer.js
+++ b/js/menuRenderer.js
@@ -10,6 +10,7 @@ var PDFViewer = require('pdfViewer.js')
 var tabEditor = require('navbar/tabEditor.js')
 var readerView = require('readerView.js')
 var taskOverlay = require('taskOverlay/taskOverlay.js')
+var { searchAndSortTasks, moveToTaskCommand } = require('searchbar/customBangs.js')
 
 module.exports = {
   initialize: function () {
@@ -94,6 +95,18 @@ module.exports = {
       browserUI.addTab(newTab, {
         enterEditMode: !data.url // only enter edit mode if the new tab is empty
       })
+
+      if (data.taskQuery) {
+      // use the first search result
+      // if there is no result, need to create a new task
+      let task = searchAndSortTasks(data.taskQuery, excludeSelected=false)[0]?.task
+      if (!task) {
+        task = tasks.get(tasks.add(undefined, tasks.getIndex(tasks.getSelected().id) + 1))
+        task.name = data.taskQuery
+      }
+
+      moveToTaskCommand(task.id)
+      }
     })
 
     ipc.on('saveCurrentPage', async function () {

--- a/js/menuRenderer.js
+++ b/js/menuRenderer.js
@@ -97,15 +97,55 @@ module.exports = {
       })
 
       if (data.taskQuery) {
-      // use the first search result
-      // if there is no result, need to create a new task
-      let task = searchAndSortTasks(data.taskQuery, excludeSelected=false)[0]?.task
-      if (!task) {
-        task = tasks.get(tasks.add(undefined, tasks.getIndex(tasks.getSelected().id) + 1))
-        task.name = data.taskQuery
+        // use the first search result
+        // if there is no result, need to create a new task
+        let task
+
+        if (/^\d+$/.test(data.taskQuery)) {
+          task = tasks.get(data.taskQuery)
+        } else {
+          task = searchAndSortTasks(data.taskQuery, excludeSelected=false)[0]?.task
+        }
+
+        if (!task) {
+          task = tasks.get(tasks.add(undefined, tasks.getIndex(tasks.getSelected().id) + 1))
+          task.name = data.taskQuery
+        }
+
+        moveToTaskCommand(task.id)
+      }
+      
+    })
+
+    ipc.on('switchToTask', function (e, data) {
+      /* new tabs can't be created in modal mode */
+      if (modalMode.enabled()) {
+        return
       }
 
-      moveToTaskCommand(task.id)
+      /* new tabs can't be created in focus mode */
+      if (focusMode.enabled()) {
+        focusMode.warn()
+        return
+      }
+
+      if (data.taskQuery) {
+        // use the first search result
+        // if there is no result, need to create a new task
+        let task
+
+        if (/^\d+$/.test(data.taskQuery)) {
+          task = tasks.get(data.taskQuery)
+        } else {
+          task = searchAndSortTasks(data.taskQuery, excludeSelected=false)[0]?.task
+        }
+
+        if (!task) {
+          task = tasks.get(tasks.add(undefined, tasks.getIndex(tasks.getSelected().id) + 1))
+          task.name = data.taskQuery
+        }
+
+        browserUI.switchToTask(task.id)
       }
     })
 

--- a/js/searchbar/customBangs.js
+++ b/js/searchbar/customBangs.js
@@ -67,14 +67,19 @@ function getTaskByNameOrNumber (text) {
 
 // return an array of tasks sorted by last activity
 // if a search string is present, filter the results with a basic fuzzy search
-function searchAndSortTasks (text) {
-  let taskResults = tasks
-    .filter(t => t.id !== tasks.getSelected().id)
-    .map(t => Object.assign({}, { task: t }, { lastActivity: tasks.getLastActivity(t.id) }))
+function searchAndSortTasks (text, excludeSelected=true) {
 
-  taskResults = taskResults.sort(function (a, b) {
-    return b.lastActivity - a.lastActivity
-  })
+  let taskResults = tasks
+  
+  if (excludeSelected === true){
+    taskResults = tasks.filter(t => t.id !== tasks.getSelected().id)
+  }
+
+  taskResults = taskResults
+    .map(t => Object.assign({}, { task: t }, { lastActivity: tasks.getLastActivity(t.id) }))
+    .sort(function (a, b) {
+      return b.lastActivity - a.lastActivity
+    })
 
   if (text !== '') {
     // fuzzy search
@@ -89,7 +94,6 @@ function searchAndSortTasks (text) {
       return (exactMatch || fuzzyTitleScore > 0.4)
     })
   }
-
   return taskResults
 }
 
@@ -364,4 +368,4 @@ function initialize () {
   })
 }
 
-module.exports = { initialize }
+module.exports = { initialize, searchAndSortTasks, moveToTaskCommand  }

--- a/main/main.js
+++ b/main/main.js
@@ -69,7 +69,7 @@ var secondaryMenu = null
 var isFocusMode = false
 var appIsReady = false
 
-const isFirstInstance = app.requestSingleInstanceLock()
+const isFirstInstance = app.requestSingleInstanceLock(process.argv)
 
 if (!isFirstInstance) {
   app.quit()
@@ -104,23 +104,34 @@ function openTabInWindow (url) {
 
 function handleCommandLineArguments (argv) {
   // the "ready" event must occur before this function can be used
+  var initTaskQuery = undefined
   if (argv) {
+
+    // check for -t task query
+    if (argv.includes('-t') && argv.indexOf('-t') > 0){
+      // query for specific task to add search to
+      initTaskQuery = argv[argv.indexOf('-t') + 1]
+    } 
+
     argv.forEach(function (arg, idx) {
       if (arg && arg.toLowerCase() !== __dirname.toLowerCase()) {
-        // URL
         if (arg.indexOf('://') !== -1) {
+          // URL
           sendIPCToWindow(mainWindow, 'addTab', {
-            url: arg
+            url: arg,
+            taskQuery: initTaskQuery
           })
         } else if (idx > 0 && argv[idx - 1] === '-s') {
           // search
           sendIPCToWindow(mainWindow, 'addTab', {
-            url: arg
+            url: arg,
+            taskQuery: initTaskQuery
           })
         } else if (/\.(m?ht(ml)?|pdf)$/.test(arg) && fs.existsSync(arg)) {
           // local files (.html, .mht, mhtml, .pdf)
           sendIPCToWindow(mainWindow, 'addTab', {
-            url: 'file://' + path.resolve(arg)
+            url: 'file://' + path.resolve(arg),
+            taskQuery: initTaskQuery
           })
         }
       }
@@ -353,14 +364,14 @@ app.on('open-url', function (e, url) {
   }
 })
 
-app.on('second-instance', function (e, argv, workingDir) {
+app.on('second-instance', function (e, argv, workingDir, additionalData) {
   if (mainWindow) {
     if (mainWindow.isMinimized()) {
       mainWindow.restore()
     }
     mainWindow.focus()
     // add a tab with the new URL
-    handleCommandLineArguments(argv)
+    handleCommandLineArguments(additionalData)
   }
 })
 

--- a/main/main.js
+++ b/main/main.js
@@ -133,6 +133,10 @@ function handleCommandLineArguments (argv) {
             url: 'file://' + path.resolve(arg),
             taskQuery: initTaskQuery
           })
+        } else if (initTaskQuery) {
+          sendIPCToWindow(mainWindow, 'switchToTask', {
+            taskQuery: initTaskQuery
+          })
         }
       }
     })


### PR DESCRIPTION
 Discussed in https://github.com/minbrowser/min/discussions/2008.

I would like to add a `-t` argument to request specific tasks from the command-line. This may be an opportunity to look at the code structure of how min handles command-line arguments to avoid confusion, inadvertent bugs, and easier extension later on. One opportunity could be to use a specific library like [commander.js](https://github.com/tj/commander.js).

This branch has some uglies at the moment due to my agile desire to just have the feature I want:
- I use the searchAndSortTasks and moveToTaskCommand from customBangs.js, so this should be separated out (probably to task.js @PalmerAL?)
- BrowserUI ipc 'switchToTask' and BrowserUI.addTab() share commonality so it should be separated out?
- Currently the -t argument tries to handle both a task name or a task id by doing an "is all digits?" comparison. Probably should eliminate this ambiguity by having a switch for a task id (maybe --task-id)
- Would like to have a command line way of switching to a particular tab (maybe -tab, and changing -t to be -task).