### PR TITLE
Update the browser debugging menu

### DIFF
--- a/js/searchbar/developmentModeNotification.js
+++ b/js/searchbar/developmentModeNotification.js
@@ -9,7 +9,8 @@ function initialize () {
     showResults: function () {
       searchbarPlugins.reset('developmentModeNotification')
       searchbarPlugins.addResult('developmentModeNotification', {
-        title: 'Development Mode Enabled'
+        title: 'Development Mode Enabled',
+        icon: 'carbon:warning-alt'
       })
     }
   })

--- a/main/main.js
+++ b/main/main.js
@@ -31,6 +31,7 @@ if (process.argv.some(arg => arg === '-v' || arg === '--version')) {
 
 let isInstallerRunning = false
 const isDevelopmentMode = process.argv.some(arg => arg === '--development-mode')
+const isDebuggingEnabled = process.argv.some(arg => arg === '--debug-browser')
 
 function clamp (n, min, max) {
   return Math.max(Math.min(n, max), min)

--- a/main/menu.js
+++ b/main/menu.js
@@ -317,30 +317,36 @@ function buildAppMenu (options = {}) {
             sendIPCToWindow(window, 'inspectPage')
           }
         },
-        {
-          type: 'separator'
-        },
-        ...(isDevelopmentMode ?
+        ...(isDevelopmentMode || isDebuggingEnabled ?
           [
+            {
+              type: 'separator'
+            },
             {
               label: l('appMenuReloadBrowser'),
               accelerator: (isDevelopmentMode ? 'alt+CmdOrCtrl+R' : undefined),
               click: function (item, focusedWindow) {
-                  destroyAllViews()
-                  windows.getAll().forEach(win => win.close())
-                  createWindow()
+                destroyAllViews()
+                windows.getAll().forEach(win => win.close())
+                createWindow()
               }
             },
-          ] : []),
-        {
-          label: l('appMenuInspectBrowser'),
-          accelerator: (function () {
-            if (process.platform === 'darwin') { return 'Shift+Cmd+Alt+I' } else { return 'Ctrl+Shift+Alt+I' }
-          })(),
-          click: function (item, focusedWindow) {
-            if (focusedWindow) focusedWindow.toggleDevTools()
-          }
-        }
+            {
+              label: l('appMenuInspectBrowser'),
+              accelerator: (function () {
+                if (process.platform === 'darwin') { return 'Shift+Cmd+Alt+I' } else { return 'Ctrl+Shift+Alt+I' }
+              })(),
+              click: function (item, focusedWindow) {
+                if (focusedWindow) focusedWindow.toggleDevTools()
+              }
+            },
+            {
+              label: 'Inspect Places Service',
+              click: function (item, focusedWindow) {
+                placesWindow.webContents.openDevTools({ mode: 'detach' })
+              }
+            }
+          ] : [])
       ]
     },
     ...(process.platform === 'darwin' ? [


### PR DESCRIPTION
* Added an option to open the devtools for the places service, which might help with debugging #2503.
* Changed the browser devtools options to appear only when Min is run with the `--debug-browser` argument, or with the existing `--development-mode`.
  * Having these options appear during regular usage is somewhat confusing (it's possible to get mixed up between the browser devtools and the page devtools), and also a potential source of security issues - if someone can be convinced to paste malicious code into the browser devtools, the consequences are quite bad. I don't know of any specific instances of this happening, but it seems worthwhile to address preemptively.

Normal mode:

![Screenshot 2024-12-01 at 9 04 40 AM](https://github.com/user-attachments/assets/97e28238-06fe-4af8-b8ea-08e29d5de2f8)

Debug mode:

![Screenshot 2024-12-01 at 9 04 47 AM](https://github.com/user-attachments/assets/3432d31c-12a6-411e-8270-997f2c7485c3)
