### PR TITLE
Remove "#pdfjs.action=download"

### DIFF
--- a/pages/pdfViewer/viewer.js
+++ b/pages/pdfViewer/viewer.js
@@ -520,7 +520,7 @@ function downloadPDF () {
   function startDownload (title) {
     var a = document.createElement('a')
     a.download = title || ''
-    a.href = url + '#pdfjs.action=download' // tell Min to download instead of opening in the viewer
+    a.href = url
     a.click()
   }
   if (pdf) {


### PR DESCRIPTION
URLs that contain "#pdfjs.action=download" was opening Electron's built-in pdf viewer.

To reproduce, open https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf#pdfjs.action=download

This also fixes #2208.
