### PR TITLE
Improve searchbar keyboard event handling

### DIFF
--- a/js/navbar/tabEditor.js
+++ b/js/navbar/tabEditor.js
@@ -93,11 +93,11 @@ const tabEditor = {
 
     keyboardNavigationHelper.addToGroup('searchbar', tabEditor.container)
 
-    // keypress doesn't fire on delete key - use keyup instead
-    tabEditor.input.addEventListener('keyup', function (e) {
-      if (e.keyCode === 8) {
-        searchbar.showResults(this.value, e)
-      }
+    tabEditor.input.addEventListener('input', function (e) {
+      // handles all inputs except for the case where the selection is moved (since we call preventDefault() there)
+      searchbar.showResults(this.value, {
+        isDeletion: e.inputType.includes('delete')
+      })
     })
 
     tabEditor.input.addEventListener('keypress', function (e) {
@@ -109,27 +109,15 @@ const tabEditor = {
         } else {
           searchbar.openURL(this.value, e)
         }
-      } else if (e.keyCode === 9) {
-        return
-        // tab key, do nothing - in keydown listener
-      } else if (e.keyCode === 16) {
-        return
-        // shift key, do nothing
-      } else if (e.keyCode === 8) {
-        return
-        // delete key is handled in keyUp
-      } else { // show the searchbar
-        searchbar.showResults(this.value, e)
+        e.preventDefault()
       }
 
       // on keydown, if the autocomplete result doesn't change, we move the selection instead of regenerating it to avoid race conditions with typing. Adapted from https://github.com/patrickburke/jquery.inlineComplete
 
-      var v = e.key
-      var sel = this.value.substring(this.selectionStart, this.selectionEnd).indexOf(v)
-
-      if (v && sel === 0) {
+      if (e.key && this.selectionEnd === this.value.length && this.value[this.selectionStart] === e.key) {
         this.selectionStart += 1
         e.preventDefault()
+        searchbar.showResults(this.value.substring(0, this.selectionStart), {})
       }
     })
 

--- a/js/searchbar/bangsPlugin.js
+++ b/js/searchbar/bangsPlugin.js
@@ -71,7 +71,7 @@ function incrementBangCount (bang) {
 }
 
 // results is an array of {phrase, snippet, image}
-function showBangSearchResults (text, results, input, event, limit = 5) {
+function showBangSearchResults (text, results, input, inputFlags, limit = 5) {
   searchbarPlugins.reset('bangs')
 
   results.sort(function (a, b) {
@@ -113,7 +113,7 @@ function showBangSearchResults (text, results, input, event, limit = 5) {
 
         // show search suggestions for custom bangs
         if (result.showSuggestions) {
-          result.showSuggestions('', input, event)
+          result.showSuggestions('', input, inputFlags)
         }
       }, 66)
     }
@@ -122,14 +122,14 @@ function showBangSearchResults (text, results, input, event, limit = 5) {
   })
 }
 
-function getBangSearchResults (text, input, event) {
+function getBangSearchResults (text, input, inputFlags) {
   // if there is a space in the text, show bang search suggestions (only supported for custom bangs)
 
   if (text.indexOf(' ') !== -1) {
     var bang = getCustomBang(text)
 
     if (bang && bang.showSuggestions) {
-      bang.showSuggestions(text.replace(bang.phrase, '').trimLeft(), input, event)
+      bang.showSuggestions(text.replace(bang.phrase, '').trimLeft(), input, inputFlags)
       return
     } else if (text.trim().indexOf(' ') !== -1) {
       searchbarPlugins.reset('bangs')
@@ -167,18 +167,18 @@ function getBangSearchResults (text, input, event) {
     }
     results = results.concat(searchCustomBangs(text))
     if (text === '!') {
-      showBangSearchResults(text, results, input, event)
+      showBangSearchResults(text, results, input, inputFlags)
       searchbarPlugins.addResult('bangs', {
         title: l('showMoreBangs'),
         icon: 'carbon:chevron-down',
         click: function () {
-          showBangSearchResults(text, results, input, event, Infinity)
+          showBangSearchResults(text, results, input, inputFlags, Infinity)
         }
       })
     } else {
-      showBangSearchResults(text, results, input, event)
+      showBangSearchResults(text, results, input, inputFlags)
 
-      if (results[0] && event.keyCode !== 8) {
+      if (results[0] && !inputFlags.isDeletion) {
         searchbarAutocomplete.autocomplete(input, [results[0].phrase])
       }
     }

--- a/js/searchbar/calculatorPlugin.js
+++ b/js/searchbar/calculatorPlugin.js
@@ -30,7 +30,7 @@ const validRegex = new RegExp(
   })+$`
 )
 
-function doMath (text, input, event) {
+function doMath (text, input, inputFlags) {
   searchbarPlugins.reset('calculatorPlugin')
   var result
 

--- a/js/searchbar/instantAnswerPlugin.js
+++ b/js/searchbar/instantAnswerPlugin.js
@@ -59,7 +59,7 @@ var instantAnswers = {
   }
 }
 
-function showSearchbarInstantAnswers (text, input, event) {
+function showSearchbarInstantAnswers (text, input, inputFlags) {
   // only make requests to the DDG api if DDG is set as the search engine
   if (searchEngine.getCurrent().name !== 'DuckDuckGo') {
     return
@@ -151,7 +151,7 @@ function showSearchbarInstantAnswers (text, input, event) {
       if (searchbarPlugins.getTopAnswer()) {
         searchbarPlugins.addResult('instantAnswers', suggestedSiteData)
       } else {
-        if (event && event.keyCode !== 8) {
+        if (!inputFlags.isDeletion) {
           // don't autocomplete if delete key pressed
           const autocompletionType = searchbarAutocomplete.autocompleteURL(input, url)
 

--- a/js/searchbar/openTabsPlugin.js
+++ b/js/searchbar/openTabsPlugin.js
@@ -4,7 +4,7 @@ var urlParser = require('util/urlParser.js')
 
 const quickScore = require('quick-score').quickScore
 
-var searchOpenTabs = function (text, input, event) {
+var searchOpenTabs = function (text, input, inputFlags) {
   searchbarPlugins.reset('openTabs')
 
   var matches = []

--- a/js/searchbar/placeSuggestionsPlugin.js
+++ b/js/searchbar/placeSuggestionsPlugin.js
@@ -4,7 +4,7 @@ var urlParser = require('util/urlParser.js')
 
 var places = require('places/places.js')
 
-async function showPlaceSuggestions (text, input, event) {
+async function showPlaceSuggestions (text, input, inputFlags) {
   // use the current tab's url for history suggestions, or the previous tab if the current tab is empty
   var url = tabs.get(tabs.getSelected()).url
 

--- a/js/searchbar/placesPlugin.js
+++ b/js/searchbar/placesPlugin.js
@@ -10,7 +10,7 @@ var searchEngine = require('util/searchEngine.js')
 
 var currentResponseSent = 0
 
-async function showSearchbarPlaceResults (text, input, event, pluginName = 'places') {
+async function showSearchbarPlaceResults (text, input, inputFlags, pluginName = 'places') {
   var responseSent = Date.now()
 
   var searchFn, resultCount
@@ -23,7 +23,7 @@ async function showSearchbarPlaceResults (text, input, event, pluginName = 'plac
   }
 
   // only autocomplete an item if the delete key wasn't pressed
-  var canAutocomplete = event && event.keyCode !== 8
+  var canAutocomplete = !inputFlags.isDeletion
 
   let results = await searchFn(text)
 

--- a/js/searchbar/searchSuggestionsPlugin.js
+++ b/js/searchbar/searchSuggestionsPlugin.js
@@ -3,7 +3,7 @@ var searchbarPlugins = require('searchbar/searchbarPlugins.js')
 var urlParser = require('util/urlParser.js')
 var searchEngine = require('util/searchEngine.js')
 
-function showSearchSuggestions (text, input, event) {
+function showSearchSuggestions (text, input, inputFlags) {
     const suggestionsURL = searchEngine.getCurrent().suggestionsURL
 
   if (!suggestionsURL) {

--- a/js/searchbar/searchbar.js
+++ b/js/searchbar/searchbar.js
@@ -33,18 +33,8 @@ var searchbar = {
     var text = searchbar.associatedInput.value
     return text.replace(text.substring(searchbar.associatedInput.selectionStart, searchbar.associatedInput.selectionEnd), '')
   },
-  showResults: function (text, event) {
-    // find the real input value, accounting for highlighted suggestions and the key that was just pressed
-    // delete key doesn't behave like the others, String.fromCharCode returns an unprintable character (which has a length of one)
-
-    var realText
-    if (event && event.keyCode !== 8) {
-      realText = text.substring(0, searchbar.associatedInput.selectionStart) + event.key + text.substring(searchbar.associatedInput.selectionEnd, text.length)
-    } else {
-      realText = text
-    }
-
-    searchbarPlugins.run(realText, searchbar.associatedInput, event)
+  showResults: function (text, inputFlags = {}) {
+    searchbarPlugins.run(text, searchbar.associatedInput, inputFlags)
   },
   openURL: function (url, event) {
     var hasURLHandler = searchbarPlugins.runURLHandlers(url)

--- a/js/searchbar/searchbarPlugins.js
+++ b/js/searchbar/searchbarPlugins.js
@@ -140,11 +140,11 @@ const searchbarPlugins = {
     results[name] = []
   },
 
-  run: function (text, input, event) {
+  run: function (text, input, inputFlags) {
     for (var i = 0; i < plugins.length; i++) {
       try {
         if (plugins[i].showResults && (!plugins[i].trigger || plugins[i].trigger(text))) {
-          plugins[i].showResults(text, input, event)
+          plugins[i].showResults(text, input, inputFlags)
         } else {
           searchbarPlugins.reset(plugins[i].name)
         }

--- a/js/searchbar/shortcutButtons.js
+++ b/js/searchbar/shortcutButtons.js
@@ -16,7 +16,7 @@ const shortcuts = [
   }
 ]
 
-function showShortcutButtons (text, input, event) {
+function showShortcutButtons (text, input, inputFlags) {
   var container = searchbarPlugins.getContainer('shortcutButtons')
 
   searchbarPlugins.reset('shortcutButtons')

--- a/js/searchbar/updateNotifications.js
+++ b/js/searchbar/updateNotifications.js
@@ -43,7 +43,7 @@ function getAvailableUpdates () {
   }
 }
 
-function showUpdateNotification (text, input, event) {
+function showUpdateNotification (text, input, inputFlags) {
   function displayUpdateNotification () {
     searchbarPlugins.reset('updateNotifications')
     searchbarPlugins.addResult('updateNotifications', {


### PR DESCRIPTION
...by using `input` rather than `keydown`. This should solve some bugs with text input - for example, pasting text or picking a character with an IME now updates the results correctly.