### PR TITLE
Scroll to query when opening full-text search result

### DIFF
--- a/js/places/fullTextSearch.js
+++ b/js/places/fullTextSearch.js
@@ -327,6 +327,11 @@ function fullTextPlacesSearch (searchText, callback) {
         indexEnd++
       }
 
+      const actualSnippetBounds = [
+        maxBegin + mappedWords.slice(maxBegin, maxEnd + 1).findIndex(token => snippetSearchWords.includes(token)),
+        maxBegin + mappedWords.slice(maxBegin, maxEnd + 1).findLastIndex(token => snippetSearchWords.includes(token))
+      ]
+
       // include a few words before the start of the match
       maxBegin = maxBegin - 2
 
@@ -340,6 +345,11 @@ function fullTextPlacesSearch (searchText, callback) {
 
       const snippet = snippetIndex.slice(maxBegin, maxEnd + 5).join(' ')
       if (snippet) {
+        doc.searchFragment = {
+          contextBefore: snippetIndex[actualSnippetBounds[0] - 1],
+          fragment: snippetIndex.slice(actualSnippetBounds[0], actualSnippetBounds[1] + 1).join(' '),
+          contextAfter: snippetIndex[actualSnippetBounds[1] + 1]
+        }
         doc.searchSnippet = snippet + '...'
       }
 

--- a/js/places/places.js
+++ b/js/places/places.js
@@ -34,7 +34,7 @@ const places = {
       const tab = tabs.get(tabId)
       if (tab) {
         const data = {
-          url: urlParser.getSourceURL(tab.url), // for PDF viewer and reader mode, save the original page URL and not the viewer URL
+          url: urlParser.removeTextFragment(urlParser.getSourceURL(tab.url)), // for PDF viewer and reader mode, save the original page URL and not the viewer URL
           title: tab.title,
           color: tab.backgroundColor,
           extractedText: extractedText

--- a/js/searchbar/placesPlugin.js
+++ b/js/searchbar/placesPlugin.js
@@ -73,8 +73,22 @@ async function showSearchbarPlaceResults (text, input, event, pluginName = 'plac
       }
     }
 
+    var url = result.url
+
+    if (result.searchFragment && pluginName === 'fullTextPlaces' && !url.includes('#')) {
+      var fragment = '#:~:text='
+      if (result.searchFragment.contextBefore) {
+        fragment += encodeURIComponent(result.searchFragment.contextBefore).replace(/-/g, '%2d') + '-,'
+      }
+      fragment += encodeURIComponent(result.searchFragment.fragment).replace(/-/g, '%2d')
+      if (result.searchFragment.contextAfter) {
+        fragment += ',-' + encodeURIComponent(result.searchFragment.contextAfter).replace(/-/g, '%2d')
+      }
+      url += fragment
+    }
+
     var data = {
-      url: result.url,
+      url: url,
       metadata: result.tags,
       descriptionBlock: result.searchSnippet,
       highlightedTerms: (result.searchSnippet ? text.toLowerCase().split(' ').filter(t => t.length > 0) : []),

--- a/js/util/urlParser.js
+++ b/js/util/urlParser.js
@@ -174,6 +174,16 @@ var urlParser = {
     const domain = removeWWW(urlParser.getDomain(url)) // list has no subdomains
 
     return httpsTopSites.includes(domain)
+  },
+  removeTextFragment: function (url) {
+    try {
+      var parsedURL = new URL(url)
+      if (parsedURL.hash.startsWith('#:~:text=')) {
+        parsedURL.hash = ''
+        return parsedURL.toString()
+      }
+    } catch (e) {}
+    return url
   }
 }
 


### PR DESCRIPTION
This uses the [text fragment API](https://developer.mozilla.org/en-US/docs/Web/URI/Fragment/Text_fragments) to generate a fragment based on the search query; Chromium will then try to scroll to the correct place in the page when the URL is opened.

This may not work in all cases (eg for certain combinations of special characters it may fail), but it works on the pages I've tested so far.


https://github.com/user-attachments/assets/8fd7b216-10df-4695-b3a2-5392f9812efb

