### PR TITLE
Switch to quick-score for fuzzy search

### DIFF
--- a/js/places/placesSearch.js
+++ b/js/places/placesSearch.js
@@ -1,10 +1,10 @@
-/* global spacesRegex oneWeekAgo historyInMemoryCache calculateHistoryScore */
+/* global spacesRegex oneWeekAgo oneDayAgo historyInMemoryCache calculateHistoryScore */
 
 /* depends on placesWorker.js */
 
 function processSearchText (text) {
   // the order of these transformations is important - for example, spacesRegex removes / characters, so protocols must be removed before it runs
-  return text.toLowerCase().split('?')[0].replace('http://', '').replace('https://', '').replace('www.', '').replace(spacesRegex, ' ')
+  return text.toLowerCase().split('?')[0].replace('http://', '').replace('https://', '').replace('www.', '').replace(spacesRegex, ' ').trim()
 }
 
 function searchPlaces (searchText, callback, options) {
@@ -13,10 +13,11 @@ function searchPlaces (searchText, callback, options) {
       return
     }
     const itextURL = processSearchText(item.url)
+    const itextTitle = item.title.toLowerCase().replace(spacesRegex, ' ')
     let itext = itextURL
 
     if (item.url !== item.title) {
-      itext += ' ' + item.title.toLowerCase().replace(spacesRegex, ' ')
+      itext += ' ' + itextTitle
     }
 
     if (item.tags) {
@@ -54,16 +55,10 @@ function searchPlaces (searchText, callback, options) {
         }
       }
 
-      if (item.visitCount !== 1 || item.lastVisit > oneWeekAgo) { // if the item has been visited more than once, or has been visited in the last week, we should calculate the fuzzy score. Otherwise, it is ignored. This reduces the number of bad results and increases search speed.
-        const score = itextURL.score(st, 0)
-
-        if (score > 0.4 + (0.00075 * itextURL.length)) {
-          item.boost = score * 0.5
-
-          if (score > 0.62) {
-            item.boost += 0.33
-          }
-
+      if ((item.visitCount > 2 && item.lastVisit > oneWeekAgo) || item.lastVisit > oneDayAgo) {
+        const score = Math.max(quickScore.quickScore(itextURL.substring(0, 100), st), quickScore.quickScore(itextTitle.substring(0, 50), st))
+        if (score > 0.3) {
+          item.boost = score * 0.33
           matches.push(item)
         }
       }

--- a/js/places/placesSearch.js
+++ b/js/places/placesSearch.js
@@ -1,4 +1,4 @@
-/* global spacesRegex oneWeekAgo oneDayAgo historyInMemoryCache calculateHistoryScore */
+/* global spacesRegex historyInMemoryCache calculateHistoryScore */
 
 /* depends on placesWorker.js */
 
@@ -64,6 +64,9 @@ function searchPlaces (searchText, callback, options) {
       }
     }
   }
+
+  const oneDayAgo = Date.now() - (oneDayInMS)
+  const oneWeekAgo = Date.now() - (oneDayInMS * 7)
 
   const matches = []
   const st = processSearchText(searchText)

--- a/js/places/placesService.html
+++ b/js/places/placesService.html
@@ -3,7 +3,7 @@
     <head>
         <title>Min history service</title>
         <script src="../../node_modules/dexie/dist/dexie.min.js"></script>
-        <script src="../../node_modules/string_score/string_score.min.js"></script>
+        <script src="../../node_modules/quick-score/dist/quick-score.min.js"></script>
         <script src="../util/database.js"></script>
         <script src="../../ext/xregexp/nonLetterRegex.js"></script>
         <script src="fullTextSearch.js"></script>

--- a/js/places/placesService.js
+++ b/js/places/placesService.js
@@ -20,8 +20,6 @@ function calculateHistoryScore (item) { // item.boost - how much the score shoul
 }
 
 const oneDayInMS = 24 * 60 * 60 * 1000 // one day in milliseconds
-const oneDayAgo = Date.now() - (oneDayInMS)
-const oneWeekAgo = Date.now() - (oneDayInMS * 7)
 
 // the oldest an item can be to remain in the database
 const maxItemAge = oneDayInMS * 42

--- a/js/places/placesService.js
+++ b/js/places/placesService.js
@@ -20,6 +20,7 @@ function calculateHistoryScore (item) { // item.boost - how much the score shoul
 }
 
 const oneDayInMS = 24 * 60 * 60 * 1000 // one day in milliseconds
+const oneDayAgo = Date.now() - (oneDayInMS)
 const oneWeekAgo = Date.now() - (oneDayInMS * 7)
 
 // the oldest an item can be to remain in the database

--- a/js/searchbar/openTabsPlugin.js
+++ b/js/searchbar/openTabsPlugin.js
@@ -38,13 +38,21 @@ var searchOpenTabs = function (text, input, event) {
     return
   }
 
-  var finalMatches = matches.sort(function (a, b) {
-    if (a.task.id === currentTask.id) {
-      a.score += 0.2
+  function scoreMatch (match) {
+    let score = 0
+    if (match.task.id === currentTask.id) {
+      score += 0.2
     }
-    if (b.task.id === currentTask.id) {
-      b.score += 0.2
-    }
+    const age = Date.now() - (match.tab.lastActivity || 0)
+
+    score += 0.3 / (1 + Math.exp(age / (30 * 24 * 60 * 60 * 1000)))
+    return score
+  }
+
+  var finalMatches = matches.map(function (match) {
+    match.score += scoreMatch(match)
+    return match
+  }).sort(function (a, b) {
     return b.score - a.score
   }).slice(0, 2)
 

--- a/js/searchbar/openTabsPlugin.js
+++ b/js/searchbar/openTabsPlugin.js
@@ -2,7 +2,7 @@ var browserUI = require('browserUI.js')
 var searchbarPlugins = require('searchbar/searchbarPlugins.js')
 var urlParser = require('util/urlParser.js')
 
-var stringScore = require('string_score') // eslint-disable-line no-unused-vars
+const quickScore = require('quick-score').quickScore
 
 var searchOpenTabs = function (text, input, event) {
   searchbarPlugins.reset('openTabs')
@@ -21,10 +21,10 @@ var searchOpenTabs = function (text, input, event) {
       var tabUrl = urlParser.basicURL(tab.url) // don't search protocols
 
       var exactMatch = tab.title.toLowerCase().indexOf(searchText) !== -1 || tabUrl.toLowerCase().indexOf(searchText) !== -1
-      var fuzzyTitleScore = tab.title.substring(0, 50).score(text, 0.5)
-      var fuzzyUrlScore = tabUrl.score(text, 0.5)
+      var fuzzyTitleScore = quickScore(tab.title.substring(0, 50), text)
+      var fuzzyUrlScore = quickScore(tabUrl, text)
 
-      if (exactMatch || fuzzyTitleScore > 0.4 || fuzzyUrlScore > 0.4) {
+      if (exactMatch || fuzzyTitleScore > 0.35 || fuzzyUrlScore > 0.35) {
         matches.push({
           task: task,
           tab: tab,

--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
     "mousetrap": "^1.5.3",
     "node-abi": "^3.8.0",
     "pdfjs-dist": "2.12.313",
+    "quick-score": "^0.2.0",
     "regedit": "^3.0.3",
-    "stemmer": "^1.0.5",
-    "string_score": "^0.1.22"
+    "stemmer": "^1.0.5"
   },
   "devDependencies": {
     "archiver": "^4.0.1",


### PR DESCRIPTION
From my testing, this module seems to produce higher-quality results, particularly for history search, than the old string-score module.

I also adjusted some of the filtering logic to do fuzzy matching against a better set of URLs.