### PR TITLE
Fix/tab item alignment

### DIFF
--- a/css/tabBar.css
+++ b/css/tabBar.css
@@ -50,7 +50,8 @@ body.is-edit-mode #toolbar-navigation-buttons {
   display: none;
 }
 
-#back-button, #forward-button {
+#back-button,
+#forward-button {
   opacity: 1;
   transition: none;
   padding: 0 0.6rem;
@@ -61,7 +62,8 @@ body.is-edit-mode #toolbar-navigation-buttons {
 #forward-button {
   margin-left: -0.75em;
 }
-#back-button:disabled, #forward-button:disabled {
+#back-button:disabled,
+#forward-button:disabled {
   opacity: 0.2;
 }
 
@@ -108,6 +110,10 @@ body.linux #menu-button {
   word-break: break-all;
   position: relative;
   padding: 0 0.8em;
+  display: flex;
+  justify-content: space-between;
+  align-items: stretch;
+  gap: 0.25rem;
 }
 .tab-item.gu-mirror {
   top: var(--control-space-top) !important;
@@ -153,14 +159,19 @@ body.linux #menu-button {
 /* icons */
 
 .tab-item .tab-icon-area {
-  float: right;
   margin-right: -0.7em;
+  display: flex;
+  align-items: center;
 }
 .tab-item .tab-icon {
   position: relative;
   font-size: 0.875em;
   padding: 0.7125em 0.5em;
-  box-sizing: content-box;
+  box-sizing: border-box;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
 }
 .tab-item .tab-icon:not(.permission-request-icon):hover:after {
   content: "";
@@ -169,8 +180,6 @@ body.linux #menu-button {
   border-radius: 50%;
   background: rgba(0, 0, 0, 0.075);
   position: absolute;
-  top: -3px;
-  left: -3px;
   z-index: -1;
 }
 .dark-theme .tab-item .tab-icon:hover:after {
@@ -209,6 +218,7 @@ body.linux #menu-button {
 }
 .tab-item .title {
   font-size: 15px;
+  order: -1;
 }
 
 /* buttons */
@@ -257,10 +267,10 @@ body.windows.dark-theme .navbar-action-button:not(:disabled):hover {
   font-size: 1.1em !important;
 }
 .tab-item.active .reader-button.can-reader {
-  display: inline-block;
+  display: inline-flex;
 }
 .tab-item.active .reader-button.is-reader {
-  display: inline-block;
+  display: inline-flex;
 }
 
 /* permission request buttons */
@@ -306,11 +316,9 @@ body.windows.dark-theme .navbar-action-button:not(:disabled):hover {
 .tab-item .tab-close-button {
   font-size: 1.25em;
   padding: 0.3em 0.45em;
-  margin-top: 0.15em;
+  box-sizing: border-box;
 }
 .tab-item .tab-close-button:hover:after {
-  top: 4px !important;
-  left: 7px !important;
   font-size: 0.9em;
 }
 
@@ -338,7 +346,7 @@ body.is-focus-mode .navbar-action-button:not(#menu-button) {
   position: absolute;
   top: 0;
   left: 0;
-  margin: 0 0.8em;
+  /* margin: 0 0.8em; */
   overflow: hidden;
 }
 

--- a/css/tabBar.css
+++ b/css/tabBar.css
@@ -278,14 +278,12 @@ body.windows.dark-theme .navbar-action-button:not(:disabled):hover {
 .tab-item .tab-icon.permission-request-icon {
   border: 1px rgba(0, 0, 0, 0.3) solid;
   padding: 0.15em 0.17em;
-  margin-right: 0.66em;
-  margin-top: -0.2em;
-  margin-left: -0.3em;
   border-radius: 0.75em;
+  height: 80%;
+  margin: auto 0;
 }
 .tab-item .tab-icon.permission-request-icon .i {
   vertical-align: middle;
-  margin-top: -3px;
   display: inline-block;
 }
 .dark-theme .tab-item .tab-icon.permission-request-icon {

--- a/css/tabBar.css
+++ b/css/tabBar.css
@@ -112,6 +112,9 @@ body.linux #menu-button {
   display: flex;
   justify-content: space-between;
   align-items: stretch;
+  gap: 0.5rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
 }
 .tab-item.gu-mirror {
   top: var(--control-space-top) !important;
@@ -164,7 +167,6 @@ body.linux #menu-button {
 .tab-item .tab-icon {
   position: relative;
   font-size: 0.875em;
-  padding: 0 0.5rem;
   box-sizing: border-box;
   display: flex;
   justify-content: center;
@@ -219,8 +221,8 @@ body.linux #menu-button {
 }
 .tab-item .title {
   font-size: 15px;
-  margin-left: 0.5rem;
-  margin-right: auto;
+  padding-left: 0.25rem;
+  padding-right: 0.25rem;
 }
 
 /* buttons */
@@ -256,7 +258,7 @@ body.windows.dark-theme .navbar-action-button:not(:disabled):hover {
 /* audio button */
 .tab-item .tab-audio-button {
   vertical-align: text-bottom;
-  padding: 0 0.5em;
+  padding: 0;
   font-size: 1.1em !important;
 }
 
@@ -282,7 +284,7 @@ body.windows.dark-theme .navbar-action-button:not(:disabled):hover {
   border-radius: 50%;
   height: 70%;
   aspect-ratio: 1 / 1;
-  margin: auto 0.5rem;
+  margin: auto 0;
   order: -1;
 }
 .tab-item .tab-icon.permission-request-icon .i {

--- a/css/tabBar.css
+++ b/css/tabBar.css
@@ -161,6 +161,7 @@ body.linux #menu-button {
 .tab-item .tab-icon-area {
   display: flex;
   align-items: center;
+  gap: 0.5rem;
   order: 1;
 }
 .tab-item .tab-icon {

--- a/css/tabBar.css
+++ b/css/tabBar.css
@@ -263,7 +263,7 @@ body.windows.dark-theme .navbar-action-button:not(:disabled):hover {
 .tab-item .reader-button {
   display: none;
   vertical-align: text-bottom;
-  padding: 0 0.5em 0 0;
+  padding: 0 0.45em;
   font-size: 1.1em !important;
 }
 .tab-item.active .reader-button.can-reader {

--- a/css/tabBar.css
+++ b/css/tabBar.css
@@ -264,6 +264,7 @@ body.windows.dark-theme .navbar-action-button:not(:disabled):hover {
   display: none;
   vertical-align: text-bottom;
   padding: 0 0.45em;
+  margin-left: -0.7em;
   font-size: 1.1em !important;
   order: -1;
 }

--- a/css/tabBar.css
+++ b/css/tabBar.css
@@ -60,7 +60,6 @@ body.is-edit-mode #toolbar-navigation-buttons {
   padding-left: 0.4rem;
 }
 #forward-button {
-  margin-left: -0.75em;
 }
 #back-button:disabled,
 #forward-button:disabled {
@@ -109,11 +108,9 @@ body.linux #menu-button {
   overflow: hidden;
   word-break: break-all;
   position: relative;
-  padding: 0 0.8em;
   display: flex;
   justify-content: space-between;
   align-items: stretch;
-  gap: 0.25rem;
 }
 .tab-item.gu-mirror {
   top: var(--control-space-top) !important;
@@ -159,7 +156,6 @@ body.linux #menu-button {
 /* icons */
 
 .tab-item .tab-icon-area {
-  margin-right: -0.7em;
   display: flex;
   align-items: center;
   order: 1;
@@ -167,7 +163,7 @@ body.linux #menu-button {
 .tab-item .tab-icon {
   position: relative;
   font-size: 0.875em;
-  padding: 0.7125em 0.5em;
+  padding: 0 0.5rem;
   box-sizing: border-box;
   display: flex;
   justify-content: center;
@@ -219,6 +215,8 @@ body.linux #menu-button {
 }
 .tab-item .title {
   font-size: 15px;
+  margin-left: 0.5rem;
+  margin-right: auto;
 }
 
 /* buttons */
@@ -254,7 +252,7 @@ body.windows.dark-theme .navbar-action-button:not(:disabled):hover {
 /* audio button */
 .tab-item .tab-audio-button {
   vertical-align: text-bottom;
-  padding: 0 0.5em 0 0;
+  padding: 0 0.5em;
   font-size: 1.1em !important;
 }
 
@@ -263,8 +261,6 @@ body.windows.dark-theme .navbar-action-button:not(:disabled):hover {
 .tab-item .reader-button {
   display: none;
   vertical-align: text-bottom;
-  padding: 0 0.45em;
-  margin-left: -0.7em;
   font-size: 1.1em !important;
   order: -1;
 }
@@ -279,10 +275,10 @@ body.windows.dark-theme .navbar-action-button:not(:disabled):hover {
 
 .tab-item .tab-icon.permission-request-icon {
   border: 1px rgba(0, 0, 0, 0.3) solid;
-  padding: 0.15em 0.17em;
-  border-radius: 0.75em;
-  height: 80%;
-  margin: auto 0;
+  border-radius: 50%;
+  height: 70%;
+  aspect-ratio: 1 / 1;
+  margin: auto 0.5rem;
   order: -1;
 }
 .tab-item .tab-icon.permission-request-icon .i {
@@ -316,7 +312,6 @@ body.windows.dark-theme .navbar-action-button:not(:disabled):hover {
 /* in Carbon, close icon is a bit smaller than other icons, enlarge it in order to match with other icons */
 .tab-item .tab-close-button {
   font-size: 1.25em;
-  padding: 0.3em 0.45em;
   box-sizing: border-box;
 }
 .tab-item .tab-close-button:hover:after {

--- a/css/tabBar.css
+++ b/css/tabBar.css
@@ -281,11 +281,11 @@ body.windows.dark-theme .navbar-action-button:not(:disabled):hover {
 
 .tab-item .tab-icon.permission-request-icon {
   border: 1px rgba(0, 0, 0, 0.3) solid;
-  border-radius: 50%;
+  border-radius: 0.75rem;
   height: 70%;
-  aspect-ratio: 1 / 1;
   margin: auto 0;
   order: -1;
+  padding-inline: 0.25rem;
 }
 .tab-item .tab-icon.permission-request-icon .i {
   vertical-align: middle;

--- a/css/tabBar.css
+++ b/css/tabBar.css
@@ -164,7 +164,9 @@ body.linux #menu-button {
   gap: 0.5rem;
   order: 1;
 }
-.tab-item:not(:hover) .tab-icon-area:has(.tab-close-button:only-child) {
+body:not(.touch)
+  .tab-item:not(:hover)
+  .tab-icon-area:has(.tab-close-button:only-child) {
   margin-left: -0.5rem;
 }
 

--- a/css/tabBar.css
+++ b/css/tabBar.css
@@ -164,9 +164,10 @@ body.linux #menu-button {
   gap: 0.5rem;
   order: 1;
 }
-.tab-item .tab-icon-area:has(i:only-child) {
+.tab-item:not(:hover) .tab-icon-area:has(.tab-close-button:only-child) {
   margin-left: -0.5rem;
 }
+
 .tab-item .tab-icon {
   position: relative;
   font-size: 0.875em;

--- a/css/tabBar.css
+++ b/css/tabBar.css
@@ -36,14 +36,14 @@
 /* navbar buttons */
 
 #toolbar-navigation-buttons {
-  width: 2.375rem;
+  width: 2rem;
   transition: 0.1s width;
   white-space: nowrap;
   overflow: hidden;
 }
 
 #toolbar-navigation-buttons.can-go-forward:hover {
-  width: max-content;
+  width: 4rem;
 }
 
 body.is-edit-mode #toolbar-navigation-buttons {
@@ -55,12 +55,7 @@ body.is-edit-mode #toolbar-navigation-buttons {
   opacity: 1;
   transition: none;
   padding: 0;
-}
-#back-button {
-  padding-left: 0.5rem;
-}
-#forward-button {
-  padding-right: 0.5rem;
+  width: 2rem;
 }
 #back-button:disabled,
 #forward-button:disabled {

--- a/css/tabBar.css
+++ b/css/tabBar.css
@@ -62,6 +62,11 @@ body.is-edit-mode #toolbar-navigation-buttons {
   opacity: 0.2;
 }
 
+/* Remove default space from being inline-block */
+#forward-button {
+  margin-left: -0.25rem;
+}
+
 #menu-button {
   width: 36px;
   padding: 0;

--- a/css/tabBar.css
+++ b/css/tabBar.css
@@ -162,6 +162,7 @@ body.linux #menu-button {
   margin-right: -0.7em;
   display: flex;
   align-items: center;
+  order: 1;
 }
 .tab-item .tab-icon {
   position: relative;
@@ -218,7 +219,6 @@ body.linux #menu-button {
 }
 .tab-item .title {
   font-size: 15px;
-  order: -1;
 }
 
 /* buttons */
@@ -265,6 +265,7 @@ body.windows.dark-theme .navbar-action-button:not(:disabled):hover {
   vertical-align: text-bottom;
   padding: 0 0.45em;
   font-size: 1.1em !important;
+  order: -1;
 }
 .tab-item.active .reader-button.can-reader {
   display: inline-flex;
@@ -281,6 +282,7 @@ body.windows.dark-theme .navbar-action-button:not(:disabled):hover {
   border-radius: 0.75em;
   height: 80%;
   margin: auto 0;
+  order: -1;
 }
 .tab-item .tab-icon.permission-request-icon .i {
   vertical-align: middle;

--- a/css/tabBar.css
+++ b/css/tabBar.css
@@ -177,6 +177,9 @@ body.linux #menu-button {
   border-radius: 50%;
   background: rgba(0, 0, 0, 0.075);
   position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   z-index: -1;
 }
 .dark-theme .tab-item .tab-icon:hover:after {

--- a/css/tabBar.css
+++ b/css/tabBar.css
@@ -110,7 +110,6 @@ body.linux #menu-button {
   word-break: break-all;
   position: relative;
   display: flex;
-  justify-content: space-between;
   align-items: stretch;
   gap: 0.5rem;
   padding-left: 0.5rem;
@@ -223,6 +222,7 @@ body.linux #menu-button {
   font-size: 15px;
   padding-left: 0.25rem;
   padding-right: 0.25rem;
+  margin-right: auto;
 }
 
 /* buttons */

--- a/css/tabBar.css
+++ b/css/tabBar.css
@@ -164,6 +164,9 @@ body.linux #menu-button {
   gap: 0.5rem;
   order: 1;
 }
+.tab-item .tab-icon-area:has(i:only-child) {
+  margin-left: -0.5rem;
+}
 .tab-item .tab-icon {
   position: relative;
   font-size: 0.875em;

--- a/css/tabBar.css
+++ b/css/tabBar.css
@@ -324,6 +324,7 @@ body.windows.dark-theme .navbar-action-button:not(:disabled):hover {
 .tab-item .tab-close-button {
   font-size: 1.25em;
   box-sizing: border-box;
+  order: 1;
 }
 .tab-item .tab-close-button:hover:after {
   font-size: 0.9em;

--- a/css/tabBar.css
+++ b/css/tabBar.css
@@ -43,7 +43,7 @@
 }
 
 #toolbar-navigation-buttons.can-go-forward:hover {
-  width: 4.25rem;
+  width: max-content;
 }
 
 body.is-edit-mode #toolbar-navigation-buttons {
@@ -54,12 +54,13 @@ body.is-edit-mode #toolbar-navigation-buttons {
 #forward-button {
   opacity: 1;
   transition: none;
-  padding: 0 0.6rem;
+  padding: 0;
 }
 #back-button {
-  padding-left: 0.4rem;
+  padding-left: 0.5rem;
 }
 #forward-button {
+  padding-right: 0.5rem;
 }
 #back-button:disabled,
 #forward-button:disabled {

--- a/js/navbar/tabBar.js
+++ b/js/navbar/tabBar.js
@@ -65,11 +65,6 @@ const tabBar = {
       iconArea.appendChild(pbIcon)
     }
 
-    var secIcon = document.createElement('i')
-    secIcon.className = 'icon-tab-not-secure tab-icon tab-info-icon i carbon:unlocked'
-    secIcon.title = l('connectionNotSecure')
-    iconArea.appendChild(secIcon)
-
     var closeTabButton = document.createElement('button')
     closeTabButton.className = 'tab-icon tab-close-button i carbon:close'
 
@@ -166,11 +161,16 @@ const tabBar = {
       tabEl.insertBefore(button, tabEl.children[0])
     })
 
-    var secIcon = tabEl.getElementsByClassName('icon-tab-not-secure')[0]
-    if (tabData.secure === false) {
-      secIcon.hidden = false
-    } else {
-      secIcon.hidden = true
+    var iconArea = tabEl.getElementsByClassName('tab-icon-area')[0]
+
+    var insecureIcon = tabEl.getElementsByClassName('icon-tab-not-secure')[0]
+    if (tabData.secure === true && insecureIcon) {
+      insecureIcon.remove()
+    } else if (tabData.secure === false && !insecureIcon) {
+      var insecureIcon = document.createElement('i')
+      insecureIcon.className = 'icon-tab-not-secure tab-icon tab-info-icon i carbon:unlocked'
+      insecureIcon.title = l('connectionNotSecure')
+      iconArea.appendChild(insecureIcon)
     }
   },
   updateAll: function () {


### PR DESCRIPTION
# Description

Improves the item alignment in a tab.

Changes made:

- Vertical align items in a tab, introduced `display: flex`
- Fix misplaced hover state on buttons
- Fix permission buttons spacing
- Buttons now have a consistent height / width

|Before|
|:-:|
|![_home_ruben_Development_forks_min_index html](https://user-images.githubusercontent.com/31519867/233373804-3ccf34fa-fff4-4d1d-ad27-b38d644e6765.png)|
|After|
|![_home_ruben_Development_forks_min_index html](https://user-images.githubusercontent.com/31519867/233373462-3a4805b6-c30d-4b86-beac-cacd5a417bbd.png)

*I forced some active states to show the icons.*