### PR TITLE
Fix: bookmarks data not being updated after importing

### DIFF
--- a/js/bookmarkConverter.js
+++ b/js/bookmarkConverter.js
@@ -40,7 +40,7 @@ const bookmarkConverter = {
       if (bookmark.getAttribute('tags')) {
         data.tags = data.tags.concat(bookmark.getAttribute('tags').split(','))
       }
-      places.updateItem(url)
+      places.updateItem(url, data)
     })
   },
   exportAll: function () {


### PR DESCRIPTION
On Windows (not sure about other OS), users are not able to import their old bookmarks from other browsers like Edge (haven't tried on Firefox). 
Ref #2444 

This patch fixes that issue. Now I can import and search through my bookmarks

![image](https://github.com/minbrowser/min/assets/83471520/ef808feb-8fb6-486a-a0f8-261d9c1353a8)
