### PR TITLE
Readme link fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ If you have questions about using Min, need help getting started with developmen
 
 #### Adding a new language
 
-- Find the language code that goes with your language from [this list](https://electron.atom.io/docs/api/locales/#locales).
+- Find the language code that goes with your language from [this list](https://source.chromium.org/chromium/chromium/src/+/main:ui/base/l10n/l10n_util.cc;l=55).
 - In the `localization/languages` directory, create a new file, and name it "[your language code].json".
 - Open your new file, and copy the contents of the <a href="https://github.com/minbrowser/min/blob/master/localization/languages/en-US.json">localization/languages/en-US.json</a> file into your new file.
 - Change the "identifier" field in the new file to the language code from step 1.

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ If you have questions about using Min, need help getting started with developmen
 
 #### Adding a new language
 
-- Find the language code that goes with your language from [this list](https://source.chromium.org/chromium/chromium/src/+/main:ui/base/l10n/l10n_util.cc;l=55).
+- Find the language code that goes with your language from [this list](https://source.chromium.org/chromium/chromium/src/+/main:ui/base/l10n/l10n_util.cc;l=55) (line 55 - 230).
 - In the `localization/languages` directory, create a new file, and name it "[your language code].json".
 - Open your new file, and copy the contents of the <a href="https://github.com/minbrowser/min/blob/master/localization/languages/en-US.json">localization/languages/en-US.json</a> file into your new file.
 - Change the "identifier" field in the new file to the language code from step 1.


### PR DESCRIPTION
Closes issue #2040 by replacing the broken link in README.md line 94 with [this](https://source.chromium.org/chromium/chromium/src/+/main:ui/base/l10n/l10n_util.cc;l=55) list. (And info about which lines are relevant)

This is my first ever PR to open source, so please tell me if I missed something! :+1: 