### PR TITLE
Reduce white flickering while in dark mode

### DIFF
--- a/css/webviews.css
+++ b/css/webviews.css
@@ -3,12 +3,6 @@
   position: relative;
 }
 
-/* Webpages assume the page background will always be white, but the Electron API to set this is broken on Windows and Linux (https://github.com/electron/electron/issues/20447) - there, the view will always be transparent.
-Therefore, the webview background should always be white, except on the new tab page. */
-body:not(.is-ntp) #webviews {
-  background-color: white;
-}
-
 .arrow-indicator {
   width: 140px;
   height: 140px;

--- a/main/viewManager.js
+++ b/main/viewManager.js
@@ -321,7 +321,10 @@ ipc.on('loadURLInView', function (e, args) {
 
   // wait until the first URL is loaded to set the background color so that new tabs can use a custom background
   if (!viewStateMap[args.id].loadedInitialURL) {
-    viewMap[args.id].setBackgroundColor('#fff')
+    // Give the site a chance to display something before setting the background, in case it has its own dark theme
+    viewMap[args.id].webContents.once('dom-ready', function() {
+      viewMap[args.id].setBackgroundColor('#fff')
+    })
     // If the view has no URL, it won't be attached yet
     if (args.id === windows.getState(win).selectedView) {
       win.setBrowserView(viewMap[args.id])


### PR DESCRIPTION
* Removes a workaround for Windows that shouldn't be necessary any more (because the issue was fixed in electron/electron#33435). Now when we hide the browserView, we should get a black flicker instead of a white one.
* Waits until the page actually starts loading to set the browserView background. Now if you open a new tab and navigate to a site that has a dark theme, it should transition directly from dark browser background -> dark page in most cases, without having a white flash in between.
  * We still have to set the background to white eventually, because some sites don't set their own background color and assume the page will be white.

I'm still seeing some remaining white flickering with this PR, however; I think it's a result of something Electron is doing that I haven't figured out.