### PR TITLE
Can import / export credentials from built-in password manager

### DIFF
--- a/css/passwordViewer.css
+++ b/css/passwordViewer.css
@@ -38,3 +38,17 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+#password-viewer-export, #password-viewer-import {
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+  opacity: 0.7;
+  margin-inline: auto;
+  margin-top: 0.5em;
+}
+
+#password-viewer-export:hover, #password-viewer-import:hover {
+  opacity: 1;
+}

--- a/css/passwordViewer.css
+++ b/css/passwordViewer.css
@@ -50,7 +50,7 @@
   cursor: pointer;
   display: flex;
   align-items: center;
-  gap: 0.5em;
+  gap: 0.25em;
   opacity: 0.7;
 }
 

--- a/css/passwordViewer.css
+++ b/css/passwordViewer.css
@@ -39,14 +39,19 @@
   text-overflow: ellipsis;
 }
 
+#password-viewer-import-container {
+  margin-top: 0.5em;
+  display: flex;
+  justify-content: center;
+  gap: 1em;
+}
+
 #password-viewer-export, #password-viewer-import {
   cursor: pointer;
   display: flex;
   align-items: center;
   gap: 0.5em;
   opacity: 0.7;
-  margin-inline: auto;
-  margin-top: 0.5em;
 }
 
 #password-viewer-export:hover, #password-viewer-import:hover {

--- a/index.html
+++ b/index.html
@@ -338,8 +338,8 @@
       ></div>
       <div id="password-viewer-list"></div>
       <div id="password-viewer-import-container">
-        <button id="password-viewer-import"><span data-string="importCredentials"></span><span class="i carbon:document-import"></span></button>
-        <button id="password-viewer-export"><span data-string="exportCredentials"></span><span class="i carbon:export"></span></button>
+        <button id="password-viewer-import"><span class="i carbon:document-import"></span><span data-string="importCredentials"></span></button>
+        <button id="password-viewer-export"><span class="i carbon:export"></span><span data-string="exportCredentials"></span></button>
 </div>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -337,8 +337,10 @@
         hidden
       ></div>
       <div id="password-viewer-list"></div>
-      <button id="password-viewer-export"><span data-string="exportCredentials"></span><span class="i carbon:export"></span></button>
-      <button id="password-viewer-import"><span data-string="importCredentials"></span><span class="i carbon:document-import"></span></button>
+      <div id="password-viewer-import-container">
+        <button id="password-viewer-import"><span data-string="importCredentials"></span><span class="i carbon:document-import"></span></button>
+        <button id="password-viewer-export"><span data-string="exportCredentials"></span><span class="i carbon:export"></span></button>
+</div>
     </div>
 
     <!-- add scripts in Gruntfile.js -->

--- a/index.html
+++ b/index.html
@@ -337,6 +337,8 @@
         hidden
       ></div>
       <div id="password-viewer-list"></div>
+      <button id="password-viewer-export"><span data-string="exportCredentials"></span><span class="i carbon:export"></span></button>
+      <button id="password-viewer-import"><span data-string="importCredentials"></span><span class="i carbon:document-import"></span></button>
     </div>
 
     <!-- add scripts in Gruntfile.js -->

--- a/js/passwordManager/keychain.js
+++ b/js/passwordManager/keychain.js
@@ -48,6 +48,27 @@ class Keychain {
     ipcRenderer.invoke('credentialStoreDeletePassword', { domain, username })
   }
 
+  async importCredentials () {
+    const filePaths = await ipc.invoke('showOpenDialog', {
+      filters: [
+        { name: 'JSON', extensions: ['json'] },
+        { name: 'All Files', extensions: ['*'] }
+      ]
+    })
+
+    if (!filePaths[0]) return
+
+    const file = fs.readFileSync(filePaths[0])
+    const { credentials } = JSON.parse(file)
+    if (credentials.length === 0 || !credentials[0].domain || !credentials[0].username || !credentials[0].password) {
+      return []
+    }
+
+    ipcRenderer.invoke('credentialStoreSetPasswordBulk', credentials)
+
+    return credentials
+  }
+
   getAllCredentials () {
     return ipcRenderer.invoke('credentialStoreGetCredentials').then(function (results) {
       return results.map(function (result) {

--- a/js/passwordManager/keychain.js
+++ b/js/passwordManager/keychain.js
@@ -61,13 +61,22 @@ class Keychain {
     try {
       const file = fs.readFileSync(filePaths[0], 'utf8')
       const lines = file.split('\n')
+      // get headers and normalize
+      const header = lines[0].split(',').map(h => h.toLowerCase().trim().replace(/["']/g, ''))
+      const urlPostion = header.indexOf('url')
+      const usernamePostion = header.indexOf('username')
+      const passwordPostion = header.indexOf('password')
+
+      if (urlPostion === -1 || usernamePostion === -1 || passwordPostion === -1) throw new Error('Invalid CSV file, csv file must contain a header with the following columns: url, username, password')
+
       const credentialsToImport = lines.slice(1).map(line => {
         const values = line.split(',')
-        if (values.length !== 3 || values.some(value => value === '')) return null
+        if (!values[urlPostion] || !values[usernamePostion] || !values[passwordPostion]) return null
+
         return {
-          domain: values[0],
-          username: values[1],
-          password: values[2]
+          domain: values[urlPostion],
+          username: values[usernamePostion],
+          password: values[passwordPostion]
         }
       }).filter(cred => cred !== null)
 

--- a/js/passwordManager/passwordViewer.js
+++ b/js/passwordManager/passwordViewer.js
@@ -87,6 +87,8 @@ const passwordViewer = {
     return container
   },
   _renderPasswordList: function (credentials) {
+    empty(passwordViewer.listContainer)
+
     credentials.forEach(function (cred) {
       passwordViewer.listContainer.appendChild(passwordViewer.createCredentialListElement(cred))
     })
@@ -102,7 +104,6 @@ const passwordViewer = {
   _updatePasswordListFooter: function () {
     const hasCredentials = (passwordViewer.listContainer.children.length !== 0)
     passwordViewer.emptyHeading.hidden = hasCredentials
-    passwordViewer.importButton.hidden = hasCredentials
     passwordViewer.exportButton.hidden = !hasCredentials
   },
   show: function () {
@@ -128,7 +129,17 @@ const passwordViewer = {
         throw new Error('unsupported password manager')
       }
 
+      const securityConsent = ipcRenderer.sendSync('prompt',{
+        text: l('importCredentialsConfirmation'),
+        ok: l('dialogConfirmButton'),
+        cancel: l('dialogCancelButton'),
+        width: 400,
+        height: 200
+      })
+      if (!securityConsent) return
+
       manager.importCredentials().then(function (credentials) {
+        if (credentials.length === 0) return
         passwordViewer._renderPasswordList(credentials)
       })
     })
@@ -166,7 +177,6 @@ const passwordViewer = {
   hide: function () {
     webviews.hidePlaceholder('passwordViewer')
     modalMode.toggle(false)
-    empty(passwordViewer.listContainer)
     passwordViewer.container.hidden = true
   },
   initialize: function () {

--- a/js/passwordManager/passwordViewer.js
+++ b/js/passwordManager/passwordViewer.js
@@ -2,6 +2,7 @@ const webviews = require('webviews.js')
 const settings = require('util/settings/settings.js')
 const PasswordManagers = require('passwordManager/passwordManager.js')
 const modalMode = require('modalMode.js')
+const { ipcRenderer } = require('electron')
 
 const passwordViewer = {
   container: document.getElementById('password-viewer'),
@@ -137,6 +138,15 @@ const passwordViewer = {
       if (!manager.getAllCredentials) {
         throw new Error('unsupported password manager')
       }
+
+      const securityConsent = ipcRenderer.sendSync('prompt',{
+        text: l('exportCredentialsConfirmation'),
+        ok: l('dialogConfirmButton'),
+        cancel: l('dialogCancelButton'),
+        width: 400,
+        height: 200
+      })
+      if (!securityConsent) return
 
       manager.getAllCredentials().then(function (credentials) {
         if (credentials.length === 0) return

--- a/js/passwordManager/passwordViewer.js
+++ b/js/passwordManager/passwordViewer.js
@@ -129,7 +129,7 @@ const passwordViewer = {
         throw new Error('unsupported password manager')
       }
 
-      const credentials = await manager.getAllCredentials();
+      const credentials = await manager.getAllCredentials()
       const shouldShowConsent = credentials.length > 0
 
       if (shouldShowConsent) {
@@ -179,7 +179,7 @@ const passwordViewer = {
         if (credentials.length === 0) return
 
         const header = 'url,username,password\n'
-        const csvData = header + credentials.map(credential => `${credential.domain},${credential.username},${credential.password}`).join('\n')
+        const csvData = header + credentials.map(credential => `https://${credential.domain},${credential.username},${credential.password}`).join('\n')
         const blob = new Blob([csvData], { type: 'text/csv' })
         const url = URL.createObjectURL(blob)
         const anchor = document.createElement('a')

--- a/js/passwordManager/passwordViewer.js
+++ b/js/passwordManager/passwordViewer.js
@@ -143,7 +143,18 @@ const passwordViewer = {
         if (!securityConsent) return
       }
 
-      manager.importCredentials().then(function (credentials) {
+      const filePaths = await ipcRenderer.invoke('showOpenDialog', {
+        filters: [
+          { name: 'CSV', extensions: ['csv'] },
+          { name: 'All Files', extensions: ['*'] }
+        ]
+      })
+
+      if (!filePaths || !filePaths[0]) return
+
+      const fileContents = fs.readFileSync(filePaths[0], 'utf8')
+
+      manager.importCredentials(fileContents).then(function (credentials) {
         if (credentials.length === 0) return
         passwordViewer._renderPasswordList(credentials)
       })

--- a/js/passwordManager/passwordViewer.js
+++ b/js/passwordManager/passwordViewer.js
@@ -3,6 +3,7 @@ const settings = require('util/settings/settings.js')
 const PasswordManagers = require('passwordManager/passwordManager.js')
 const modalMode = require('modalMode.js')
 const { ipcRenderer } = require('electron')
+const papaparse = require('papaparse')
 
 const passwordViewer = {
   container: document.getElementById('password-viewer'),
@@ -178,8 +179,14 @@ const passwordViewer = {
       manager.getAllCredentials().then(function (credentials) {
         if (credentials.length === 0) return
 
-        const header = 'url,username,password\n'
-        const csvData = header + credentials.map(credential => `https://${credential.domain},${credential.username},${credential.password}`).join('\n')
+        const csvData = papaparse.unparse({
+          fields: ['url', 'username', 'password'],
+          data: credentials.map(credential => [
+            `https://${credential.domain}`,
+            credential.username,
+            credential.password
+          ])
+        })
         const blob = new Blob([csvData], { type: 'text/csv' })
         const url = URL.createObjectURL(blob)
         const anchor = document.createElement('a')

--- a/js/passwordManager/passwordViewer.js
+++ b/js/passwordManager/passwordViewer.js
@@ -141,22 +141,13 @@ const passwordViewer = {
       manager.getAllCredentials().then(function (credentials) {
         if (credentials.length === 0) return
 
-        const credentialsWithoutManager = credentials.map(function (credential) {
-          return {
-            domain: credential.domain,
-            username: credential.username,
-            password: credential.password
-          }
-        })
-
-        const blob = new Blob([JSON.stringify({
-          version: 1,
-          credentials: credentialsWithoutManager
-        }, null, 2)], { type: 'application/json' })
+        const header = 'url,username,password\n'
+        const csvData = header + credentials.map(credential => `${credential.domain},${credential.username},${credential.password}`).join('\n')
+        const blob = new Blob([csvData], { type: 'text/csv' })
         const url = URL.createObjectURL(blob)
         const anchor = document.createElement('a')
         anchor.href = url
-        anchor.download = 'credentials.json'
+        anchor.download = 'credentials.csv'
         anchor.click()
         URL.revokeObjectURL(url)
       })

--- a/js/passwordManager/passwordViewer.js
+++ b/js/passwordManager/passwordViewer.js
@@ -129,7 +129,7 @@ const passwordViewer = {
         throw new Error('unsupported password manager')
       }
 
-      const securityConsent = ipcRenderer.sendSync('prompt',{
+      const securityConsent = ipcRenderer.sendSync('prompt', {
         text: l('importCredentialsConfirmation'),
         ok: l('dialogConfirmButton'),
         cancel: l('dialogCancelButton'),
@@ -150,7 +150,7 @@ const passwordViewer = {
         throw new Error('unsupported password manager')
       }
 
-      const securityConsent = ipcRenderer.sendSync('prompt',{
+      const securityConsent = ipcRenderer.sendSync('prompt', {
         text: l('exportCredentialsConfirmation'),
         ok: l('dialogConfirmButton'),
         cancel: l('dialogCancelButton'),

--- a/localization/languages/en-US.json
+++ b/localization/languages/en-US.json
@@ -299,6 +299,7 @@
     "exportCredentials": "Export credentials",
     "importCredentials": "Import credentials",
     "exportCredentialsConfirmation": "When you export your passwords, they will be saved to a file with readable text. When you're done using this file, we recommend deleting it. Are you sure you want to continue?",
+    "importCredentialsConfirmation": "Importing passwords will overwrite any existing passwords for the same sites. Are you sure you want to continue?",
     /* Dialogs */
     "loginPromptTitle": "Sign in to %h", //%h is replaced with host, %r with realm (title of protected part of site)
     "dialogConfirmButton": "Confirm",

--- a/localization/languages/en-US.json
+++ b/localization/languages/en-US.json
@@ -298,6 +298,7 @@
     "deletePassword": "Delete password for %s?",
     "exportCredentials": "Export credentials",
     "importCredentials": "Import credentials",
+    "exportCredentialsConfirmation": "When you export your passwords, they will be saved to a file with readable text. When you're done using this file, we recommend deleting it. Are you sure you want to continue?",
     /* Dialogs */
     "loginPromptTitle": "Sign in to %h", //%h is replaced with host, %r with realm (title of protected part of site)
     "dialogConfirmButton": "Confirm",

--- a/localization/languages/en-US.json
+++ b/localization/languages/en-US.json
@@ -298,7 +298,7 @@
     "deletePassword": "Delete password for %s?",
     "exportCredentials": "Export credentials",
     "importCredentials": "Import credentials",
-    "exportCredentialsConfirmation": "When you export your passwords, they will be saved to a file with readable text. When you're done using this file, we recommend deleting it. Are you sure you want to continue?",
+    "exportCredentialsConfirmation": "Your exported credentials will be saved in a file in plain text. When you're done using this file, you should delete it. Are you sure you want to continue?",
     "importCredentialsConfirmation": "Importing passwords will overwrite any existing passwords for the same sites. Are you sure you want to continue?",
     /* Dialogs */
     "loginPromptTitle": "Sign in to %h", //%h is replaced with host, %r with realm (title of protected part of site)

--- a/localization/languages/en-US.json
+++ b/localization/languages/en-US.json
@@ -296,6 +296,8 @@
     "savedPasswordsEmpty": "No saved passwords.",
     "savedPasswordsNeverSavedLabel": "Never saved",
     "deletePassword": "Delete password for %s?",
+    "exportCredentials": "Export credentials",
+    "importCredentials": "Import credentials",
     /* Dialogs */
     "loginPromptTitle": "Sign in to %h", //%h is replaced with host, %r with realm (title of protected part of site)
     "dialogConfirmButton": "Confirm",

--- a/localization/languages/nl.json
+++ b/localization/languages/nl.json
@@ -297,6 +297,7 @@
     "deletePassword": "Verwijder wachtwoord voor %s?",
     "exportCredentials": "Exporteer wachtwoorden",
     "importCredentials": "Importeer wachtwoorden",
+    "exportCredentialsConfirmation": "Wanneer u uw wachtwoorden exporteert, worden ze opgeslagen in een bestand met leesbare tekst. Wanneer u dit bestand klaar bent, raden wij u het te verwijderen. Weet u zeker dat u wilt doorgaan?",
     /* Dialogs */
     "loginPromptTitle": "Inloggen bij %h", //%h is replaced with host, %r with realm (title of protected part of site)
     "dialogConfirmButton": "Bevestigen",

--- a/localization/languages/nl.json
+++ b/localization/languages/nl.json
@@ -298,6 +298,7 @@
     "exportCredentials": "Exporteer wachtwoorden",
     "importCredentials": "Importeer wachtwoorden",
     "exportCredentialsConfirmation": "Wanneer u uw wachtwoorden exporteert, worden ze opgeslagen in een bestand met leesbare tekst. Wanneer u dit bestand klaar bent, raden wij u het te verwijderen. Weet u zeker dat u wilt doorgaan?",
+    "importCredentialsConfirmation": "Het importeren van wachtwoorden overschrijft alle bestaande wachtwoorden voor dezelfde sites. Weet u zeker dat u wilt doorgaan?",
     /* Dialogs */
     "loginPromptTitle": "Inloggen bij %h", //%h is replaced with host, %r with realm (title of protected part of site)
     "dialogConfirmButton": "Bevestigen",

--- a/localization/languages/nl.json
+++ b/localization/languages/nl.json
@@ -297,7 +297,7 @@
     "deletePassword": "Verwijder wachtwoord voor %s?",
     "exportCredentials": "Exporteer wachtwoorden",
     "importCredentials": "Importeer wachtwoorden",
-    "exportCredentialsConfirmation": "Wanneer u uw wachtwoorden exporteert, worden ze opgeslagen in een bestand met leesbare tekst. Wanneer u dit bestand klaar bent, raden wij u het te verwijderen. Weet u zeker dat u wilt doorgaan?",
+    "exportCredentialsConfirmation": "Uw geëxporteerde wachtwoorden worden opgeslagen in een bestand in leesbare tekst. Als u dit bestand niet meer gebruikt, is het aan te raden om het bestand te verwijderen. Weet u zeker dat u wilt doorgaan?",
     "importCredentialsConfirmation": "Het importeren van wachtwoorden overschrijft alle bestaande wachtwoorden voor dezelfde sites. Weet u zeker dat u wilt doorgaan?",
     /* Dialogs */
     "loginPromptTitle": "Inloggen bij %h", //%h is replaced with host, %r with realm (title of protected part of site)

--- a/localization/languages/nl.json
+++ b/localization/languages/nl.json
@@ -295,6 +295,8 @@
     "savedPasswordsEmpty": "Geen opgeslagen wachtwoorden.",
     "savedPasswordsNeverSavedLabel": "Nooit opgeslagen",
     "deletePassword": "Verwijder wachtwoord voor %s?",
+    "exportCredentials": "Exporteer wachtwoorden",
+    "importCredentials": "Importeer wachtwoorden",
     /* Dialogs */
     "loginPromptTitle": "Inloggen bij %h", //%h is replaced with host, %r with realm (title of protected part of site)
     "dialogConfirmButton": "Bevestigen",

--- a/main/keychainService.js
+++ b/main/keychainService.js
@@ -41,6 +41,24 @@ function writeSavedPasswordFile (content) {
   fs.writeFileSync(passwordFilePath, safeStorage.encryptString(JSON.stringify(content)))
 }
 
+function credentialStoreSetPasswordBulk (accounts) {
+  const fileContent = readSavedPasswordFile()
+
+  // delete duplicate credentials
+  for (let i = 0; i < fileContent.credentials.length; i++) {
+    for (let j = 0; j < accounts.length; j++) {
+      if (fileContent.credentials[i].domain === accounts[j].domain && fileContent.credentials[i].username === accounts[j].username) {
+        fileContent.credentials.splice(i, 1)
+        i--
+      }
+    }
+    accounts.splice(j, 1)
+  }
+
+  fileContent.credentials = fileContent.credentials.concat(accounts)
+  writeSavedPasswordFile(fileContent)
+}
+
 function credentialStoreSetPassword (account) {
   const fileContent = readSavedPasswordFile()
 
@@ -55,6 +73,10 @@ function credentialStoreSetPassword (account) {
   fileContent.credentials.push(account)
   writeSavedPasswordFile(fileContent)
 }
+
+ipc.handle('credentialStoreSetPasswordBulk', async function (event, accounts) {
+  return credentialStoreSetPasswordBulk(accounts)
+})
 
 ipc.handle('credentialStoreSetPassword', async function (event, account) {
   return credentialStoreSetPassword(account)

--- a/main/keychainService.js
+++ b/main/keychainService.js
@@ -44,18 +44,7 @@ function writeSavedPasswordFile (content) {
 function credentialStoreSetPasswordBulk (accounts) {
   const fileContent = readSavedPasswordFile()
 
-  // delete duplicate credentials
-  for (let i = 0; i < fileContent.credentials.length; i++) {
-    for (let j = 0; j < accounts.length; j++) {
-      if (fileContent.credentials[i].domain === accounts[j].domain && fileContent.credentials[i].username === accounts[j].username) {
-        fileContent.credentials.splice(i, 1)
-        i--
-      }
-    }
-    accounts.splice(j, 1)
-  }
-
-  fileContent.credentials = fileContent.credentials.concat(accounts)
+  fileContent.credentials = accounts
   writeSavedPasswordFile(fileContent)
 }
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "electron-squirrel-startup": "^1.0.0",
     "expr-eval": "^2.0.2",
     "node-abi": "^3.8.0",
+    "papaparse": "^5.5.1",
     "pdfjs-dist": "4.2.67",
     "quick-score": "^0.2.0",
     "regedit": "^3.0.3",


### PR DESCRIPTION
Allows you to import / export credentials from the built-in password manager.

It will import / export using the same schema the built-in password manager uses to store the credentials which is the following:

```json
{
  "version": 1,
  "credentials": [
    {
      "domain": "google.com",
      "username": "Google User",
      "password": "123456"
    },
    {
      "domain": "github.com",
      "username": "Github User",
      "password": "123456"
    }
  ]
}
```

Currently it will only let you import if you have 0 passwords and only export if you have more than 1 password. We might want to do some merge thing but I didn't want to do that yet since that could go a couple ways, e.g. override, merge.

Also refactored some "render to dom" functionality into separate functions.

Let me know what you think.