### PR TITLE
Fix Spanish translation for `email`

### DIFF
--- a/localization/languages/es.json
+++ b/localization/languages/es.json
@@ -287,7 +287,7 @@
     "dialogConfirmButton": "Confirmar",
     "dialogSkipButton": "Cancelar",
     "username": "Nombre de usuario",
-    "email": "Direccion de correo",
+    "email": "Dirección de correo",
     "password": "Contraseña",
     "secretKey": "Clave secreta",
     "openExternalApp": "Abrir en \\\"%s\\\"?", // %s is the name of an app


### PR DESCRIPTION
Fix the Spanish translation for `email`.