### PR TITLE
Enable Gatekeeper support on macOS

### DIFF
--- a/scripts/createPackage.js
+++ b/scripts/createPackage.js
@@ -95,7 +95,9 @@ module.exports = function (platform, extraOptions) {
             LSItemContentTypes: ['public.xhtml']
           }
         ],
-        NSUserActivityTypes: ['NSUserActivityTypeBrowsingWeb'] // macOS handoff support
+        NSUserActivityTypes: ['NSUserActivityTypeBrowsingWeb'], // macOS handoff support
+        LSFileQuarantineEnabled: true // https://github.com/minbrowser/min/issues/2073
+        // need to revisit if implementing autoupdate, see https://github.com/brave/browser-laptop/issues/13817
       }
     },
     directories: {


### PR DESCRIPTION
Fixes #2073

@Harsith-Panda can you confirm this works?

After checking out the branch, you'll need to build a package with `npm run buildMac[Intel/Arm]`