### PR TITLE
Modify Mac draggable region for Electron 24

### DIFF
--- a/css/windowControls.css
+++ b/css/windowControls.css
@@ -27,18 +27,19 @@ body.linux:not(.maximized):not(.fullscreen):not(.separate-titlebar):not(.disable
   -webkit-app-region: drag;
 }
 
-body.mac:not(.separate-titlebar) .window-drag-area {
+body.mac:not(.separate-titlebar):not(.fullscreen) .window-drag-area {
   display: block;
   position: fixed;
   top: 0;
   left: 0;
   width: 100%;
-  height: 8px;
+  height: 7px;
   -webkit-app-region: drag;
 }
 
 body.mac:not(.is-edit-mode):not(.fullscreen):not(.separate-titlebar) #mac-window-drag-area {
-  width: 1.5em;
+  margin-left: calc(var(--control-space-left) * -1);
+  width: calc(var(--control-space-left) + 1.25em);
   height: 100%;
   -webkit-app-region: drag;
 }

--- a/css/windowControls.css
+++ b/css/windowControls.css
@@ -27,14 +27,19 @@ body.linux:not(.maximized):not(.fullscreen):not(.separate-titlebar):not(.disable
   -webkit-app-region: drag;
 }
 
-/* On mac, the entire navbar is draggable, so the drag area is placed behind the navbar */
-body.mac:not(.separate-titlebar):not(.disable-window-drag) .window-drag-area {
+body.mac:not(.separate-titlebar) .window-drag-area {
   display: block;
   position: fixed;
   top: 0;
   left: 0;
   width: 100%;
-  height: 32px;
+  height: 8px;
+  -webkit-app-region: drag;
+}
+
+body.mac:not(.is-edit-mode):not(.fullscreen):not(.separate-titlebar) #mac-window-drag-area {
+  width: 1.5em;
+  height: 100%;
   -webkit-app-region: drag;
 }
 

--- a/index.html
+++ b/index.html
@@ -113,6 +113,7 @@
       class="theme-background-color theme-text-color windowDragHandle"
       tabindex="-1"
     >
+    <div id="mac-window-drag-area"></div>
       <button
         id="menu-button"
         class="navbar-action-button i carbon:overflow-menu-vertical"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "PalmerAL",
   "version": "1.27.0",
   "description": "A fast, minimal browser that protects your privacy",
-  "electronVersion": "22.0.0",
+  "electronVersion": "24.4.0",
   "main": "main.build.js",
   "standard": {
     "globals": [
@@ -46,7 +46,7 @@
     "chokidar": "^3.4.0",
     "concurrently": "^5.2.0",
     "decomment": "^0.9.0",
-    "electron": "22.0.0",
+    "electron": "24.4.0",
     "electron-builder": "^22.14.13",
     "electron-installer-windows": "^3.0.0",
     "electron-packager": "^15.1.0",


### PR DESCRIPTION
In Electron 24, we can't have a region that is both draggable and clickable: https://github.com/electron/electron/issues/37789. This makes it impossible to drag the window on macOS with the existing titlebar design.

Windows and Linux currently have the same limitation; we solve it there by shifting the titlebar down and adding empty space above (see previous discussion: https://github.com/minbrowser/min/issues/630). But no other apps do the same thing on macOS, so it would look odd to do it there.

My current idea (which this PR implements) is to do this, where the draggable regions are in red:

<img width="832" alt="Screenshot 2023-05-30 at 10 19 03 PM" src="https://github.com/minbrowser/min/assets/10314059/a835bda7-1e8f-4a9f-b32c-81564db789ad">

Although the space to the right of the window controls looks slightly odd, and it's not obvious what's draggable:

<img width="832" alt="Screenshot 2023-05-30 at 10 22 19 PM" src="https://github.com/minbrowser/min/assets/10314059/91958921-09b4-4c0d-a011-ebc0933b6177">

If anyone has feedback or other ideas, please let me know!