### PR TITLE
Fixed ctrl+wheel zooming in reader mode

### DIFF
--- a/reader/reader.js
+++ b/reader/reader.js
@@ -265,7 +265,31 @@ function startReaderView (article, date) {
 
     window.addEventListener('resize', setReaderFrameSize)
   }
-  document.body.appendChild(rframe)
+
+  const overlayForZooming = document.createElement('div')
+  overlayForZooming.id = 'overlay'
+
+  rframe.addEventListener('load', function () {
+    rframe.contentWindow.document.addEventListener('keydown', function (e) {
+      if (e.getModifierState('Control')) {
+        overlayForZooming.style.pointerEvents = 'auto'
+      }
+    })
+
+    rframe.contentWindow.document.addEventListener('keyup', function (e) {
+      if (e.key === 'Control') {
+        overlayForZooming.style.pointerEvents = 'none'
+      }
+    })
+  })
+
+  const container = document.createElement('div')
+  container.id = 'container'
+
+  container.appendChild(overlayForZooming)
+  container.appendChild(rframe)
+
+  document.body.appendChild(container)
 }
 
 function processArticle (data) {

--- a/reader/readerUI.css
+++ b/reader/readerUI.css
@@ -219,3 +219,19 @@ body:not([theme="light"]) #site-nav-links a {
 body:not([theme="light"]) #site-nav-links a.selected {
   opacity: 0.75;
 }
+
+#container {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+#overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 1;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}


### PR DESCRIPTION
A fix for : ['Reader View' zoom in / out via ctrl + mouse wheel or ctrl++ / ctrl+- not working](https://github.com/minbrowser/min/issues/2149). Though addresses only ctrl + mouse wheel zooming.

How it looks like in practice 

### Caveat
Not sure how this will behave in MacOS which uses the Cmd key instead of Ctrl. Do MacOS browsers make the substitution automatically or this case needs to be handled in code as well?

I could use e.metaKey but it will display true if the windows key is pressed.


https://user-images.githubusercontent.com/70408318/219492984-132f39e2-bb1e-4818-944a-18b070abe4ee.mp4

