### PR TITLE
Use atomic writes for session restore

### DIFF
--- a/js/util/settings/settingsMain.js
+++ b/js/util/settings/settingsMain.js
@@ -1,3 +1,5 @@
+const writeFileAtomic = require('write-file-atomic')
+
 var settings = {
   filePath: null,
   fileWritePromise: null,
@@ -13,7 +15,15 @@ var settings = {
 
     /* eslint-disable no-inner-declarations */
     function newFileWrite () {
-      return fs.promises.writeFile(settings.filePath, JSON.stringify(settings.list))
+      return new Promise(function (resolve, reject) {
+        writeFileAtomic(settings.filePath, JSON.stringify(settings.list), {}, function (err) {
+          if (err) {
+            reject(err)
+          } else {
+            resolve()
+          }
+        })
+      })
     }
 
     function ongoingFileWrite () {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "quick-score": "^0.2.0",
     "regedit": "^3.0.3",
     "sortablejs": "^1.15.1",
-    "stemmer": "^1.0.5"
+    "stemmer": "^1.0.5",
+    "write-file-atomic": "^6.0.0"
   },
   "devDependencies": {
     "archiver": "^4.0.1",

--- a/scripts/buildBrowser.js
+++ b/scripts/buildBrowser.js
@@ -34,6 +34,7 @@ function buildBrowser () {
   })
 
   instance.exclude('chokidar')
+  instance.exclude('write-file-atomic')
 
   instance.transform(renderify)
   const stream = fs.createWriteStream(outFile, { encoding: 'utf-8' })


### PR DESCRIPTION
Recently, there's been a couple reports of Min losing session restore data unexpectedly (#2519, #2527, also #2503 and https://discord.com/channels/764269005195968512/764544014259060797/1305916870473547776 which may or may not be related).

I'm not currently sure what the cause(s) of these are, as nothing has changed recently in this code, but this PR updates session restore to write the file atomically, which should mean that we can always re-launch with a valid restore file even if something goes wrong during the write. I also added some metrics collection for write failures and restoration failures to try to understand if this is a widespread issue.

It's possible that this is slower than a standard write, which mainly impacts shutdown times, as we write the file synchronously before exiting. In my very limited experimentation it doesn't seem to be too bad though.

If this resolves the issue, we could also extend this approach to the settings file, about which we've also had similar reports. That data is less critical though, so the performance vs reliability tradeoff may be different there.