### PR TITLE
Fix scrolling using spacebar in reader mode

### DIFF
--- a/reader/reader.js
+++ b/reader/reader.js
@@ -259,7 +259,7 @@ function startReaderView (article, date) {
     requestAnimationFrame(function () {
       setReaderFrameSize()
       requestAnimationFrame(function () {
-        rframe.focus() // allows spacebar page down and arrow keys to work correctly
+        //rframe.focus() // allows spacebar page down and arrow keys to work correctly
       })
     })
 


### PR DESCRIPTION
I think I've successfully fixed the [issue](https://github.com/minbrowser/min/issues/2103) where scrolling with space in reader mode didn't work.