### PR TITLE
Improve the process of writing userscripts

### DIFF
--- a/js/preload/default.js
+++ b/js/preload/default.js
@@ -50,7 +50,11 @@ window.addEventListener('message', function (e) {
     return
   }
 
-  if (e.data && e.data.message && e.data.message === 'showCredentialList') {
+  if (e.data?.message === 'showCredentialList') {
     ipc.send('showCredentialList')
+  }
+
+  if (e.data?.message === 'showUserscriptDirectory') {
+    ipc.send('showUserscriptDirectory')
   }
 })

--- a/localization/languages/ar.json
+++ b/localization/languages/ar.json
@@ -163,6 +163,7 @@
     "settingsUserscriptsExplanation": {
       "unsafeHTML": "يمكن سكريبت المستخدم من  تغير سلوك المواقع - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">معرفة المزيد</a>."
     },
+    "settingsUserscriptShowDirectory": null, //missing translation,
     "settingsUserAgentToggle": "خاص user-agent إستخدم",
     "settingsUpdateNotificationsToggle": "إبحث تلقائيا عن التحديثات",
     "settingsUsageStatisticsToggle": {

--- a/localization/languages/be.json
+++ b/localization/languages/be.json
@@ -163,7 +163,8 @@
       "settingsUserscriptsExplanation": {
         "unsafeHTML": "Карыстальнiцкiя скрыпты дазваляюць змяняць паводзіны сайтаў - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">даведацца больш</a>."
       },
-      "settingsUserAgentToggle": "Выкарыстоўваць карыстацкі user agent",
+      "settingsUserscriptShowDirectory": null, //missing translation,
+    "settingsUserAgentToggle": "Выкарыстоўваць карыстацкі user agent",
       "settingsUpdateNotificationsToggle": "Аўтаматычна правяраць наяўнасць абнаўленняў",
       "settingsUsageStatisticsToggle": {
         "unsafeHTML": "Адпраўляць статыстыку выкарыстання (<a href=\"https://github.com/minbrowser/min/blob/master/docs/statistics.md\">Больш інфармацыі</a>)"

--- a/localization/languages/bg.json
+++ b/localization/languages/bg.json
@@ -162,6 +162,7 @@
     "settingsUserscriptsExplanation": {
       "unsafeHTML": "Потребителските скриптове Ви позволяват да промените поведението на уеб сайтове - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">научете повече</a>."
     },
+    "settingsUserscriptShowDirectory": null, //missing translation,
     "settingsUserAgentToggle": "Използване на персонализиран потребителски агент",
     "settingsUpdateNotificationsToggle": "Автоматично проверяване за актуализации",
     "settingsUsageStatisticsToggle": null, //missing translation

--- a/localization/languages/bn.json
+++ b/localization/languages/bn.json
@@ -163,6 +163,7 @@
     "settingsUserscriptsExplanation": {
       "unsafeHTML": "ব্যবহারকারীর স্ক্রিপ্ট আপনাকে ওয়েবসাইটের আচরণ পরিবর্তন করার অনুমতি দেয় - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\"> আরও শিখুন </a>"
     },
+    "settingsUserscriptShowDirectory": null, //missing translation,
     "settingsUserAgentToggle": "একটি কাস্টম ব্যবহারকারী এজেন্ট ব্যবহার করুন",
     "settingsUpdateNotificationsToggle": "স্বয়ংক্রিয়ভাবে আপডেটগুলির জন্য পরীক্ষা করুন",
     "settingsUsageStatisticsToggle": null, //missing translation

--- a/localization/languages/ca.json
+++ b/localization/languages/ca.json
@@ -163,6 +163,7 @@
     "settingsUserscriptsExplanation": {
       "unsafeHTML": "Els scripts d'usuari et permeten modificar el comportament dels llocs web - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">més informació</a>."
     },
+    "settingsUserscriptShowDirectory": null, //missing translation,
     "settingsUserAgentToggle": "Utilitzar un agent d'usuari personalitzat",
     "settingsUpdateNotificationsToggle": "Comprovar actualitzacions automàticament",
     "settingsUsageStatisticsToggle": {

--- a/localization/languages/cs.json
+++ b/localization/languages/cs.json
@@ -163,6 +163,7 @@
     "settingsUserscriptsExplanation": {
       "unsafeHTML": "Uživatelské skripty umožňují upravit chování webových stránek - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">více informací</a>."
     },
+    "settingsUserscriptShowDirectory": null, //missing translation,
     "settingsUserAgentToggle": "Použít vlastní User-Agent řetězec",
     "settingsUpdateNotificationsToggle": "Automaticky kontrolovat aktualizace",
     "settingsUsageStatisticsToggle": {

--- a/localization/languages/da.json
+++ b/localization/languages/da.json
@@ -163,6 +163,7 @@
     "settingsUserscriptsExplanation": {
       "unsafeHTML": "Brugerscripts giver dig mulighed for at ændre adfærd på websteder - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">få mere at vide her</a>."
     },
+    "settingsUserscriptShowDirectory": null, //missing translation,
     "settingsUserAgentToggle": "Brug en brugerdefineret brugeragent",
     "settingsUpdateNotificationsToggle": "Kontroller automatisk for opdateringer",
     "settingsUsageStatisticsToggle": {

--- a/localization/languages/de.json
+++ b/localization/languages/de.json
@@ -163,6 +163,7 @@
     "settingsUserscriptsExplanation": {
       "unsafeHTML": "Benutzerdefinierte Skripte erlauben es das Verhalten von Webseiten zu modifizieren - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\"> mehr dazu.</a>."
     },
+    "settingsUserscriptShowDirectory": null, //missing translation,
     "settingsUserAgentToggle": "Benutzerdefinierten Benutzer-Agent nutzen",
     "settingsUpdateNotificationsToggle": "Automatisch nach Aktualisierungen überprüfen",
     "settingsUsageStatisticsToggle": {

--- a/localization/languages/el.json
+++ b/localization/languages/el.json
@@ -163,7 +163,8 @@
       "settingsUserscriptsExplanation": {
         "unsafeHTML": "Τα scripts χρηστών σας επιτρέπουν να τροποποιήσετε την συμπεριφορά των ιστοσελίδων - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">μάθετε περισσότερα</a>."
       },
-      "settingsUserAgentToggle": "Χρήση προσαρμοσμένου χρήστη agent",
+      "settingsUserscriptShowDirectory": null, //missing translation,
+    "settingsUserAgentToggle": "Χρήση προσαρμοσμένου χρήστη agent",
       "settingsUpdateNotificationsToggle": "Αυτόματος έλεγχος για ενημερώσεις",
       "settingsUsageStatisticsToggle": {
         "unsafeHTML": "Αποστολή στατιστικών χρήσης (<a href=\"https://github.com/minbrowser/min/blob/master/docs/statistics.md\">Παραπάνω πληροφορίες</a>)"

--- a/localization/languages/en-US.json
+++ b/localization/languages/en-US.json
@@ -163,6 +163,7 @@
     "settingsUserscriptsExplanation": {
       "unsafeHTML": "User scripts allow you to modify the behavior of websites - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">learn more</a>."
     },
+    "settingsUserscriptShowDirectory": "Show script directory",
     "settingsUserAgentToggle": "Use a custom user agent",
     "settingsUpdateNotificationsToggle": "Automatically check for updates",
     "settingsUsageStatisticsToggle": {

--- a/localization/languages/es.json
+++ b/localization/languages/es.json
@@ -163,6 +163,7 @@
     "settingsUserscriptsExplanation": {
       "unsafeHTML": "Los userscripts te permiten modificar el comportamiento de los sitios web - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">Más información</a>."
     }, //"learn more" was translated to "más información" (more info)
+    "settingsUserscriptShowDirectory": null, //missing translation,
     "settingsUserAgentToggle": "Usar agente de usuario personalizado",
     "settingsUpdateNotificationsToggle": "Buscar actualizaciones automáticamente",
     "settingsUsageStatisticsToggle": {

--- a/localization/languages/fa.json
+++ b/localization/languages/fa.json
@@ -164,6 +164,7 @@
     "settingsUserscriptsExplanation": {
       "unsafeHTML": "اسکریپت های کاربر این اجازه را به شما می دهند تا رفتار سایت ها را تغییر دهید - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">اطلاعات بیشتر</a>."
     },
+    "settingsUserscriptShowDirectory": null, //missing translation,
     "settingsUserAgentToggle": null, //missing translation
     "settingsUpdateNotificationsToggle": null, //missing translation
     "settingsUsageStatisticsToggle": null, //missing translation

--- a/localization/languages/fi.json
+++ b/localization/languages/fi.json
@@ -163,6 +163,7 @@
     "settingsUserscriptsExplanation": {
       "unsafeHTML": "Komentosarjat mahdollistavat sivustojen käyttäytymisen mukauttamisen - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">lisätietoja</a>."
     },
+    "settingsUserscriptShowDirectory": null, //missing translation,
     "settingsUserAgentToggle": "Käytä mukautettua käyttäjäagenttia",
     "settingsUpdateNotificationsToggle": "Tarkista päivitykset automaattisesti",
     "settingsUsageStatisticsToggle": {

--- a/localization/languages/fr.json
+++ b/localization/languages/fr.json
@@ -163,6 +163,7 @@
     "settingsUserscriptsExplanation": {
       "unsafeHTML": "Les scripts personnalisés vous permettent de modifier le comportement des pages web - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">en savoir plus (en anglais)</a>."
     },
+    "settingsUserscriptShowDirectory": null, //missing translation,
     "settingsUserAgentToggle": "Utiliser un user-agent particulier",
     "settingsUpdateNotificationsToggle": "Vérifier automatiquement pour des mises à jour",
     "settingsUsageStatisticsToggle": {

--- a/localization/languages/hr.json
+++ b/localization/languages/hr.json
@@ -163,6 +163,7 @@
     "settingsUserscriptsExplanation": {
       "unsafeHTML": "Korisničke skripte omogućuju vam izmjenu ponašanja web stranica - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">Saznajte više</a>."
     },
+    "settingsUserscriptShowDirectory": null, //missing translation,
     "settingsUserAgentToggle": "Upotrijebite prilagođeni korisnički agent",
     "settingsUpdateNotificationsToggle": "Automatski provjeri ima li ažuriranja",
     "settingsUsageStatisticsToggle": {

--- a/localization/languages/hu.json
+++ b/localization/languages/hu.json
@@ -161,6 +161,7 @@
     "settingsAutoplayToggle": null, //missing translation 
     "settingsOpenTabsInForegroundToggle": null, //missing translation
     "settingsUserscriptsExplanation": "Felhasználói szkript magyarázat",
+    "settingsUserscriptShowDirectory": null, //missing translation,
     "settingsUserAgentToggle": null, //missing translation
     "settingsUpdateNotificationsToggle": null, //missing translation
     "settingsUsageStatisticsToggle": null, //missing translation

--- a/localization/languages/id.json
+++ b/localization/languages/id.json
@@ -163,6 +163,7 @@
     "settingsUserscriptsExplanation": {
       "unsafeHTML": "User script memungkinkan Anda untuk merubah perilaku situs web - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">Pelajari lebih lanjut</a>."
     },
+    "settingsUserscriptShowDirectory": null, //missing translation,
     "settingsUserAgentToggle": "Gunakan user agent khusus",
     "settingsUpdateNotificationsToggle": "Cek pembaruan secara otomatis",
     "settingsUsageStatisticsToggle": {

--- a/localization/languages/it.json
+++ b/localization/languages/it.json
@@ -163,6 +163,7 @@
     "settingsUserscriptsExplanation": {
       "unsafeHTML": "Gli script definiti dall'utente ti permettono di modificare il comportamento dei siti - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">scopri di più</a>."
     },
+    "settingsUserscriptShowDirectory": null, //missing translation,
     "settingsUserAgentToggle": "Utilizza un user agent personalizzato",
     "settingsUpdateNotificationsToggle": "Controlla automaticamente la presenza di aggiornamenti",
     "settingsUsageStatisticsToggle": {

--- a/localization/languages/ja.json
+++ b/localization/languages/ja.json
@@ -163,6 +163,7 @@
     "settingsUserscriptsExplanation": {
       "unsafeHTML": "ユーザースクリプトを使用して、Webサイトの動作を変更できます -  <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">詳細</a>。"
     },
+    "settingsUserscriptShowDirectory": null, //missing translation,
     "settingsUserAgentToggle": "カスタムユーザーエージェントを使用する",
     "settingsUpdateNotificationsToggle": "アップデートを自動的に確認する",
     "settingsUsageStatisticsToggle": {

--- a/localization/languages/ko.json
+++ b/localization/languages/ko.json
@@ -163,6 +163,7 @@
     "settingsUserscriptsExplanation": {
       "unsafeHTML": "사용자 명령(스크립트)을 사용하면 누리집의 행동을 수정할 수 있습니다. - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">더보기</a>."
     },
+    "settingsUserscriptShowDirectory": null, //missing translation,
     "settingsUserAgentToggle": "사용자 정의 에이전트(UserAgent) 사용",
     "settingsUpdateNotificationsToggle": "판올림 자동 확인",
     "settingsUsageStatisticsToggle": {

--- a/localization/languages/lt.json
+++ b/localization/languages/lt.json
@@ -163,6 +163,7 @@
     "settingsUserscriptsExplanation": {
       "unsafeHTML": "Naudotojo scenarijai leidžia jums modifikuoti internetinių svetainių elgseną - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">sužinokite daugiau</a>."
     },
+    "settingsUserscriptShowDirectory": null, //missing translation,
     "settingsUserAgentToggle": null, //missing translation
     "settingsUpdateNotificationsToggle": "Automatiškai tikrinti ar yra atnaujinimų",
     "settingsUsageStatisticsToggle": null, //missing translation

--- a/localization/languages/nl.json
+++ b/localization/languages/nl.json
@@ -163,6 +163,7 @@
     "settingsUserscriptsExplanation": {
       "unsafeHTML": "Gebruikersscripten kunt u gebruiken om het gedrag van websites te wijzigingen - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">lees meer</a>."
     },
+    "settingsUserscriptShowDirectory": null, //missing translation,
     "settingsUserAgentToggle": "Gebruik een aangepaste gebruikersagent",
     "settingsUpdateNotificationsToggle": "Automatisch controleren op updates",
     "settingsUsageStatisticsToggle": {

--- a/localization/languages/pl.json
+++ b/localization/languages/pl.json
@@ -163,6 +163,7 @@
     "settingsUserscriptsExplanation": {
       "unsafeHTML": "Skrypty użytkownika pozwalają modyfikować zachowanie stron internetowych - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">dowiedz się więcej</a>."
     },
+    "settingsUserscriptShowDirectory": null, //missing translation,
     "settingsUserAgentToggle": "Użyj niestandardowego klienta użytkownika",
     "settingsUpdateNotificationsToggle": "Automatycznie sprawdź dostępność aktualizacji",
     "settingsUsageStatisticsToggle": {

--- a/localization/languages/pt-BR.json
+++ b/localization/languages/pt-BR.json
@@ -163,6 +163,7 @@
     "settingsUserscriptsExplanation": {
       "unsafeHTML": "Scripts do usuário permitem modificar o comportamento do site - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">Saiba mais</a>."
     },
+    "settingsUserscriptShowDirectory": null, //missing translation,
     "settingsUserAgentToggle": "Usar agente de usuário personalizado",
     "settingsUpdateNotificationsToggle": "Verificar atualizações automaticamente",
     "settingsUsageStatisticsToggle": {

--- a/localization/languages/pt-PT.json
+++ b/localization/languages/pt-PT.json
@@ -163,6 +163,7 @@
     "settingsUserscriptsExplanation": {
       "unsafeHTML": "Os scripts permitem-lhe alterar o comportamento dos sites - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">Saber mais</a>."
     },
+    "settingsUserscriptShowDirectory": null, //missing translation,
     "settingsUserAgentToggle": "Utilizar um agente de utilizador personalizado",
     "settingsUpdateNotificationsToggle": "Procurar atualizações automaticamente",
     "settingsUsageStatisticsToggle": {

--- a/localization/languages/ru.json
+++ b/localization/languages/ru.json
@@ -163,6 +163,7 @@
     "settingsUserscriptsExplanation": {
       "unsafeHTML": "Пользовательские скрипты позволяют изменять поведение сайтов - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">узнать больше</a>."
     },
+    "settingsUserscriptShowDirectory": null, //missing translation,
     "settingsUserAgentToggle": "Использовать пользовательский user agent",
     "settingsUpdateNotificationsToggle": "Автоматически проверять наличие обновлений",
     "settingsUsageStatisticsToggle": {

--- a/localization/languages/sr.json
+++ b/localization/languages/sr.json
@@ -163,6 +163,7 @@
     "settingsUserscriptsExplanation": {
       "unsafeHTML": "Korisničke skripte omogućavaju modifikovanje ponašanja sajtova - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">learn more</a>."
     },
+    "settingsUserscriptShowDirectory": null, //missing translation,
     "settingsUserAgentToggle": "Koristi prilagođeni korisnički agent",
     "settingsUpdateNotificationsToggle": "Automatski obaveštavaj o novim verzijama Min",
     "settingsUsageStatisticsToggle": {

--- a/localization/languages/th.json
+++ b/localization/languages/th.json
@@ -163,6 +163,7 @@
     "settingsUserscriptsExplanation": {
       "unsafeHTML": "สคริปต์ผู้ใช้ที่จะช่วยให้คุณปรับเปลี่ยนพฤติกรรมของเว็บไซต์ได้ - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">เรียนรู้เพิ่มเติม</a>."
     },
+    "settingsUserscriptShowDirectory": null, //missing translation,
     "settingsUserAgentToggle": "ใช้ตัวแทนผู้ใช้ที่กำหนดค่าเอง",
     "settingsUpdateNotificationsToggle": "ตรวจสอบการอัปเดตโดยอัตโนมัติ",
     "settingsUsageStatisticsToggle": {

--- a/localization/languages/tr.json
+++ b/localization/languages/tr.json
@@ -163,6 +163,7 @@
     "settingsUserscriptsExplanation": {
       "unsafeHTML": "Kullancı betikleri size websitelerinin davranışını değiştirmenize izin verir - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">daha fazla bilgi için</a>."
     },
+    "settingsUserscriptShowDirectory": null, //missing translation,
     "settingsUserAgentToggle": "Özel kullanıcı aracısı kullan",
     "settingsUpdateNotificationsToggle": "Güncelleştirmeleri otomatik olarak denetle",
     "settingsUsageStatisticsToggle": {

--- a/localization/languages/uk.json
+++ b/localization/languages/uk.json
@@ -164,6 +164,7 @@
     "settingsUserscriptsExplanation": {
       "unsafeHTML": "Скрипти користувача дозволяють змінювати поведінку веб-сайтів - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">дізнатися більше</a>."
     },
+    "settingsUserscriptShowDirectory": null, //missing translation,
     "settingsUserAgentToggle": "Використовувати власний агент користувача",
     "settingsUpdateNotificationsToggle": "Автоматично перевіряти наявність оновлень",
     "settingsUsageStatisticsToggle": {

--- a/localization/languages/uz.json
+++ b/localization/languages/uz.json
@@ -163,6 +163,7 @@
     "settingsUserscriptsExplanation": {
       "unsafeHTML": "Foydalanuvchi skriptlari sahifa ishlashini o'zgartirishga yordam beradi - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">qo'shimcha ma'lumot</a>."
     },
+    "settingsUserscriptShowDirectory": null, //missing translation,
     "settingsUserAgentToggle": "Maxsus foydalanvuchi agentidan foydalanish",
     "settingsUpdateNotificationsToggle": " Yangilanishlarni avtomatik ravishda tekshirish",
     "settingsUsageStatisticsToggle": null, //missing translation

--- a/localization/languages/vi.json
+++ b/localization/languages/vi.json
@@ -156,7 +156,8 @@
         "settingsUserscriptsExplanation": {
             "unsafeHTML": "Mã script người dùng có thể cho bạn thay đổi hành vi trang web - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">Xem thêm</a>."
         },
-        "settingsUserAgentToggle": "Sử dụng tác nhân người dùng tùy chỉnh",
+        "settingsUserscriptShowDirectory": null, //missing translation,
+    "settingsUserAgentToggle": "Sử dụng tác nhân người dùng tùy chỉnh",
         "settingsUpdateNotificationsToggle": "Tự động kiểm tra cập nhật",
         "settingsUsageStatisticsToggle": {
           "unsafeHTML": "Gửi thống kê sử dụng (<a href=\"https://github.com/minbrowser/min/blob/master/docs/statistics.md\">Xem thêm</a>)"

--- a/localization/languages/zh-CN.json
+++ b/localization/languages/zh-CN.json
@@ -163,6 +163,7 @@
     "settingsUserscriptsExplanation": {
       "unsafeHTML": "自定义脚本允许您改变网站行为 - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">查看更多</a>."
     },
+    "settingsUserscriptShowDirectory": null, //missing translation,
     "settingsUserAgentToggle": "自定义浏览器User-Agent",
     "settingsUpdateNotificationsToggle": "自动检查更新",
     "settingsUsageStatisticsToggle": {

--- a/localization/languages/zh-TW.json
+++ b/localization/languages/zh-TW.json
@@ -163,6 +163,7 @@
     "settingsUserscriptsExplanation": {
       "unsafeHTML": "使用者指令允許您改變網站的行為 - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">查看更多</a>."
     },
+    "settingsUserscriptShowDirectory": null, //missing translation,
     "settingsUserAgentToggle": "使用自訂使用者代理",
     "settingsUpdateNotificationsToggle": "自動檢查更新",
     "settingsUsageStatisticsToggle": {

--- a/package.json
+++ b/package.json
@@ -39,12 +39,12 @@
     "quick-score": "^0.2.0",
     "regedit": "^3.0.3",
     "sortablejs": "^1.15.1",
-    "stemmer": "^1.0.5"
+    "stemmer": "^1.0.5",
+    "chokidar": "^3.5.3"
   },
   "devDependencies": {
     "archiver": "^4.0.1",
     "browserify": "^16.5.1",
-    "chokidar": "^3.4.0",
     "concurrently": "^5.2.0",
     "decomment": "^0.9.0",
     "electron": "29.0.0-alpha.4",

--- a/pages/settings/index.html
+++ b/pages/settings/index.html
@@ -166,6 +166,9 @@
           data-string="settingsUserscriptsExplanation"
           data-allowHTML
         ></div>
+        <div class="setting-secondary-label" id="userscripts-show-directory" hidden style="margin-top: -0.5em; margin-bottom: 0.5em">
+          <a data-string="settingsUserscriptShowDirectory"></a>
+        </div>
       </div>
 
       <div class="setting-section" id="section-separate-titlebar">

--- a/pages/settings/settings.js
+++ b/pages/settings/settings.js
@@ -5,6 +5,7 @@ var banner = document.getElementById('restart-required-banner')
 var siteThemeCheckbox = document.getElementById('checkbox-site-theme')
 var showDividerCheckbox = document.getElementById('checkbox-show-divider')
 var userscriptsCheckbox = document.getElementById('checkbox-userscripts')
+var userscriptsShowDirectorySection = document.getElementById('userscripts-show-directory')
 var separateTitlebarCheckbox = document.getElementById('checkbox-separate-titlebar')
 var openTabsInForegroundCheckbox = document.getElementById('checkbox-open-tabs-in-foreground')
 var autoPlayCheckbox = document.getElementById('checkbox-enable-autoplay')
@@ -259,11 +260,17 @@ newWindowSettingInput.addEventListener('change', function() {
 settings.get('userscriptsEnabled', function (value) {
   if (value === true) {
     userscriptsCheckbox.checked = true
+    userscriptsShowDirectorySection.hidden = false
   }
 })
 
 userscriptsCheckbox.addEventListener('change', function (e) {
   settings.set('userscriptsEnabled', this.checked)
+  userscriptsShowDirectorySection.hidden = !this.checked
+})
+
+userscriptsShowDirectorySection.getElementsByTagName('a')[0].addEventListener('click', function() {
+  postMessage({ message: 'showUserscriptDirectory' })
 })
 
 /* show divider between tabs setting */

--- a/scripts/buildBrowser.js
+++ b/scripts/buildBrowser.js
@@ -33,6 +33,8 @@ function buildBrowser () {
     detectGlobals: false
   })
 
+  instance.exclude('chokidar')
+
   instance.transform(renderify)
   const stream = fs.createWriteStream(outFile, { encoding: 'utf-8' })
   instance.bundle()


### PR DESCRIPTION
* Enabling userscripts now creates the directory automatically, and I've added a button from the settings page to open it:
![Screenshot 2023-12-27 at 11 12 50 PM](https://github.com/minbrowser/min/assets/10314059/4bb1dd73-0a93-43f2-8afa-c84f67b1c930)

* Userscripts now reload when edited, so that only the webpage needs to be reloaded rather than restarting the browser.

If anyone has feedback on this, let me know! I'd like for userscripts to be more accessible and easier to set up, so I'd be interested in hearing further ideas to make that happen.