### PR TITLE
fix: change libsecret-1-dev to libsecret-1-0 for build debian

### DIFF
--- a/scripts/buildDebian.js
+++ b/scripts/buildDebian.js
@@ -30,7 +30,7 @@ require('./createPackage.js')('linux', { arch: toArch(platform) }).then(function
     description: 'Min is a fast, minimal browser that protects your privacy.',
     synopsis: 'A web browser with smarter search, improved tab management, and built-in ad blocking. Includes full-text history search, instant answers from DuckDuckGo, the ability to split tabs into groups, and more.',
     depends: [
-      'libsecret-1-dev',
+      'libsecret-1-0',
       'gconf2',
       'gconf-service',
       'libasound2',


### PR DESCRIPTION
While trying to install the browser on Debian based distributions like Ubuntu and Zorin OS, I came across the dependency error stating that the libsecret-1-dev package was not found.

In other projects I participate in, by default we don't send dev packages to build in production.

This PR fixes the catch below.

![min-browser-install-error](https://user-images.githubusercontent.com/14093492/186020869-b842af1e-f765-4914-a5b9-7e4e6c0f2dec.png)

Congratulations on the project, it is very useful.
