### PR TITLE
LLM integration proof-of-concept

### DIFF
--- a/main/llmService.mjs
+++ b/main/llmService.mjs
@@ -1,0 +1,50 @@
+import { getLlama, LlamaChatSession } from 'node-llama-cpp'
+
+process.parentPort.on('message', (e) => {
+  e.ports[0].addListener('message', function (e2) {
+    console.log(e2)
+    handleRequest(e2.data).then(res => e.ports[0].postMessage(res))
+  })
+  e.ports[0].start()
+})
+
+let model
+let context
+let session
+
+async function ensureModelLoaded () {
+  if (!model) {
+    console.log('run')
+    const llama = await getLlama()
+    console.log('loaded')
+    model = await llama.loadModel({
+      // TODO update
+      // modelPath: 'Llama-3.2-1B-Instruct-Q6_K_L.gguf'
+      // modelPath: 'Llama-3.2-3B-Instruct-Q4_K_M.gguf'
+    })
+    context = await model.createContext()
+    session = new LlamaChatSession({
+      contextSequence: context.getSequence()
+    })
+  }
+}
+
+async function handleRequest (data) {
+  console.log(data)
+
+  await ensureModelLoaded()
+
+  if (data.action === 'run') {
+    console.log("input: " + decodeURIComponent(data.input))
+    const result = await session.prompt(decodeURIComponent(data.input))
+
+    console.log('result: ' + result)
+
+    session.resetChatHistory()
+
+    return {
+      result,
+      callbackId: data.callbackId
+    }
+  }
+}

--- a/main/main.js
+++ b/main/main.js
@@ -16,7 +16,9 @@ const {
   nativeTheme,
   shell,
   net,
-  WebContentsView
+  WebContentsView,
+  utilityProcess,
+  MessageChannelMain
 } = electron
 
 crashReporter.start({
@@ -495,3 +497,12 @@ ipc.on('places-connect', function (e) {
 function getWindowWebContents (win) {
   return win.getContentView().children[0].webContents
 }
+
+app.on('ready', () => {
+  // Main process
+  const llmServiceProcess = utilityProcess.fork(path.join(__dirname, "main/llmService.mjs"))
+
+  ipc.on('llm-service-connect', function(e) {
+    llmServiceProcess.postMessage({message: 'init'}, e.ports)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "electron-squirrel-startup": "^1.0.0",
     "expr-eval": "^2.0.2",
     "node-abi": "^3.8.0",
+    "node-llama-cpp": "^3.3.2",
     "pdfjs-dist": "4.2.67",
     "quick-score": "^0.2.0",
     "regedit": "^3.0.3",


### PR DESCRIPTION
This PR sets up the basic infrastructure to run an LLM inside Min using [node-llama-cpp](https://node-llama-cpp.withcat.ai/) inside a utility process. Any llama.cpp-formatted model file should work; the model can be configured by updating `modelPath` inside `llmService.mjs`. My testing so far has been with either [this model](https://huggingface.co/bartowski/Llama-3.2-1B-Instruct-GGUF) or [this one](https://huggingface.co/bartowski/Llama-3.2-3B-Instruct-GGUF).

My original intent with this was to see if it was possible to generate high-quality page summaries to display in the searchbar. Unfortunately, with llama-3.2-1b, the quality of the summaries seems quite poor. llama-3.2-3b does much better, but keeping the model loaded requires around 5GB of memory. I think this means that any use case that requires the model to continually be loaded in the background is infeasible, but it might work in a situation where the user explicitly requests to use it, which would allow us to load the model for a brief period of time and then immediately unload it. I'm planning to experiment with language translation (replacing the current cloud-based version) and with an explicit "summarize page" command, but if anyone has additional ideas for where this could be useful, I'd be happy to test them.