### PR TITLE
Improve the "block scripts" setting

### DIFF
--- a/js/webviews.js
+++ b/js/webviews.js
@@ -197,9 +197,9 @@ const webviews = {
     ipc.send('createView', {
       existingViewId,
       id: tabId,
-      webPreferencesString: JSON.stringify({
+      webPreferences: {
         partition: partition || 'persist:webcontent'
-      }),
+      },
       boundsString: JSON.stringify(webviews.getViewBounds()),
       events: webviews.events.map(e => e.event).filter((i, idx, arr) => arr.indexOf(i) === idx)
     })


### PR DESCRIPTION
Previously, "block scripts" filtered requests at the network level by content type, which meant inline scripts weren't being blocked. This sets `javascript: false` on the webContents, which truly disables all JS.

We still need JS for the browser internal pages (settings/reader/PDF viewer), so this checks the URL on each navigation and re-creates the view with an updated preference value if necessary.

Fixes #2382.