### PR TITLE
Added visit Site option to access custom domains (including localhost)

### DIFF
--- a/js/default.js
+++ b/js/default.js
@@ -171,6 +171,7 @@ require('macHandoff.js').initialize()
 // default searchbar plugins
 
 require('searchbar/placesPlugin.js').initialize()
+require('searchbar/domainGuessPlugin.js').initialize()
 require('searchbar/instantAnswerPlugin.js').initialize()
 require('searchbar/bangsPlugin.js').initialize()
 require('searchbar/customBangs.js').initialize()

--- a/js/searchbar/domainGuessPlugin.js
+++ b/js/searchbar/domainGuessPlugin.js
@@ -9,11 +9,19 @@ function showDomainGuess (text) {
     return
   }
 
+  var url
+
+  if (urlParser.isHTTPSUpgreadable(text)) {
+    url = 'https://' + text
+  } else {
+    url = 'http://' + text
+  }
+
   searchbarPlugins.addResult('domainGuess', {
     icon: 'carbon:earth-filled',
     title: text,
     secondaryText: l('visitSite'),
-    url: urlParser.parseAsURL(text)
+    url: url
   }, { allowDuplicates: true })
 }
 
@@ -21,7 +29,7 @@ function initialize () {
   searchbarPlugins.register('domainGuess', {
     index: 3,
     trigger: function (text) {
-      return !!text && !tabs.get(tabs.getSelected()).private
+      return !!text
     },
     showResults: showDomainGuess
   })

--- a/js/searchbar/domainGuessPlugin.js
+++ b/js/searchbar/domainGuessPlugin.js
@@ -1,0 +1,30 @@
+var searchbarPlugins = require('searchbar/searchbarPlugins.js')
+
+var urlParser = require('util/urlParser.js')
+
+function showDomainGuess (text) {
+  searchbarPlugins.reset('domainGuess')
+
+  if (!text || text.indexOf(' ') !== -1 || text.indexOf('!') === 0 || urlParser.isPossibleURL(text)) {
+    return
+  }
+
+  searchbarPlugins.addResult('domainGuess', {
+    icon: 'carbon:earth-filled',
+    title: text,
+    secondaryText: l('visitSite'),
+    url: urlParser.parseAsURL(text)
+  }, { allowDuplicates: true })
+}
+
+function initialize () {
+  searchbarPlugins.register('domainGuess', {
+    index: 3,
+    trigger: function (text) {
+      return !!text && !tabs.get(tabs.getSelected()).private
+    },
+    showResults: showDomainGuess
+  })
+}
+
+module.exports = { initialize }

--- a/js/util/urlParser.js
+++ b/js/util/urlParser.js
@@ -92,6 +92,23 @@ var urlParser = {
     // else, do a search
     return searchEngine.getCurrent().searchURL.replace('%s', encodeURIComponent(url))
   },
+  parseAsURL: function (url) {
+    url = url.trim()
+
+    if (!url) {
+      return 'about:blank'
+    }
+
+    if (urlParser.isURL(url) || url.startsWith('view-source:') || url.startsWith('min:')) {
+      return urlParser.parse(url)
+    }
+
+    if (urlParser.isHTTPSUpgreadable(url)) {
+      return 'https://' + url
+    }
+
+    return 'http://' + url
+  },
   basicURL: function (url) {
     return removeWWW(urlParser.removeProtocol(removeTrailingSlash(url)))
   },

--- a/js/util/urlParser.js
+++ b/js/util/urlParser.js
@@ -92,23 +92,6 @@ var urlParser = {
     // else, do a search
     return searchEngine.getCurrent().searchURL.replace('%s', encodeURIComponent(url))
   },
-  parseAsURL: function (url) {
-    url = url.trim()
-
-    if (!url) {
-      return 'about:blank'
-    }
-
-    if (urlParser.isURL(url) || url.startsWith('view-source:') || url.startsWith('min:')) {
-      return urlParser.parse(url)
-    }
-
-    if (urlParser.isHTTPSUpgreadable(url)) {
-      return 'https://' + url
-    }
-
-    return 'http://' + url
-  },
   basicURL: function (url) {
     return removeWWW(urlParser.removeProtocol(removeTrailingSlash(url)))
   },

--- a/localization/languages/en-US.json
+++ b/localization/languages/en-US.json
@@ -35,6 +35,7 @@
     "pasteAndGo": "Paste and Go", //context menu item
     "DDGAnswerSubtitle": "Answer", //this is a noun - it is used as a subtitle when displaying Instant Answers from DuckDuckGo in the searchbar
     "suggestedSite": "Suggested site", //this is used to label suggested websites from the DuckDuckGo API,
+    "visitSite": "Visit site",
     "resultsFromDDG": "Results from DuckDuckGo", //this is used as a label to indicate which results come from DuckDuckGo's API
     "taskN": "Task %n", //this is used as a way to identify which tab a task is in "task 1", "task 2", ...
     /* custom commands


### PR DESCRIPTION
This is a simple addition to always allow a bottom action to just try and search the url entered as if it was an actual domain. this is especially useful for homelab settups and custom domains in a network for big homelabers like me

main use case is go/ is a custom domain that redirects me to different websites on any device in my tailnet and in the vanilla min browser it just treats it as a web search.


its the bottom recommended option will now always be there for those of us that need it for first time min users so that we dont have to type https://go/ manually and such

this would also give those that have issues with localhost an option to use this to override any issues with the basic interpertation and not result in a search instead
<img width="1712" height="370" alt="image" src="https://github.com/user-attachments/assets/4dd8004b-92e2-4212-9e17-c64d0d760d8c" />



Issues this would cover with this as an option and is how brave browser handles it in a round about way:

https://github.com/minbrowser/min/issues/482

https://github.com/minbrowser/min/issues/2602

https://github.com/minbrowser/min/issues/2516

