### PR TITLE
Update window title with tab and task name

### DIFF
--- a/js/browserUI.js
+++ b/js/browserUI.js
@@ -142,15 +142,31 @@ function closeTab (tabId) {
   }
 }
 
-/* changes the currently-selected task and updates the UI */
+function setWindowTitle () {
+  const task = tasks.getSelected()
+  const tab = task.tabs.get(task.tabs.getSelected())
 
-function setWindowTitle (taskData) {
-  if (taskData.name) {
-    document.title = (taskData.name.length > 100 ? taskData.name.substring(0, 100) + '...' : taskData.name)
-  } else {
-    document.title = 'Min'
+  const truncateString = (str, len) => {
+    if (str.length > len) {
+      return str.substring(0, len) + '...'
+    } else {
+      return str
+    }
+  }
+
+  const title = [
+    truncateString(tab.title || '', 100),
+    truncateString(task.name || '', 100),
+    'Min'
+  ].filter(str => !!str).join(' | ')
+
+  if (document.title !== title) {
+    document.title = title
+    ipc.send('set-window-title', title)
   }
 }
+
+/* changes the currently-selected task and updates the UI */
 
 function switchToTask (id) {
   tasks.setSelected(id)
@@ -180,7 +196,17 @@ function switchToTask (id) {
 
 tasks.on('task-updated', function (id, key) {
   if (key === 'name' && id === tasks.getSelected().id) {
-    setWindowTitle(tasks.get(id))
+    setWindowTitle()
+  }
+})
+
+tasks.on('tab-selected', function () {
+  setWindowTitle()
+})
+
+tasks.on('tab-updated', function (id, key) {
+  if (key === 'title') {
+    setWindowTitle()
   }
 })
 

--- a/main/main.js
+++ b/main/main.js
@@ -249,6 +249,10 @@ function createWindowWithBounds (bounds, customArgs) {
     mainView.setBounds({x: 0, y: 0, width: winBounds.width, height: winBounds.height})
   })
 
+  mainView.webContents.ipc.on('set-window-title', function(e, title) {
+    newWin.title = title
+  })
+
   newWin.on('resize', function () {
     // The result of getContentBounds doesn't update until the next tick
     setTimeout(function () {


### PR DESCRIPTION
Previously, we were only using the task name, and it looks like the old approach wasn't working at all regardless

Fixes #2654