### PR TITLE
fix(arch):change aur pkg

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You can find prebuilt binaries for Min [here](https://github.com/minbrowser/min/
 
 - To install the .deb file, use `sudo dpkg -i /path/to/download`
 - To install the RPM build, use `sudo rpm -i /path/to/download --ignoreos`
-- On Arch Linux install from [AUR](https://aur.archlinux.org/packages/min).
+- On Arch Linux install from [AUR](https://aur.archlinux.org/packages/min-browser-bin).
 - On Raspberry Pi, you can install Min from [Pi-Apps](https://github.com/Botspot/pi-apps).
 
 ## Developing


### PR DESCRIPTION
The [min](https://aur.archlinux.org/packages/min)  is still on 1.30 and also using electron24.
Due to the current lifescycle of Arch Linux it is now using electron29 which ends up in having to compile electron24 from source.
This requires compiling Chromium then which is nearly 30 GB of downloading only and not mentioning the amount of time it would take to compile.
Instead this [min-browser-bin](https://aur.archlinux.org/packages/min-browser-bin) is up to date and also solves the issue as it compiles it from the `.deb` file provided which makes it take about a minute only.