### PR TITLE
Tab bar UI updates

### DIFF
--- a/css/tabBar.css
+++ b/css/tabBar.css
@@ -246,6 +246,9 @@ body:not(.touch)
   flex: 1;
   overflow: hidden;
 }
+.compact-tabs .tab-item .title {
+  font-size: 14px;
+}
 .tab-item .title {
   display: block;
   position: absolute;
@@ -271,8 +274,11 @@ body:not(.touch)
   opacity: 1;
 }
 .tab-item.active.has-url:hover .title {
-  transform: scale(0.7) translateY(-10%);
+  transform: scale(0.7333) translateY(-10%);
   opacity: 0.9;
+}
+.compact-tabs .tab-item.active.has-url:hover .title {
+  transform: scale(0.78571) translateY(-12%);
 }
 
 /* buttons */

--- a/css/tabBar.css
+++ b/css/tabBar.css
@@ -112,6 +112,9 @@ body.linux #menu-button {
   padding-left: 0.5rem;
   padding-right: 0.5rem;
 }
+.tab-item.active {
+  min-width: 168px;
+}
 .tab-item.gu-mirror {
   top: var(--control-space-top) !important;
   height: 32px !important;
@@ -235,11 +238,41 @@ body:not(.touch)
 .tab-item:not(.active) .icon-tab-not-secure {
   display: none;
 }
-.tab-item .title {
-  font-size: 15px;
+.tab-item .title-container {
+  display: inline-block;
+  position: relative;
   padding-left: 0.25rem;
   padding-right: 0.25rem;
-  margin-right: auto;
+  flex: 1;
+  overflow: hidden;
+}
+.tab-item .title {
+  display: block;
+  position: absolute;
+  top: 0;
+  font-size: 15px;
+  transform-origin: left 10%;
+  transition: 0.15s transform;
+  white-space: nowrap;
+}
+.tab-item .url-element {
+  display: block;
+  position: absolute;
+  top: 5px;
+  transform-origin: left 90%;
+  transform: translateY(15%);
+  opacity: 0;
+  transition: 0.15s all;
+  font-size: 13px;
+  white-space: nowrap;
+}
+.tab-item.active.has-url:hover .url-element {
+  transform: none;
+  opacity: 1;
+}
+.tab-item.active.has-url:hover .title {
+  transform: scale(0.7) translateY(-10%);
+  opacity: 0.9;
 }
 
 /* buttons */

--- a/js/navbar/tabBar.js
+++ b/js/navbar/tabBar.js
@@ -210,6 +210,7 @@ const tabBar = {
     if (tabs.getSelected()) {
       tabBar.setActiveTab(tabs.getSelected())
     }
+    tabBar.handleSizeChange()
   },
   addTab: function (tabId) {
     var tab = tabs.get(tabId)
@@ -218,6 +219,7 @@ const tabBar = {
     var tabEl = tabBar.createTab(tab)
     tabBar.containerInner.insertBefore(tabEl, tabBar.containerInner.childNodes[index])
     tabBar.tabElementMap[tabId] = tabEl
+    tabBar.handleSizeChange()
   },
   removeTab: function (tabId) {
     var tabEl = tabBar.getTab(tabId)
@@ -226,6 +228,7 @@ const tabBar = {
       // This happens when destroying tabs from other task where this .tab-item is not present
       tabBar.containerInner.removeChild(tabEl)
       delete tabBar.tabElementMap[tabId]
+      tabBar.handleSizeChange()
     }
   },
   handleDividerPreference: function (dividerPreference) {
@@ -259,8 +262,17 @@ const tabBar = {
 
       tabs.splice(newIdx, 0, oldTab)
     })
+  },
+  handleSizeChange: function () {
+    if (window.innerWidth / tabBar.containerInner.childNodes.length < 190) {
+      tabBar.container.classList.add('compact-tabs')
+    } else {
+      tabBar.container.classList.remove('compact-tabs')
+    }
   }
 }
+
+window.addEventListener('resize', tabBar.handleSizeChange)
 
 settings.listen('showDividerBetweenTabs', function (dividerPreference) {
   tabBar.handleDividerPreference(dividerPreference)

--- a/js/navbar/tabBar.js
+++ b/js/navbar/tabBar.js
@@ -80,10 +80,21 @@ const tabBar = {
 
     // title
 
+    var titleContainer = document.createElement('div')
+    titleContainer.className = 'title-container'
+
     var title = document.createElement('span')
     title.className = 'title'
 
-    tabEl.appendChild(title)
+    // URL
+
+    var urlElement = document.createElement('span')
+    urlElement.className = 'url-element'
+
+    titleContainer.appendChild(title)
+    titleContainer.appendChild(urlElement)
+
+    tabEl.appendChild(titleContainer)
 
     // click to enter edit mode or switch to a tab
     tabEl.addEventListener('click', function (e) {
@@ -149,6 +160,15 @@ const tabBar = {
     tabEl.title = tabTitle
     if (tabData.private) {
       tabEl.title += ' (' + l('privateTab') + ')'
+    }
+
+    var tabUrl = urlParser.getDomain(tabData.url)
+    tabEl.querySelector('.url-element').textContent = tabUrl
+
+    if (tabUrl && !urlParser.isInternalURL(tabData.url)) {
+      tabEl.classList.add('has-url')
+    } else {
+      tabEl.classList.remove('has-url')
     }
 
     // update tab audio icon

--- a/js/navbar/tabBar.js
+++ b/js/navbar/tabBar.js
@@ -163,6 +163,10 @@ const tabBar = {
     }
 
     var tabUrl = urlParser.getDomain(tabData.url)
+    if (tabUrl.startsWith('www.') && tabUrl.split('.').length > 2) {
+      tabUrl = tabUrl.replace('www.', '')
+    }
+
     tabEl.querySelector('.url-element').textContent = tabUrl
 
     if (tabUrl && !urlParser.isInternalURL(tabData.url)) {


### PR DESCRIPTION
This PR makes a couple of improvements to the tab bar:

* When you hover over the current tab, the domain is displayed. I'm hoping this does two things:
  * It makes it a bit easier to check what site you're currently on, which helps with eg. phishing
  * It provides more of a hint that you can click on the tab to get to the URL bar
  * <img src="https://github.com/minbrowser/min/assets/10314059/440a3e1e-747d-462d-845b-49ab9b75a3d6" width="400"/>
* The current tab now has a larger minimum width than the other tabs.
  * At the old minimum width, it was difficult to fit the title and the controls in; this gets worse when we show a URL, since there usually isn't room to fit the complete domain.
* When the ratio of (window width / tab count) drops below a threshold, the font size for the tab titles is now reduced slightly.
  * This should help a tiny bit with readability of the tab bar when there are many tabs open.

I'd appreciate any feedback on this!