### PR TITLE
Fixed `SharedArrayBuffer` issue

### DIFF
--- a/main/main.js
+++ b/main/main.js
@@ -15,6 +15,8 @@ const {
   nativeTheme
 } = electron
 
+
+app.commandLine.appendSwitch('enable-features','SharedArrayBuffer'); // Required for using SharedArrayBuffer inside the browser
 crashReporter.start({
   submitURL: 'https://minbrowser.org/',
   uploadToServer: false,


### PR DESCRIPTION
Fixed issue #1995

`SharedArrayBuffer` wasn't implemented in the Min browser, so some sites (like Google Earth) couldn't be used by the Min browser.
