### PR TITLE
feat: Add hide translate menu setting

### DIFF
--- a/js/webviewMenu.js
+++ b/js/webviewMenu.js
@@ -347,7 +347,9 @@ const webviewMenu = {
       }
     })
 
-    menuSections.push([translateMenu])
+    if (!settings.get('hideTranslateMenu')) {
+     menuSections.push([translateMenu])
+    }
 
     // Electron's default menu position is sometimes wrong on Windows with a touchscreen
     // https://github.com/minbrowser/min/issues/903

--- a/localization/languages/en-US.json
+++ b/localization/languages/en-US.json
@@ -164,6 +164,7 @@
     "settingsLanguageSelection": "Language: ",
     "settingsSeparateTitlebarToggle": "Use separate title bar",
     "settingsAutoplayToggle": "Enable Autoplay",
+    "settingsHideTranslateMenu": "Hide page translation in context menu",
     "settingsOpenTabsInForegroundToggle": "Open new tabs in the foreground",
     "settingsUserscriptsExplanation": {
       "unsafeHTML": "User scripts allow you to modify the behavior of websites - <a href=\"https://github.com/minbrowser/min/wiki/userscripts\">learn more</a>."

--- a/pages/settings/index.html
+++ b/pages/settings/index.html
@@ -215,6 +215,11 @@
 			<input type="checkbox" id="checkbox-enable-autoplay">
 			<label for="checkbox-enable-autoplay" data-string="settingsAutoplayToggle"></label>
 		</div>
+		
+		<div class="setting-section">
+            <input type="checkbox" id="checkbox-hide-translate-menu" />
+            <label for="checkbox-hide-translate-menu" data-string="settingsHideTranslateMenu"></label>
+        </div>
 
       <div class="setting-section">
         <input type="checkbox" id="checkbox-update-notifications" />

--- a/pages/settings/settings.js
+++ b/pages/settings/settings.js
@@ -10,6 +10,7 @@ var separateTitlebarCheckbox = document.getElementById('checkbox-separate-titleb
 var openTabsInForegroundCheckbox = document.getElementById('checkbox-open-tabs-in-foreground')
 var autoPlayCheckbox = document.getElementById('checkbox-enable-autoplay')
 var userAgentCheckbox = document.getElementById('checkbox-user-agent')
+var hideTranslateMenuCheckbox = document.getElementById('checkbox-hide-translate-menu') 
 var userAgentInput = document.getElementById('input-user-agent')
 
 function showRestartRequiredBanner () {
@@ -336,6 +337,16 @@ settings.get('enableAutoplay', function (value) {
 
 autoPlayCheckbox.addEventListener('change', function (e) {
   settings.set('enableAutoplay', this.checked)
+})
+
+/* hide context menu translate setting */
+
+settings.get('hideTranslateMenu', function (value) {
+  hideTranslateMenuCheckbox.checked = value
+})
+
+hideTranslateMenuCheckbox.addEventListener('change', function (e) {
+  settings.set('hideTranslateMenu', this.checked)
 })
 
 /* user agent settting */


### PR DESCRIPTION
Changes:
- added option to hide `Translate Page(Beta)` from context menu
- located in additional features