### PR TITLE
remove dangerous pacman -Sy command for arch linux install

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You can find prebuilt binaries for Min [here](https://github.com/minbrowser/min/
 
 - To install the .deb file, use `sudo dpkg -i /path/to/download`
 - To install the RPM build, use `sudo rpm -i /path/to/download --ignoreos`
-- On Arch Linux it's in the community repository, use `sudo pacman -Sy min`
+- On Arch Linux it's in the community repository, use `sudo pacman -S min`
 - On Raspberry Pi, you can install Min from [Pi-Apps](https://github.com/Botspot/pi-apps).
 
 ## Developing


### PR DESCRIPTION
Using `pacman -Sy <package>` in Arch Linux distributions is dangerous as it can lead to dependency mismatches and a "partial upgrade".   
using `pacman -S <package>` is the correct process, or if you want to update to the latest versions, using the full upgrade command, `pacman -Syu <package>` will update all packages and install the latest version of your package    
https://wiki.archlinux.org/title/System_maintenance#Partial_upgrades_are_unsupported