### PR TITLE
Switch to quick-score for fuzzy search (leftover)

### DIFF
--- a/js/searchbar/customBangs.js
+++ b/js/searchbar/customBangs.js
@@ -15,6 +15,7 @@ const bookmarkConverter = require('bookmarkConverter.js')
 const searchbarPlugins = require('searchbar/searchbarPlugins.js')
 const tabEditor = require('navbar/tabEditor.js')
 const formatRelativeDate = require('util/relativeDate.js')
+const quickScore = require('quick-score').quickScore
 
 function moveToTaskCommand (taskId) {
   // remove the tab from the current task
@@ -84,7 +85,7 @@ function searchAndSortTasks (text) {
       const task = t.task
       const taskName = (task.name ? task.name : l('defaultTaskName').replace('%n', tasks.getIndex(task.id) + 1)).toLowerCase()
       const exactMatch = taskName.indexOf(searchText) !== -1
-      const fuzzyTitleScore = taskName.score(searchText, 0.5)
+      const fuzzyTitleScore = quickScore(taskName, searchText)
 
       return (exactMatch || fuzzyTitleScore > 0.4)
     })

--- a/js/searchbar/customBangs.js
+++ b/js/searchbar/customBangs.js
@@ -2,9 +2,9 @@
 
 const { ipcRenderer } = require('electron')
 const fs = require('fs')
+const quickScore = require('quick-score').quickScore
 
 const bangsPlugin = require('searchbar/bangsPlugin.js')
-const quickScore = require('quick-score').quickScore
 
 const webviews = require('webviews.js')
 const browserUI = require('browserUI.js')

--- a/js/searchbar/customBangs.js
+++ b/js/searchbar/customBangs.js
@@ -4,6 +4,7 @@ const { ipcRenderer } = require('electron')
 const fs = require('fs')
 
 const bangsPlugin = require('searchbar/bangsPlugin.js')
+const quickScore = require('quick-score').quickScore
 
 const webviews = require('webviews.js')
 const browserUI = require('browserUI.js')
@@ -15,7 +16,6 @@ const bookmarkConverter = require('bookmarkConverter.js')
 const searchbarPlugins = require('searchbar/searchbarPlugins.js')
 const tabEditor = require('navbar/tabEditor.js')
 const formatRelativeDate = require('util/relativeDate.js')
-const quickScore = require('quick-score').quickScore
 
 function moveToTaskCommand (taskId) {
   // remove the tab from the current task


### PR DESCRIPTION
I think you might have left this behind when you were working on [this PR](https://github.com/minbrowser/min/pull/2342) I noticed it because the fuzzy finding functionality using `!task` was not working anymore. I also noticed in that PR you changed the score target from .4 to .35, I was not sure wether it was necessary here so I did not do it for now. One last thing I am not sure that the `require` statement is in the right place but if it isn't I can move it where you prefer.
This is my first time contributing to Min I hope I did everything according to your requirements.