### PR TITLE
Implement multi-select for rearranging tabs in task overlay

### DIFF
--- a/css/taskOverlay.css
+++ b/css/taskOverlay.css
@@ -307,3 +307,24 @@ body.dark-mode #task-overlay {
 .dark-mode #switch-task-button {
   color: dodgerblue;
 }
+
+.tab-drop-placeholder, .task-drop-placeholder {
+  opacity: 0.25;
+}
+
+.task-container.sortable-chosen {
+  background: white;
+}
+.dark-mode .task-container.sortable-chosen {
+  background: rgb(40, 44, 52);
+}
+
+.task-tab-item.dragging-selected {
+  border-left: 3px solid cornflowerblue;
+  margin-left: -3px;
+  background: rgba(0, 0, 0, 0.04) !important;
+}
+
+.dark-mode .task-tab-item.dragging-selected {
+  background: rgba(255, 255, 255, 0.05) !important;
+}

--- a/js/taskOverlay/taskOverlayBuilder.js
+++ b/js/taskOverlay/taskOverlayBuilder.js
@@ -270,7 +270,7 @@ var TaskOverlayBuilder = {
         el.setAttribute('data-tab', tab.id)
 
         el.addEventListener('click', function (e) {
-          if (!e.metaKey && !e.ctrlKey) {
+          if (!e.metaKey && !e.ctrlKey && !e.shiftKey) {
             events.tabSelect.call(this, e)
           }
         })

--- a/js/taskOverlay/taskOverlayBuilder.js
+++ b/js/taskOverlay/taskOverlayBuilder.js
@@ -269,7 +269,11 @@ var TaskOverlayBuilder = {
 
         el.setAttribute('data-tab', tab.id)
 
-        el.addEventListener('click', events.tabSelect)
+        el.addEventListener('click', function (e) {
+          if (!e.metaKey && !e.ctrlKey) {
+            events.tabSelect.call(this, e)
+          }
+        })
         return el
       },
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "pdfjs-dist": "2.12.313",
     "quick-score": "^0.2.0",
     "regedit": "^3.0.3",
+    "sortablejs": "^1.15.1",
     "stemmer": "^1.0.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Selecting multiple tabs works by holding Cmd (Mac) or Ctrl (Windows/Linux) and clicking.


https://github.com/minbrowser/min/assets/10314059/0226a8ac-f28b-4201-96db-a16e0e368a1a


At some point, I plan to implement this for the tab bar also (which will require switching from Dragula to SortableJS there as well).