### PR TITLE
v8-compile-cache for (slightly) faster load times

### DIFF
--- a/js/default.js
+++ b/js/default.js
@@ -1,3 +1,5 @@
+require("v8-compile-cache");
+
 window.globalArgs = {}
 
 process.argv.forEach(function (arg) {

--- a/main/main.js
+++ b/main/main.js
@@ -1,3 +1,5 @@
+require("v8-compile-cache");
+
 const electron = require('electron')
 const fs = require('fs')
 const path = require('path')

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "pdfjs-dist": "2.12.313",
     "regedit": "^3.0.3",
     "stemmer": "^1.0.5",
-    "string_score": "^0.1.22"
+    "string_score": "^0.1.22",
+    "v8-compile-cache": "^2.3.0"
   },
   "devDependencies": {
     "archiver": "^4.0.1",


### PR DESCRIPTION
This pull requests introduces [`v8-compile-cache`](https://github.com/zertosh/v8-compile-cache), a small library that speed up instantiation time using V8's code cache system.
At the moment, `v8-compile-cache` is integrated in `js/default.js` and `main/main.js`.
If needed, `require('v8-compile-cache);` can be used in other modules if they need a (little) speed up.